### PR TITLE
Support switched form of CASE function

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveFunction.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveFunction.java
@@ -14,6 +14,7 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.fun.SqlCase;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.util.Util;
 
@@ -84,7 +85,7 @@ public class HiveFunction {
       }
       // 1 node for case, 2n for when/then nodes, and optionally 1 else node
       SqlNode elseNode = operands.size() % 2 == 1 ? SqlLiteral.createNull(ZERO) : Util.last(operands);
-      return getSqlOperator().createCall(ZERO, operands.get(0), new SqlNodeList(whenNodes, ZERO),
+      return SqlCase.createSwitched(ZERO, operands.get(0), new SqlNodeList(whenNodes, ZERO),
           new SqlNodeList(thenNodes, ZERO), elseNode);
     }
   };
@@ -101,7 +102,7 @@ public class HiveFunction {
       }
       // 2n for when/then nodes, and optionally 1 else node
       SqlNode elseNode = operands.size() % 2 == 0 ? SqlLiteral.createNull(ZERO) : Util.last(operands);
-      return getSqlOperator().createCall(ZERO, null, new SqlNodeList(whenNodes, ZERO), new SqlNodeList(thenNodes, ZERO),
+      return new SqlCase(ZERO, null, new SqlNodeList(whenNodes, ZERO), new SqlNodeList(thenNodes, ZERO),
           elseNode);
     }
   };

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
@@ -71,9 +71,19 @@ public class HiveToRelConverterTest {
   }
 
   @Test
-  public void testCast() {
+  public void testWhen() {
     final String sql = "SELECT CASE WHEN '1.5' = 1 THEN 'abc' ELSE 'def' END";
-    System.out.println(relToString(sql));
+    final String expected = "LogicalProject(EXPR$0=[CASE(=(CAST('1.5'):INTEGER NOT NULL, 1), 'abc', 'def')])\n"
+        + "  LogicalValues(tuples=[[{ 0 }]])\n";
+    assertEquals(relToString(sql), expected);
+  }
+
+  @Test
+  public void testCase() {
+    final String sql = "SELECT CASE '1.5' WHEN '1.5' THEN 'abc' ELSE 'def' END";
+    final String expected = "LogicalProject(EXPR$0=[CASE(=('1.5', '1.5'), 'abc', 'def')])\n"
+        + "  LogicalValues(tuples=[[{ 0 }]])\n";
+    assertEquals(relToString(sql), expected);
   }
 
   @Test

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
@@ -133,7 +133,7 @@ public class ParseTreeBuilderTest {
         {"SELECT a, c from foo union all select x, y from bar",
             "SELECT * FROM (SELECT `a`, `c` from `foo` union all SELECT `x`, `y` from `bar`) as `_u1`"},
         {"SELECT case (a + 10) when 20 then 5 when 30 then 10 else 1 END from foo",
-            "SELECT CASE `a` + 10 when 20 then 5 when 30 then 10 else 1 END from `foo`"},
+            "SELECT CASE WHEN `a` + 10 = 20 THEN 5 WHEN `a` + 10 = 30 THEN 10 ELSE 1 END from `foo`"},
         {"SELECT CASE WHEN a THEN 10 WHEN b THEN 20 ELSE 30 END from foo",
             "SELECT CASE WHEN `a` THEN 10 WHEN `b` THEN 20 ELSE 30 END from `foo`"},
         {"SELECT named_struct('abc', 123, 'def', 234.23) FROM foo",


### PR DESCRIPTION
This patch adds support to the switched form of CASE statement. The syntax of this form is:
```
CASE a WHEN b THEN c [WHEN d THEN e]* [ELSE f] END
```
This function returns c if a=b, and e if a=d, else returns f.