### PR TITLE
Change group name to com.linkedin.coral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ configurations {
 }
 
 allprojects {
+  group = "com.linkedin.coral"
   repositories {
     mavenCentral()
     maven {


### PR DESCRIPTION
Right now, the maven pom's group id is 'coral'. It will be better to use 'com.linkedin.coral'
