### PR TITLE
Change bounded bintray account to lnkd-apa

### DIFF
--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -23,7 +23,7 @@ allprojects {
 
            pkg {
                repo = 'maven'
-               user = 'linkedin-apa-dali'
+               user = 'lnkd-apa'
                userOrg = 'linkedin'
                name = 'coral'
                licenses = ['BSD 2-Clause']


### PR DESCRIPTION
Hi, Walaa
Let's try to change the bintray bounding to lnkd-apa bintray account. The reason is the linkedin-apa-dali did not setup as an free open source account.