### PR TITLE
Make CARDINALITY return INT in Trino

### DIFF
--- a/coral-presto/src/main/java/com/linkedin/coral/presto/rel2presto/CalcitePrestoUDFMap.java
+++ b/coral-presto/src/main/java/com/linkedin/coral/presto/rel2presto/CalcitePrestoUDFMap.java
@@ -18,6 +18,7 @@ import com.linkedin.coral.com.google.common.collect.ImmutableMultimap;
 import com.linkedin.coral.hive.hive2rel.functions.HiveFunction;
 import com.linkedin.coral.hive.hive2rel.functions.HiveRLikeOperator;
 import com.linkedin.coral.hive.hive2rel.functions.StaticHiveFunctionRegistry;
+import com.linkedin.coral.presto.rel2presto.functions.PrestoCardinalityFunction;
 import com.linkedin.coral.presto.rel2presto.functions.PrestoElementAtFunction;
 
 import static com.linkedin.coral.presto.rel2presto.UDFMapUtils.*;
@@ -34,6 +35,7 @@ public class CalcitePrestoUDFMap {
     createUDFMapEntry(UDF_MAP, hiveToCalciteOp("nvl"), 2, "coalesce");
     // Array and map functions
     createUDFMapEntry(UDF_MAP, SqlStdOperatorTable.ITEM, 2, PrestoElementAtFunction.INSTANCE);
+    createUDFMapEntry(UDF_MAP, SqlStdOperatorTable.CARDINALITY, 1, PrestoCardinalityFunction.INSTANCE);
 
     // Math Functions
     createUDFMapEntry(UDF_MAP, SqlStdOperatorTable.RAND, 0, "RANDOM");

--- a/coral-presto/src/main/java/com/linkedin/coral/presto/rel2presto/functions/PrestoCardinalityFunction.java
+++ b/coral-presto/src/main/java/com/linkedin/coral/presto/rel2presto/functions/PrestoCardinalityFunction.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.presto.rel2presto.functions;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+
+
+/**
+ * Represents the CARDINALITY function in Presto
+ *
+ * Identical the CARDINALITY SQL function, but CARDINALITY in PRESTO returns a BIGINT so we
+ * need to cast it to an INTEGER when unparsing
+ */
+public class PrestoCardinalityFunction extends SqlFunction {
+  public static final PrestoCardinalityFunction INSTANCE = new PrestoCardinalityFunction();
+
+  public PrestoCardinalityFunction() {
+    super("CARDINALITY", SqlKind.OTHER_FUNCTION, ReturnTypes.INTEGER_NULLABLE, null, OperandTypes.COLLECTION_OR_MAP,
+        SqlFunctionCategory.SYSTEM);
+  }
+
+  @Override
+  public void unparse(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+    final SqlWriter.Frame frame = writer.startFunCall(SqlStdOperatorTable.CAST.getName());
+    super.unparse(writer, call, leftPrec, rightPrec);
+    writer.sep("AS");
+    writer.sep("INTEGER");
+    writer.endFunCall(frame);
+  }
+}

--- a/coral-presto/src/test/java/com/linkedin/coral/presto/rel2presto/RelToPrestoConverterTest.java
+++ b/coral-presto/src/test/java/com/linkedin/coral/presto/rel2presto/RelToPrestoConverterTest.java
@@ -480,4 +480,11 @@ public class RelToPrestoConverterTest {
     String expected = formatSql("SELECT CURRENT_DATE AS \"CURRENT_DATE\"\nFROM (VALUES  (0)) AS \"t\" (\"ZERO\")");
     testConversion(sql, expected);
   }
+
+  @Test
+  public void testCardinality() {
+    String sql = "SELECT cardinality(acol) FROM " + tableFour;
+    String expected = formatSql("SELECT CAST(CARDINALITY(acol) AS INTEGER) FROM " + tableFour);
+    testConversion(sql, expected);
+  }
 }


### PR DESCRIPTION
We convert the `size` function in Hive to `cardinality` in Trino (FKA PrestoSQL). However, `size` returns an `int` while `cardinality` returns `bigint`. This causes type validation issues in Trino when reading the view to fail with the error `<view_name> is stale; it must be re-created`.

When unparsing the `cardinality` function in Trino, we should add `CAST` to an integer to retain the semantics of Hive's `size` and Calcite's `cardinality`