### PR TITLE
Rename Presto to Trino

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,20 @@
 
 **Coral** is a library for analyzing, processing, and rewriting views defined in the Hive Metastore, and sharing them
 across multiple execution engines. It performs SQL translations to enable views expressed in HiveQL (and potentially
-other languages) to be accessible in engines such as [Presto](https://prestosql.io/),
+other languages) to be accessible in engines such as [Trino (formerly PrestoSQL)](https://trino.io/),
 [Apache Spark](https://spark.apache.org/), and [Apache Pig](https://pig.apache.org/).
 Coral not only translates view definitions between different SQL/non-SQL dialects, but also rewrites expressions to
 produce semantically equivalent ones, taking into account the semantics of the target language or engine.
 For example, it automatically composes new built-in expressions that are equivalent to each built-in expression in the
  source view definition. Additionally, it integrates with [Transport UDFs](https://github.com/linkedin/transport)
-to enable translating and executing user-defined functions (UDFs) across Hive, Presto, Spark, and Pig. Coral is under
+to enable translating and executing user-defined functions (UDFs) across Hive, Trino, Spark, and Pig. Coral is under
 active development. Currently, we are looking into expanding the set of input view language APIs beyond HiveQL,
 and implementing query rewrite algorithms for data governance and query optimization.
 
 ## Modules
 **Coral** consists of following modules:
 - Coral-Hive: Converts definitions of Hive views with UDFs to equivalent view logical plan.
-- Coral-Presto: Converts view logical plan to Presto SQL.
+- Coral-Presto: Converts view logical plan to Trino (formerly PrestoSQL) SQL.
 - Coral-Spark: Converts view logical plan to Spark SQL.
 - Coral-Pig: Converts view logical plan to Pig-latin.
 - Coral-Schema: Derives Avro schema of view using view logical plan and input Avro schemas of base tables.


### PR DESCRIPTION
PrestoSQL was rebranded as Trino. See: https://trino.io/blog/2020/12/27/announcing-trino.html