### PR TITLE
Update Slack Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Please see the [Contribution Agreement](CONTRIBUTING.md).
 
 ## Community
 
-- Join the chat on [Slack](https://join.slack.com/t/coral-sql/shared_invite/zt-krbxjj9w-YkIWKVAufVtlHyoKtU6DWQ)!
+- Join the chat on [Slack](https://join.slack.com/t/coral-sql/shared_invite/zt-ntfxw19j-psQlunH1xlQbDZjle5_ZsA)!
 
 ## Resources
 


### PR DESCRIPTION
Update Slack invitation link. Current link expired.