### PR TITLE
Bump shipkit version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 }
 
 plugins {
-  id "org.shipkit.java" version "2.3.0"
+  id "org.shipkit.java" version "2.3.4"
 }
 
 configurations {


### PR DESCRIPTION
Remove shipkit's dependence on a now deprecated Github API which will stop working in March 2021 (was October 2020 previously) mockito/shipkit#871

Tested by running `./gradlew performRelease` -PdryRun locally