### PR TITLE
[Reference PR] Skip publishing to Bintray from Shipkit; publish to Maven Central instead

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,14 @@
 plugins {
   id "com.diffplug.spotless" version "5.8.2"
   id 'com.github.johnrengelman.shadow' version '5.2.0'
-  id "org.shipkit.java" version "2.3.4"
+  // The following Shipkit plugins are required to make Shipkit skip publishing to Bintray.
+  // Bintray is sunset starting 3/1/2021.
+  // For more details on how to integrate Shipkit with other repositories please see
+  // https://github.com/mockito/shipkit/blob/master/docs/features/publishing-binaries-using-maven-publish-plugin.md
+  id "org.shipkit.travis" version "2.3.4"
+  id "org.shipkit.github-pom-contributors" version "2.3.4"
+  id "org.shipkit.release-notes" version "2.3.4"
+  id "org.shipkit.compare-publications" version "2.3.4"
 }
 
 configurations {
@@ -18,9 +25,6 @@ allprojects {
 
   repositories {
     mavenCentral()
-    maven {
-      url 'https://linkedin.bintray.com/maven/'
-    }
   }
 
   spotless {
@@ -39,8 +43,10 @@ allprojects {
     }
   }
 }
+tasks.updateReleaseNotes.publicationRepository = "https://repo1.maven.org/maven2/com/linkedin/coral/"
+tasks.updateReleaseNotesOnGitHub.publicationRepository = "https://repo1.maven.org/maven2/com/linkedin/coral/"
 
-subprojects {
+subprojects { subproject ->
   plugins.withType(JavaPlugin) {
     dependencies {
       testCompile deps.'testing'
@@ -59,4 +65,95 @@ subprojects {
   }
 
   apply from: "${rootDir}/gradle/dependencies.gradle"
+
+  plugins.withType(MavenPublishPlugin).withType(SigningPlugin) {
+    apply plugin: "org.shipkit.travis"
+    apply plugin: "org.shipkit.github-pom-contributors"
+    apply plugin: "org.shipkit.release-notes"
+    apply plugin: "org.shipkit.compare-publications"
+    publishing {
+      publications {
+        tasks.downloadPreviousReleaseArtifacts.previousSourcesJarUrl =
+            "https://repo1.maven.org/maven2/com/linkedin/coral/" + subproject.name + "/" + tasks.fetchReleaseNotes.previousVersion +
+            subproject.name + "-" + tasks.fetchReleaseNotes.previousVersion + "-sources.jar"
+        maven(MavenPublication) { publication ->
+          tasks.performRelease.dependsOn(tasks.publish)
+          from components.java
+          artifact(javadocJar) {
+            classifier = 'javadoc'
+          }
+          artifact(sourcesJar) {
+            classifier = 'sources'
+          }
+          pom {
+            groupId = 'com.linkedin.coral'
+            artifactId = subproject.name
+            name = 'Coral'
+            description = 'Coral is a SQL analysis, translation, and rewrite engine'
+            url = 'https://github.com/linkedin/coral'
+            licenses {
+              license {
+                name = 'BSD 2-Clause License'
+                url = 'https://opensource.org/licenses/BSD-2-Clause'
+              }
+            }
+            developers {
+              developer {
+                id = 'wmoustafa'
+                name = 'Walaa Eldin Moustafa'
+              }
+              developer {
+                id = 'funcheetah'
+                name = 'Wenye Zhang'
+              }
+              developer {
+                id = 'shardulm94'
+                name = 'Shardul Mahadik'
+              }
+              developer {
+                id = 'hotsushi'
+                name = 'Sushant Raikar'
+              }
+            }
+            scm {
+              connection = 'scm:git:git://github.com/linkedin/coral.git'
+              developerConnection = 'scm:git:ssh://github.com:linkedin/coral.git'
+              url = 'https://github.com/linkedin/coral/tree/master'
+            }
+          }
+        }
+      }
+      repositories {
+        def sonatypeUsername = System.getenv("SONATYPE_USER")
+        def sonatypePassword = System.getenv("SONATYPE_PASSWORD")
+        maven {
+          name = "sonatypeSnapshot"
+          url = "https://oss.sonatype.org/content/repositories/snapshots"
+          credentials {
+            username = sonatypeUsername
+            password = sonatypePassword
+          }
+        }
+        maven {
+          name = "mavenCentral"
+          url = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+          credentials {
+            username = sonatypeUsername
+            password = sonatypePassword
+          }
+        }
+      }
+    }
+
+    // CORAL_GPG_PRIVATE_KEY should contain the armoured private key that
+    // starts with -----BEGIN PGP PRIVATE KEY BLOCK-----
+    // It can be obtained with gpg --armour --export-secret-keys KEY_ID
+    def signingKey = System.getenv("CORAL_GPG_PRIVATE_KEY")
+    def signingPassword = System.getenv("CORAL_GPG_PASSPHRASE")
+    signing {
+      required { signingKey != null && signingPassword != null }
+      useInMemoryPgpKeys(signingKey, signingPassword)
+      sign publishing.publications.maven
+    }
+  }
 }

--- a/coral-hive/build.gradle
+++ b/coral-hive/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'antlr'
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 dependencies {
   antlr deps.'antlr'
@@ -46,7 +48,7 @@ generateGrammarSource {
   ]}
 
 artifacts {
-  archives jar, javadocJar, sourcesJar
+  archives jar
 }
 
 

--- a/coral-pig/build.gradle
+++ b/coral-pig/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 dependencies {
   compile deps.'javax-annotation'
@@ -31,5 +32,5 @@ dependencies {
 }
 
 artifacts {
-  archives jar, javadocJar, sourcesJar
+  archives jar
 }

--- a/coral-presto/build.gradle
+++ b/coral-presto/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'java'
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 dependencies {
   compile deps.'gson'
@@ -20,5 +22,5 @@ dependencies {
 }
 
 artifacts {
-  archives jar, javadocJar, sourcesJar
+  archives jar
 }

--- a/coral-schema/build.gradle
+++ b/coral-schema/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 dependencies {
   compile deps.'slf4j-api'
@@ -22,5 +23,5 @@ dependencies {
 }
 
 artifacts {
-  archives jar, javadocJar, sourcesJar
+  archives jar
 }

--- a/coral-spark-plan/build.gradle
+++ b/coral-spark-plan/build.gradle
@@ -1,5 +1,6 @@
 apply plugin:'java'
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 dependencies {
   compile deps.'gson'
@@ -20,5 +21,5 @@ dependencies {
 }
 
 artifacts {
-  archives jar, javadocJar, sourcesJar
+  archives jar
 }

--- a/coral-spark/build.gradle
+++ b/coral-spark/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 dependencies {
   compile deps.'gson'
@@ -20,5 +21,5 @@ dependencies {
 }
 
 artifacts {
-  archives jar, javadocJar, sourcesJar
+  archives jar
 }

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -8,43 +8,4 @@ shipkit {
   gitHub.writeAuthToken = System.getenv("GH_WRITE_TOKEN")
 
   git.releasableBranchRegex = "master|release/.+"
-
-  team.developers = [
-    'wmoustafa:Walaa Eldin Moustafa',
-    'khaitranq:Khai Tranh',
-    'funcheetah:Wenye Zhang',
-    'shardulm94:Shardul Mahadik',
-    'hotsushi:Sushant Raikar'
-  ]
-}
-
-allprojects {
-  plugins.withId("org.shipkit.bintray") {
-
-    //Bintray configuration is handled by JFrog Bintray Gradle Plugin
-    //For reference see the official documentation: https://github.com/bintray/gradle-bintray-plugin
-    bintray {
-      // The Bintray API token is required to publish artifacts to Bintray
-      // Ensure that the release machine or Travis CI has this env variable exported
-      key = System.getenv("BINTRAY_API_KEY")
-      pkg {
-        repo = 'maven'
-        user = 'lnkd-apa'
-        userOrg = 'linkedin'
-        name = 'coral'
-        licenses = ['BSD 2-Clause']
-        labels = [
-          'coral',
-          'sql',
-          'presto',
-          'spark',
-          'hive',
-          'views'
-        ]
-        vcsUrl = "https://github.com/linkedin/coral.git"
-        description = "A library for analyzing, processing, and rewriting views defined in the Hive Metastore, and sharing them across multiple execution engines"
-      }
-      publish = true
-    }
-  }
 }


### PR DESCRIPTION
[Bintray is sunset](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) starting 3/1/2021. This patch adapts Shipkit plugin integration so that it skips the Bintray publication step. Also, it sets up the `maven-publish` plugin so that it can publish to Maven Central. This patch is based on combining guides from [Shipkit](https://github.com/mockito/shipkit/blob/master/docs/features/publishing-binaries-using-maven-publish-plugin.md), [OSSRH with Gradle](https://central.sonatype.org/pages/gradle.html) and an [example Maven Central + Gradle integration from dex-test-parser](https://github.com/linkedin/dex-test-parser/blob/main/parser/build.gradle).

This patch is tested by running `./gradlew publishToMavenLocal` which publishes artifacts locally. I found the expected artifacts in the local m2 repo, but did not notice he signing files. I will wait after check-in to see if they will be generated in the non-local publication case.

The patch was also tested by running Shipkit's release in the dry run mode: `./gradlew performRelease -PdryRun`. It works all the way up to pushing. I did not provide a Github write token so that it does not accidentally push an undesired change.