### PR TITLE
Ensure field-properties and schema properties being replicated when cloning schema object

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -15,6 +15,8 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.calcite.rel.type.RelDataType;
@@ -31,7 +33,6 @@ import org.codehaus.jackson.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.coral.com.google.common.base.Preconditions;
 import com.linkedin.coral.com.google.common.base.Strings;
 import com.linkedin.coral.schema.avro.exceptions.SchemaNotFoundException;
@@ -317,13 +318,13 @@ class SchemaUtilities {
     Preconditions.checkNotNull(leftSchema);
     Preconditions.checkNotNull(rightSchema);
 
-    List<Schema.Field> combinedSchemaFields = new ArrayList<>(cloneFieldList(leftSchema.getFields()));
+    List<Schema.Field> combinedSchemaFields = cloneFieldList(leftSchema.getFields());
     combinedSchemaFields.addAll(cloneFieldList(rightSchema.getFields()));
 
     Schema combinedSchema =
         Schema.createRecord(leftSchema.getName(), leftSchema.getDoc(), leftSchema.getNamespace(), leftSchema.isError());
     combinedSchema.setFields(combinedSchemaFields);
-    // Not replicate schema level props as it may not be well-defined in joined schema.
+    // While we replicate schema-level props in addPartitionColsToSchema(), we avoid doing this here since it may lead to conflict
 
     return combinedSchema;
   }

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -280,7 +280,9 @@ class SchemaUtilities {
 
   static void replicateSchemaProps(Schema srcSchema, Schema targetSchema) {
     for (Map.Entry<String, JsonNode> prop : srcSchema.getJsonProps().entrySet()) {
-      targetSchema.addProp(prop.getKey(), prop.getValue());
+      if (targetSchema.getProp(prop.getKey()) == null) {
+        targetSchema.addProp(prop.getKey(), prop.getValue());
+      }
     }
   }
 
@@ -333,7 +335,10 @@ class SchemaUtilities {
     Schema combinedSchema =
         Schema.createRecord(leftSchema.getName(), leftSchema.getDoc(), leftSchema.getNamespace(), leftSchema.isError());
     combinedSchema.setFields(combinedSchemaFields);
-    // While we replicate schema-level props in addPartitionColsToSchema(), we avoid doing this here since it may lead to conflict
+    // In case there are conflicts of property values among leftSchema and rightSchema, the former-applied leftSchema
+    // will be the winner as Schema object doesn't support prop-overwrite.
+    replicateSchemaProps(leftSchema, combinedSchema);
+    replicateSchemaProps(rightSchema, combinedSchema);
 
     return combinedSchema;
   }

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
@@ -18,7 +18,6 @@ public class SchemaUtilitiesTests {
   @Test
   public void testCloneFieldList() {
     Schema dummySchema = SchemaBuilder.record("test").fields().name("a").type().intType().noDefault().endRecord();
-    dummySchema.addProp("key", "value");
     Schema.Field field1 =
         new Schema.Field("one", dummySchema, "", dummySchema.getJsonProp("key"), Schema.Field.Order.IGNORE);
     field1.addProp("field_key1", "field_value1");
@@ -39,5 +38,21 @@ public class SchemaUtilitiesTests {
         new Schema.Field("one", dummySchema, "", dummySchema.getJsonProp("key"), Schema.Field.Order.IGNORE);
     field3.addProp("field_key1", "random");
     Assert.assertFalse(resultList.contains(field3));
+  }
+
+  @Test
+  public void testSchemaPropReplicate() {
+    Schema dummySchema = SchemaBuilder.record("test").fields().name("a").type().intType().noDefault().endRecord();
+    dummySchema.addProp("schema_key", "schema_value");
+    Schema schemaReplicate = SchemaBuilder.record("test").fields().name("a").type().intType().noDefault().endRecord();
+    Assert.assertNotEquals(schemaReplicate, dummySchema);
+    SchemaUtilities.replicateSchemaProps(dummySchema, schemaReplicate);
+    Assert.assertEquals(schemaReplicate, dummySchema);
+
+    // Testing overwrite behavior: No overwrite should happen.
+    Schema dummySchema2 = SchemaBuilder.record("test").fields().name("a").type().intType().noDefault().endRecord();
+    dummySchema2.addProp("schema_key", "schema_value_overwrite");
+    SchemaUtilities.replicateSchemaProps(dummySchema2, schemaReplicate);
+    Assert.assertEquals(schemaReplicate.getProp("schema_key"), "schema_value");
   }
 }

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2020 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
@@ -5,6 +5,39 @@
  */
 package com.linkedin.coral.schema.avro;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
 public class SchemaUtilitiesTests {
-  // TODO: add unit tests for methods in SchemaUtilities
+  @Test
+  public void testCloneFieldList() {
+    Schema dummySchema = SchemaBuilder.record("test").fields().name("a").type().intType().noDefault().endRecord();
+    dummySchema.addProp("key", "value");
+    Schema.Field field1 =
+        new Schema.Field("one", dummySchema, "", dummySchema.getJsonProp("key"), Schema.Field.Order.IGNORE);
+    field1.addProp("field_key1", "field_value1");
+    Schema.Field field2 =
+        new Schema.Field("two", dummySchema, "", dummySchema.getJsonProp("key"), Schema.Field.Order.IGNORE);
+    field2.addProp("field_key2", "field_value2");
+    List<Schema.Field> originalList = new ArrayList<>();
+    originalList.add(field1);
+    originalList.add(field2);
+    List<Schema.Field> resultList = SchemaUtilities.cloneFieldList(originalList);
+
+    Assert.assertTrue(resultList.contains(field1));
+    Assert.assertTrue(resultList.contains(field2));
+
+    // Without props being identical, equal-check will not pass.
+    // A dummy field3 with only property being different from field1
+    Schema.Field field3 =
+        new Schema.Field("one", dummySchema, "", dummySchema.getJsonProp("key"), Schema.Field.Order.IGNORE);
+    field3.addProp("field_key1", "random");
+    Assert.assertFalse(resultList.contains(field3));
+  }
 }

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2020 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -580,7 +580,7 @@ public class ViewToAvroSchemaConverterTests {
   }
 
   @Test
-  public void testBaseTableWithPartiton() {
+  public void testBaseTableWithPartition() {
     ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);
     Schema actualSchema = viewToAvroSchemaConverter.toAvroSchema("default", "basecasepreservation");
 


### PR DESCRIPTION
There are couple of methods attempting to replicate the schema object, a part of steps is to replicate the `List<Schema.Field>` since there's no public `clone` method for schema object. The replication was buggy since it doesn't carry over the field-level properties (which could be critical in some of cases like logical-type handling).  With this PR, this problem should be resolved. 

Note there are multiple places where the schema is being replicated. 