### PR TITLE
Use enclosing SqlOperator UDF name when translating Transport UDFs in Spark

### DIFF
--- a/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
@@ -211,8 +211,9 @@ class IRRelToSparkRelTransformer {
     private Optional<RexNode> convertDaliUDF(RexCall call) {
       Optional<SparkUDFInfo> sparkUDFInfo = TransportableUDFMap.lookup(call.getOperator().getName());
       sparkUDFInfo.ifPresent(sparkUDFInfos::add);
-      return sparkUDFInfo.map(sparkUDFInfo1 -> rexBuilder.makeCall(
-          createUDF(sparkUDFInfo1.getFunctionName(), call.getOperator().getReturnTypeInference()), call.getOperands()));
+      return sparkUDFInfo.map(sparkUDFInfo1 -> rexBuilder
+          .makeCall(createUDF(((VersionedSqlUserDefinedFunction) call.getOperator()).getViewDependentFunctionName(),
+              call.getOperator().getReturnTypeInference()), call.getOperands()));
     }
 
     private Optional<RexNode> convertBuiltInUDF(RexCall call) {

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/TransportableUDFMap.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/TransportableUDFMap.java
@@ -36,80 +36,79 @@ class TransportableUDFMap {
 
     // LIHADOOP-48502: The following UDFs are the legacy Hive UDF. Since they have been converted to
     // Transport UDF, we point their class files to the corresponding Spark jar.
-    add("com.linkedin.dali.udf.date.hive.DateFormatToEpoch", "dateFormatToEpoch",
-        "com.linkedin.stdudfs.daliudfs.spark.DateFormatToEpoch", STANDARD_UDFS_DALI_UDFS_URL);
+    add("com.linkedin.dali.udf.date.hive.DateFormatToEpoch", "com.linkedin.stdudfs.daliudfs.spark.DateFormatToEpoch",
+        STANDARD_UDFS_DALI_UDFS_URL);
 
-    add("com.linkedin.dali.udf.date.hive.EpochToDateFormat", "epochToDateFormat",
-        "com.linkedin.stdudfs.daliudfs.spark.EpochToDateFormat", STANDARD_UDFS_DALI_UDFS_URL);
+    add("com.linkedin.dali.udf.date.hive.EpochToDateFormat", "com.linkedin.stdudfs.daliudfs.spark.EpochToDateFormat",
+        STANDARD_UDFS_DALI_UDFS_URL);
 
-    add("com.linkedin.dali.udf.date.hive.EpochToEpochMilliseconds", "epochToEpochMilliseconds",
+    add("com.linkedin.dali.udf.date.hive.EpochToEpochMilliseconds",
         "com.linkedin.stdudfs.daliudfs.spark.EpochToEpochMilliseconds", STANDARD_UDFS_DALI_UDFS_URL);
 
-    add("com.linkedin.dali.udf.isguestmemberid.hive.IsGuestMemberId", "isGuestMemberId",
+    add("com.linkedin.dali.udf.isguestmemberid.hive.IsGuestMemberId",
         "com.linkedin.stdudfs.daliudfs.spark.IsGuestMemberId", STANDARD_UDFS_DALI_UDFS_URL);
 
     // LIHADOOP-49851 add the transportudf spark version for lookup UDF
-    add("com.linkedin.dali.udf.istestmemberid.hive.IsTestMemberId", "isTestMemberId",
+    add("com.linkedin.dali.udf.istestmemberid.hive.IsTestMemberId",
         "com.linkedin.stdudfs.daliudfs.spark.IsTestMemberId", STANDARD_UDFS_DALI_UDFS_URL);
 
-    add("com.linkedin.dali.udf.maplookup.hive.MapLookup", "mapLookup", "com.linkedin.stdudfs.daliudfs.spark.MapLookup",
+    add("com.linkedin.dali.udf.maplookup.hive.MapLookup", "com.linkedin.stdudfs.daliudfs.spark.MapLookup",
         STANDARD_UDFS_DALI_UDFS_URL);
 
-    add("com.linkedin.dali.udf.sanitize.hive.Sanitize", "sanitize", "com.linkedin.stdudfs.daliudfs.spark.Sanitize",
+    add("com.linkedin.dali.udf.sanitize.hive.Sanitize", "com.linkedin.stdudfs.daliudfs.spark.Sanitize",
         STANDARD_UDFS_DALI_UDFS_URL);
 
     // LIHADOOP-49851 add the transportudf spark version for lookup UDF
-    add("com.linkedin.dali.udf.watbotcrawlerlookup.hive.WATBotCrawlerLookup", "watBotCrawlerLookup",
+    add("com.linkedin.dali.udf.watbotcrawlerlookup.hive.WATBotCrawlerLookup",
         "com.linkedin.stdudfs.daliudfs.spark.WatBotCrawlerLookup", STANDARD_UDFS_DALI_UDFS_URL);
 
     // LIHADOOP-48502: The following UDFs are already defined using Transport UDF.
     // The class name is the corresponding Hive UDF.
     // We point their class files to the corresponding Spark jar file.
-    add("com.linkedin.stdudfs.daliudfs.hive.DateFormatToEpoch", "dateFormatToEpoch",
-        "com.linkedin.stdudfs.daliudfs.spark.DateFormatToEpoch", STANDARD_UDFS_DALI_UDFS_URL);
+    add("com.linkedin.stdudfs.daliudfs.hive.DateFormatToEpoch", "com.linkedin.stdudfs.daliudfs.spark.DateFormatToEpoch",
+        STANDARD_UDFS_DALI_UDFS_URL);
 
-    add("com.linkedin.stdudfs.daliudfs.hive.EpochToDateFormat", "epochToDateFormat",
-        "com.linkedin.stdudfs.daliudfs.spark.EpochToDateFormat", STANDARD_UDFS_DALI_UDFS_URL);
+    add("com.linkedin.stdudfs.daliudfs.hive.EpochToDateFormat", "com.linkedin.stdudfs.daliudfs.spark.EpochToDateFormat",
+        STANDARD_UDFS_DALI_UDFS_URL);
 
-    add("com.linkedin.stdudfs.daliudfs.hive.EpochToEpochMilliseconds", "epochToEpochMilliseconds",
+    add("com.linkedin.stdudfs.daliudfs.hive.EpochToEpochMilliseconds",
         "com.linkedin.stdudfs.daliudfs.spark.EpochToEpochMilliseconds", STANDARD_UDFS_DALI_UDFS_URL);
 
-    add("com.linkedin.stdudfs.daliudfs.hive.GetProfileSections", "getProfileSections",
+    add("com.linkedin.stdudfs.daliudfs.hive.GetProfileSections",
         "com.linkedin.stdudfs.daliudfs.spark.GetProfileSections", STANDARD_UDFS_DALI_UDFS_URL);
 
-    add("com.linkedin.stdudfs.stringudfs.hive.InitCap", "initCap", "com.linkedin.stdudfs.stringudfs.spark.InitCap",
+    add("com.linkedin.stdudfs.stringudfs.hive.InitCap", "com.linkedin.stdudfs.stringudfs.spark.InitCap",
         "ivy://com.linkedin.standard-udfs-common-sql-udfs:standard-udfs-string-udfs:0.0.7?classifier=spark");
 
-    add("com.linkedin.stdudfs.daliudfs.hive.IsGuestMemberId", "isGuestMemberId",
-        "com.linkedin.stdudfs.daliudfs.spark.IsGuestMemberId", STANDARD_UDFS_DALI_UDFS_URL);
-
-    add("com.linkedin.stdudfs.daliudfs.hive.IsTestMemberId", "isTestMemberId",
-        "com.linkedin.stdudfs.daliudfs.spark.IsTestMemberId", STANDARD_UDFS_DALI_UDFS_URL);
-
-    add("com.linkedin.stdudfs.daliudfs.hive.MapLookup", "mapLookup", "com.linkedin.stdudfs.daliudfs.spark.MapLookup",
+    add("com.linkedin.stdudfs.daliudfs.hive.IsGuestMemberId", "com.linkedin.stdudfs.daliudfs.spark.IsGuestMemberId",
         STANDARD_UDFS_DALI_UDFS_URL);
 
-    add("com.linkedin.stdudfs.daliudfs.hive.PortalLookup", "portalLookup",
-        "com.linkedin.stdudfs.daliudfs.spark.PortalLookup", STANDARD_UDFS_DALI_UDFS_URL);
-
-    add("com.linkedin.stdudfs.daliudfs.hive.Sanitize", "sanitize", "com.linkedin.stdudfs.daliudfs.spark.Sanitize",
+    add("com.linkedin.stdudfs.daliudfs.hive.IsTestMemberId", "com.linkedin.stdudfs.daliudfs.spark.IsTestMemberId",
         STANDARD_UDFS_DALI_UDFS_URL);
 
-    add("com.linkedin.stdudfs.userinterfacelookup.hive.UserInterfaceLookup", "userInterfaceLookup",
+    add("com.linkedin.stdudfs.daliudfs.hive.MapLookup", "com.linkedin.stdudfs.daliudfs.spark.MapLookup",
+        STANDARD_UDFS_DALI_UDFS_URL);
+
+    add("com.linkedin.stdudfs.daliudfs.hive.PortalLookup", "com.linkedin.stdudfs.daliudfs.spark.PortalLookup",
+        STANDARD_UDFS_DALI_UDFS_URL);
+
+    add("com.linkedin.stdudfs.daliudfs.hive.Sanitize", "com.linkedin.stdudfs.daliudfs.spark.Sanitize",
+        STANDARD_UDFS_DALI_UDFS_URL);
+
+    add("com.linkedin.stdudfs.userinterfacelookup.hive.UserInterfaceLookup",
         "com.linkedin.stdudfs.userinterfacelookup.spark.UserInterfaceLookup",
         "ivy://com.linkedin.standard-udf-userinterfacelookup:userinterfacelookup-std-udf:0.0.9?classifier=spark");
 
-    add("com.linkedin.stdudfs.daliudfs.hive.WatBotCrawlerLookup", "watBotCrawlerLookup",
+    add("com.linkedin.stdudfs.daliudfs.hive.WatBotCrawlerLookup",
         "com.linkedin.stdudfs.daliudfs.spark.WatBotCrawlerLookup", STANDARD_UDFS_DALI_UDFS_URL);
 
-    add("com.linkedin.jemslookup.udf.hive.JemsLookup", "jemsLookup", "com.linkedin.jemslookup.udf.spark.JemsLookup",
+    add("com.linkedin.jemslookup.udf.hive.JemsLookup", "com.linkedin.jemslookup.udf.spark.JemsLookup",
         "ivy://com.linkedin.jobs-udf:jems-udfs:1.0.0?classifier=spark");
 
-    add("com.linkedin.stdudfs.parsing.hive.UserAgentParser", "userAgentParser",
-        "com.linkedin.stdudfs.parsing.spark.UserAgentParser",
+    add("com.linkedin.stdudfs.parsing.hive.UserAgentParser", "com.linkedin.stdudfs.parsing.spark.UserAgentParser",
         "ivy://com.linkedin.standard-udfs-parsing:parsing-stdudfs:2.0.1?classifier=spark");
 
-    add("com.linkedin.stdudfs.parsing.hive.Ip2Str", "ip2Str", "com.linkedin.stdudfs.parsing.spark.Ip2Str",
+    add("com.linkedin.stdudfs.parsing.hive.Ip2Str", "com.linkedin.stdudfs.parsing.spark.Ip2Str",
         "ivy://com.linkedin.standard-udfs-parsing:parsing-stdudfs:2.0.1?classifier=spark");
   }
 
@@ -123,14 +122,15 @@ class TransportableUDFMap {
     return Optional.ofNullable(UDF_MAP.get(className));
   }
 
-  public static void add(String className, String sparkFunctionName, String sparkClassName, String artifcatoryUrl) {
+  public static void add(String className, String sparkClassName, String artifcatoryUrl) {
     try {
       URI url = new URI(artifcatoryUrl);
       List<URI> listOfUris = new LinkedList<>();
       listOfUris.add(url);
 
+      // Set the function name to null here because it is determined dynamically from the enclosing SqlOperand
       UDF_MAP.put(className,
-          new SparkUDFInfo(sparkClassName, sparkFunctionName, listOfUris, SparkUDFInfo.UDFTYPE.TRANSPORTABLE_UDF));
+          new SparkUDFInfo(sparkClassName, null, listOfUris, SparkUDFInfo.UDFTYPE.TRANSPORTABLE_UDF));
     } catch (URISyntaxException e) {
       throw new RuntimeException(String.format("Artifactory URL is malformed %s", artifcatoryUrl), e);
     }

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2020 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -45,8 +45,8 @@ public class CoralSparkTest {
 
     UnsupportedHiveUDFsInSpark.add("com.linkedin.coral.hive.hive2rel.CoralTestUnsupportedUDF");
 
-    TransportableUDFMap.add("com.linkedin.coral.hive.hive2rel.CoralTestUDF", "coralTestUDF",
-        "com.linkedin.coral.spark.CoralTestUDF", "ivy://com.linkedin.coral.spark.CoralTestUDF");
+    TransportableUDFMap.add("com.linkedin.coral.hive.hive2rel.CoralTestUDF", "com.linkedin.coral.spark.CoralTestUDF",
+        "ivy://com.linkedin.coral.spark.CoralTestUDF");
   }
 
   @Test
@@ -99,9 +99,6 @@ public class CoralSparkTest {
     String udfClassName = udfJars.get(0).getClassName();
     String targetClassName = "com.linkedin.coral.spark.CoralTestUDF";
     assertEquals(udfClassName, targetClassName);
-    String udfFunctionName = udfJars.get(0).getFunctionName();
-    String targetFunctionName = "coralTestUDF";
-    assertEquals(udfFunctionName, targetFunctionName);
     // check if CoralSpark can fetch artifactory url from TransportableUDFMap
     List<String> listOfUriStrings = convertToListOfUriStrings(udfJars.get(0).getArtifactoryUrls());
     String targetArtifactoryUrl = "ivy://com.linkedin.coral.spark.CoralTestUDF";
@@ -111,7 +108,7 @@ public class CoralSparkTest {
     SparkUDFInfo.UDFTYPE targetUdfType = SparkUDFInfo.UDFTYPE.TRANSPORTABLE_UDF;
     assertEquals(testUdfType, targetUdfType);
     String sparkSqlStmt = coralSpark.getSparkSql();
-    String targetSqlStmt = "SELECT coralTestUDF(a)\nFROM default.foo";
+    String targetSqlStmt = "SELECT default_foo_dali_udf_LessThanHundred(a)\nFROM default.foo";
     assertEquals(sparkSqlStmt, targetSqlStmt);
   }
 

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -99,6 +99,9 @@ public class CoralSparkTest {
     String udfClassName = udfJars.get(0).getClassName();
     String targetClassName = "com.linkedin.coral.spark.CoralTestUDF";
     assertEquals(udfClassName, targetClassName);
+    String udfFunctionName = udfJars.get(0).getFunctionName();
+    String targetFunctionName = "default_foo_dali_udf_LessThanHundred";
+    assertEquals(udfFunctionName, targetFunctionName);
     // check if CoralSpark can fetch artifactory url from TransportableUDFMap
     List<String> listOfUriStrings = convertToListOfUriStrings(udfJars.get(0).getArtifactoryUrls());
     String targetArtifactoryUrl = "ivy://com.linkedin.coral.spark.CoralTestUDF";


### PR DESCRIPTION
Before this patch, UDF names were hard-coded in the Transport UDF map (`TransportableUDFMap`). This could lead functions registered in the same Spark session by the end users using the same name to collide with those hard-coded names, especially that the hard-coded names are commonly used. This patch uses the view-specific UDF name from the enclosing `SqlOperator` instead. The `DaliSpark.testDaliUdf()` test is updated to capture the new expected behavior.