### PR TITLE
Migrated to new Shipkit plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,17 @@ branches:
 
 #Build and perform release (if needed)
 script:
-  # Print output every minute to avoid travis timeout
+
+  # 1. Print output every minute to avoid travis timeout
   - while sleep 1m; do echo "=====[ $SECONDS seconds elapsed -- still running ]====="; done &
-  - ./gradlew build -s && ./gradlew ciPerformRelease -s
-  # Killing background sleep loop
+
+  # 2. To validate changes, we run building and bintray upload in dry run. This happens on every build, even PRs.
+  # To publish, we perform github release and perform bintray upload (no dry run). This only for main branch builds.
+  - >
+    ./gradlew build bintrayUpload --s -PbintrayDryRun
+    && if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ];
+      then ./gradlew githubRelease bintrayUpload --s; fi
+
+  # 3. Killing background sleep loop
   - kill %1
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,26 @@
 // Licensed under the BSD-2 Clause license.
 // See LICENSE in the project root for license information.
 
+buildscript {
+  repositories {
+    jcenter()
+    maven {
+      url "https://plugins.gradle.org/m2/"
+    }
+  }
+  dependencies {
+    classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
+    classpath "org.shipkit:shipkit-auto-version:1.1.1"
+    classpath "org.shipkit:shipkit-changelog:1.1.1"
+  }
+}
+
 plugins {
   id "com.diffplug.spotless" version "5.8.2"
   id 'com.github.johnrengelman.shadow' version '5.2.0'
-  id "org.shipkit.java" version "2.3.4"
 }
+
+apply from: "gradle/shipkit.gradle"
 
 configurations {
   provided

--- a/coral-hive/build.gradle
+++ b/coral-hive/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'java'
+apply from: "$rootDir/gradle/java-publication.gradle"
 
 dependencies {
   compile('com.linkedin.calcite:calcite-core:1.21.0.140') {

--- a/coral-pig/build.gradle
+++ b/coral-pig/build.gradle
@@ -1,5 +1,4 @@
-apply plugin: 'java'
-apply plugin: 'maven-publish'
+apply from: "$rootDir/gradle/java-publication.gradle"
 
 dependencies {
   compile deps.'javax-annotation'

--- a/coral-presto/build.gradle
+++ b/coral-presto/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'java'
+apply from: "$rootDir/gradle/java-publication.gradle"
 
 dependencies {
   compile deps.'gson'

--- a/coral-schema/build.gradle
+++ b/coral-schema/build.gradle
@@ -1,5 +1,4 @@
-apply plugin: 'java'
-apply plugin: 'maven-publish'
+apply from: "$rootDir/gradle/java-publication.gradle"
 
 dependencies {
   compile deps.'slf4j-api'

--- a/coral-spark-plan/build.gradle
+++ b/coral-spark-plan/build.gradle
@@ -1,5 +1,4 @@
-apply plugin:'java'
-apply plugin: 'maven-publish'
+apply from: "$rootDir/gradle/java-publication.gradle"
 
 dependencies {
   compile deps.'gson'

--- a/coral-spark/build.gradle
+++ b/coral-spark/build.gradle
@@ -1,5 +1,4 @@
-apply plugin: 'java'
-apply plugin: 'maven-publish'
+apply from: "$rootDir/gradle/java-publication.gradle"
 
 dependencies {
   compile deps.'gson'

--- a/gradle/java-publication.gradle
+++ b/gradle/java-publication.gradle
@@ -1,0 +1,126 @@
+apply plugin: "java"
+apply plugin: "maven-publish"
+apply plugin: "com.jfrog.bintray"
+
+def licenseSpec = copySpec {
+  from project.rootDir
+  include "LICENSE"
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+  classifier 'sources'
+  from sourceSets.main.allSource
+  with licenseSpec
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+  classifier 'javadoc'
+  from tasks.javadoc
+  with licenseSpec
+}
+
+jar {
+  with licenseSpec
+}
+
+artifacts {
+  archives sourcesJar
+  archives javadocJar
+}
+
+//Gradle Maven publishing plugin configuration (https://docs.gradle.org/current/userguide/publishing_maven.html)
+apply plugin: "maven-publish"
+publishing {
+  publications {
+    javaLibrary(MavenPublication) {
+      //name of the publication
+      from components.java
+      artifact sourcesJar
+      artifact javadocJar
+
+      artifactId = project.archivesBaseName
+
+      pom {
+        name = artifactId
+        description = "A library for analyzing, processing, and rewriting views defined in the Hive Metastore, and sharing them across multiple execution engines"
+
+        url = "https://github.com/linkedin/coral"
+        licenses {
+          license {
+            name = 'The MIT License'
+            url = 'https://github.com/linkedin/coral/blob/master/LICENSE'
+            distribution = 'repo'
+          }
+        }
+        developers {
+          [
+            'wmoustafa:Walaa Eldin Moustafa',
+            'khaitranq:Khai Tranh',
+            'funcheetah:Wenye Zhang',
+            'shardulm94:Shardul Mahadik',
+            'hotsushi:Sushant Raikar'
+          ].each { devData ->
+            developer {
+              def devInfo = devData.split(':')
+              id = devInfo[0]
+              name = devInfo[1]
+              url = 'https://github.com/' + devInfo[0]
+              roles = ["Core developer"]
+            }
+          }
+        }
+        scm {
+          url = 'https://github.com/linkedin/coral.git'
+        }
+        issueManagement {
+          url = 'https://github.com/linkedin/coral/issues'
+          system = 'GitHub issues'
+        }
+        ciManagement {
+          url = 'https://travis-ci.com/linkedin/coral'
+          system = 'Travis CI'
+        }
+      }
+    }
+  }
+
+  //useful for testing - running "publish" will create artifacts/pom in a local dir
+  repositories { maven { url = "$rootProject.buildDir/repo" } }
+}
+
+//fleshes out problems with Maven pom generation when building
+tasks.build.dependsOn("publishJavaLibraryPublicationToMavenLocal")
+
+//Bintray configuration is handled by JFrog Bintray Gradle Plugin
+//For reference see the official documentation: https://github.com/bintray/gradle-bintray-plugin
+bintray {
+  user = 'lnkd-apa'
+  // The Bintray API token is required to publish artifacts to Bintray
+  // Ensure that the release machine or Travis CI has this env variable exported
+  key = System.getenv("BINTRAY_API_KEY")
+  publish = true //can be changed to 'false' for testing
+  dryRun = project.hasProperty("bintrayDryRun")
+  publications = ['javaLibrary']
+
+  pkg {
+    repo = 'maven'
+
+    userOrg = 'linkedin'
+    name = 'coral'
+    licenses = ['BSD 2-Clause']
+    labels = [
+      'coral',
+      'sql',
+      'presto',
+      'spark',
+      'hive',
+      'views'
+    ]
+    vcsUrl = "https://github.com/linkedin/coral.git"
+
+    version {
+      name = project.version
+      vcsTag = "v$project.version"
+    }
+  }
+}

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -1,50 +1,18 @@
-shipkit {
-  gitHub.repository = "linkedin/coral"
+apply plugin: "org.shipkit.shipkit-auto-version"
+apply plugin: "org.shipkit.shipkit-changelog"
+apply plugin: "org.shipkit.shipkit-github-release"
 
-  gitHub.readOnlyAuthToken = "361a43a2b351e61e2243c5ea15792f33a3c9b467"
-
-  // The GitHub write token is required for committing release notes and bumping up project version
-  // Ensure that the release machine or Travis CI has this env variable exported
-  gitHub.writeAuthToken = System.getenv("GH_WRITE_TOKEN")
-
-  git.releasableBranchRegex = "master|release/.+"
-
-  team.developers = [
-    'wmoustafa:Walaa Eldin Moustafa',
-    'khaitranq:Khai Tranh',
-    'funcheetah:Wenye Zhang',
-    'shardulm94:Shardul Mahadik',
-    'hotsushi:Sushant Raikar'
-  ]
+tasks.named("generateChangelog") {
+  previousRevision = project.ext.'shipkit-auto-version.previous-tag'
+  githubToken = System.getenv("GH_WRITE_TOKEN")
+  repository = "linkedin/coral"
 }
 
-allprojects {
-  plugins.withId("org.shipkit.bintray") {
-
-    //Bintray configuration is handled by JFrog Bintray Gradle Plugin
-    //For reference see the official documentation: https://github.com/bintray/gradle-bintray-plugin
-    bintray {
-      // The Bintray API token is required to publish artifacts to Bintray
-      // Ensure that the release machine or Travis CI has this env variable exported
-      key = System.getenv("BINTRAY_API_KEY")
-      pkg {
-        repo = 'maven'
-        user = 'lnkd-apa'
-        userOrg = 'linkedin'
-        name = 'coral'
-        licenses = ['BSD 2-Clause']
-        labels = [
-          'coral',
-          'sql',
-          'presto',
-          'spark',
-          'hive',
-          'views'
-        ]
-        vcsUrl = "https://github.com/linkedin/coral.git"
-        description = "A library for analyzing, processing, and rewriting views defined in the Hive Metastore, and sharing them across multiple execution engines"
-      }
-      publish = true
-    }
-  }
+tasks.named("githubRelease") {
+  def genTask = tasks.named("generateChangelog").get()
+  dependsOn genTask
+  repository = genTask.repository
+  changelog = genTask.outputFile
+  githubToken = System.getenv("GH_WRITE_TOKEN")
+  newTagRevision = System.getenv("TRAVIS_COMMIT")
 }

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,3 @@
-#Version of the produced binaries. This file is intended to be checked-in.
-#It will be automatically bumped by release automation.
-version=1.0.19
-previousVersion=1.0.18
+# Version of the produced binaries.
+# The version is inferred by shipkit-auto-version Gradle plugin (https://github.com/shipkit/shipkit-auto-version)
+version=1.0.*


### PR DESCRIPTION
This change is fully backwards compatible, please review!

- enables concurrent releases
- avoids unnecessary version bump commits
- enables using higher versions of Gradle ("org.shipkit.java" plugin is deprecated)
- removed read-only token from checked-in files (even though it is read read-only, it should not be exposed to unexpected users/bots)

Tested by:
- ran `./gradlew publishToMavenLocal` with the old code, generated all artifacts and poms, then I ran the new code and compared the artifacts and poms
- executed the release steps locally:
    - `./gradlew githubRelease` -> released to GitHub: https://github.com/mockitoguy/coral/releases/tag/v1.0.19
    - `./gradlew bintrayUpload` -> released to Bintray: https://bintray.com/shipkit/examples/coral/1.0.19