### PR TITLE
Adjust array indices for non-literals

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveRelConverter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveRelConverter.java
@@ -158,8 +158,8 @@ public class HiveRelConverter extends RelShuttleImpl {
             RexLiteral newItemRef = rexBuilder.makeExactLiteral(new BigDecimal(val + 1), itemRef.getType());
             return rexBuilder.makeCall(call.op, columnRef, newItemRef);
           } else {
-            RexNode oneBasedIndex = rexBuilder.makeCall(
-                SqlStdOperatorTable.PLUS, itemRef, rexBuilder.makeExactLiteral(BigDecimal.ONE));
+            RexNode oneBasedIndex =
+                rexBuilder.makeCall(SqlStdOperatorTable.PLUS, itemRef, rexBuilder.makeExactLiteral(BigDecimal.ONE));
             return rexBuilder.makeCall(call.op, columnRef, oneBasedIndex);
           }
         }

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveRelConverter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveRelConverter.java
@@ -152,11 +152,16 @@ public class HiveRelConverter extends RelShuttleImpl {
       if (call.getOperator().equals(SqlStdOperatorTable.ITEM)) {
         RexNode columnRef = call.getOperands().get(0);
         RexNode itemRef = call.getOperands().get(1);
-        if (columnRef.getType() instanceof ArraySqlType && itemRef.isA(SqlKind.LITERAL)
-            && itemRef.getType().getSqlTypeName().equals(SqlTypeName.INTEGER)) {
-          Integer val = ((RexLiteral) itemRef).getValueAs(Integer.class);
-          RexLiteral newItemRef = rexBuilder.makeExactLiteral(new BigDecimal(val + 1), itemRef.getType());
-          return rexBuilder.makeCall(call.op, columnRef, newItemRef);
+        if (columnRef.getType() instanceof ArraySqlType) {
+          if (itemRef.isA(SqlKind.LITERAL) && itemRef.getType().getSqlTypeName().equals(SqlTypeName.INTEGER)) {
+            Integer val = ((RexLiteral) itemRef).getValueAs(Integer.class);
+            RexLiteral newItemRef = rexBuilder.makeExactLiteral(new BigDecimal(val + 1), itemRef.getType());
+            return rexBuilder.makeCall(call.op, columnRef, newItemRef);
+          } else {
+            RexNode oneBasedIndex = rexBuilder.makeCall(
+                SqlStdOperatorTable.PLUS, itemRef, rexBuilder.makeExactLiteral(BigDecimal.ONE));
+            return rexBuilder.makeCall(call.op, columnRef, oneBasedIndex);
+          }
         }
       }
       return call;

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
@@ -209,8 +209,8 @@ public class HiveToRelConverterTest {
   @Test
   public void testSelectArrayElemWithFunctionArgument() {
     final String sql = "SELECT c[size(c) - 1] FROM complex";
-    final String expected =
-        "LogicalProject(EXPR$0=[ITEM($2, +(-(CARDINALITY($2), 1), 1))])\n" + "  LogicalTableScan(table=[[hive, default, complex]])\n";
+    final String expected = "LogicalProject(EXPR$0=[ITEM($2, +(-(CARDINALITY($2), 1), 1))])\n"
+        + "  LogicalTableScan(table=[[hive, default, complex]])\n";
     assertEquals(relToString(sql), expected);
   }
 

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
@@ -207,6 +207,14 @@ public class HiveToRelConverterTest {
   }
 
   @Test
+  public void testSelectArrayElemWithFunctionArgument() {
+    final String sql = "SELECT c[size(c) - 1] FROM complex";
+    final String expected =
+        "LogicalProject(EXPR$0=[ITEM($2, +(-(CARDINALITY($2), 1), 1))])\n" + "  LogicalTableScan(table=[[hive, default, complex]])\n";
+    assertEquals(relToString(sql), expected);
+  }
+
+  @Test
   public void testMapType() {
     final String sql = "SELECT map('abc', 123, 'def', 567)";
     String generated = relToString(sql);

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
@@ -273,9 +273,9 @@ class IRRelToSparkRelTransformer {
             RexLiteral newItemRef = rexBuilder.makeExactLiteral(new BigDecimal(val - 1), itemRef.getType());
             return Optional.of(rexBuilder.makeCall(call.op, columnRef, newItemRef));
           } else {
-            RexNode oneBasedIndex =
+            RexNode zeroBasedIndex =
                 rexBuilder.makeCall(SqlStdOperatorTable.MINUS, itemRef, rexBuilder.makeExactLiteral(BigDecimal.ONE));
-            return Optional.of(rexBuilder.makeCall(call.op, columnRef, oneBasedIndex));
+            return Optional.of(rexBuilder.makeCall(call.op, columnRef, zeroBasedIndex));
           }
         }
       }

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
@@ -267,11 +267,16 @@ class IRRelToSparkRelTransformer {
       if (call.getOperator().equals(SqlStdOperatorTable.ITEM)) {
         RexNode columnRef = call.getOperands().get(0);
         RexNode itemRef = call.getOperands().get(1);
-        if (columnRef.getType() instanceof ArraySqlType && itemRef.isA(SqlKind.LITERAL)
-            && itemRef.getType().getSqlTypeName().equals(SqlTypeName.INTEGER)) {
-          Integer val = ((RexLiteral) itemRef).getValueAs(Integer.class);
-          RexLiteral newItemRef = rexBuilder.makeExactLiteral(new BigDecimal(val - 1), itemRef.getType());
-          return Optional.of(rexBuilder.makeCall(call.op, columnRef, newItemRef));
+        if (columnRef.getType() instanceof ArraySqlType) {
+          if (itemRef.isA(SqlKind.LITERAL) && itemRef.getType().getSqlTypeName().equals(SqlTypeName.INTEGER)) {
+            Integer val = ((RexLiteral) itemRef).getValueAs(Integer.class);
+            RexLiteral newItemRef = rexBuilder.makeExactLiteral(new BigDecimal(val - 1), itemRef.getType());
+            return Optional.of(rexBuilder.makeCall(call.op, columnRef, newItemRef));
+          } else {
+            RexNode oneBasedIndex = rexBuilder.makeCall(
+                SqlStdOperatorTable.MINUS, itemRef, rexBuilder.makeExactLiteral(BigDecimal.ONE));
+            return Optional.of(rexBuilder.makeCall(call.op, columnRef, oneBasedIndex));
+          }
         }
       }
       return Optional.empty();

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
@@ -273,8 +273,8 @@ class IRRelToSparkRelTransformer {
             RexLiteral newItemRef = rexBuilder.makeExactLiteral(new BigDecimal(val - 1), itemRef.getType());
             return Optional.of(rexBuilder.makeCall(call.op, columnRef, newItemRef));
           } else {
-            RexNode oneBasedIndex = rexBuilder.makeCall(
-                SqlStdOperatorTable.MINUS, itemRef, rexBuilder.makeExactLiteral(BigDecimal.ONE));
+            RexNode oneBasedIndex =
+                rexBuilder.makeCall(SqlStdOperatorTable.MINUS, itemRef, rexBuilder.makeExactLiteral(BigDecimal.ONE));
             return Optional.of(rexBuilder.makeCall(call.op, columnRef, oneBasedIndex));
           }
         }

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -226,6 +226,16 @@ public class CoralSparkTest {
   }
 
   @Test
+  public void testArrayElementWithFunctionArgument() {
+    RelNode relNode = TestUtils.toRelNode(String.join("\n", "",
+        "SELECT c[size(c) - 1]", "FROM complex"));
+
+    String targetSql = String.join("\n",
+        "SELECT c[size(c) - 1 + 1 - 1]", "FROM default.complex");
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+  }
+
+  @Test
   public void testDataTypeNamedStruct() {
     RelNode relNode =
         TestUtils.toRelNode(String.join("\n", "", "SELECT named_struct('abc', 123, 'def', 'xyz').def", "FROM bar"));

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -227,11 +227,9 @@ public class CoralSparkTest {
 
   @Test
   public void testArrayElementWithFunctionArgument() {
-    RelNode relNode = TestUtils.toRelNode(String.join("\n", "",
-        "SELECT c[size(c) - 1]", "FROM complex"));
+    RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT c[size(c) - 1]", "FROM complex"));
 
-    String targetSql = String.join("\n",
-        "SELECT c[size(c) - 1 + 1 - 1]", "FROM default.complex");
+    String targetSql = String.join("\n", "SELECT c[size(c) - 1 + 1 - 1]", "FROM default.complex");
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 


### PR DESCRIPTION
Hive uses 0-based array indices while ANSI SQL/Presto uses 1-based indices. When we convert from Hive QL to Calcite RelNodes we add 1 to all array indices. Hence `arrayField[0]` is converted to `arrayField[1]`. However today this adjustment only considers integer literals, all other indices are ignored and passed through as-is. This causes non-literal indices to not be adjusted, e.g. HiveQL `arrayField[size(arrayField) - 1]` still remains `arrayField[size(arrayField) - 1]` in RelNode leading to silent correctness issues.

This PR translates any non-integer literals by using a SQL function call to add one to the index.
`arrayField[size(arrayField) - 1]` => `arrayField[size(arrayField) - 1 + 1]`

I decided to keep the original implementation for integer literals for simplicity of the converted SQL in the most common cases, so that `arrayField[0]` is converted to `arrayField[1]` instead of `arrayField[0 + 1]`.

cc: @wmoustafa @funcheetah 