### PR TITLE
Throw error when LATERAL VIEW uses unsupported table operator

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -54,6 +54,7 @@ import com.linkedin.coral.hive.hive2rel.parsetree.parser.ParseException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
 import static org.apache.calcite.sql.parser.SqlParserPos.ZERO;
 
 
@@ -200,9 +201,10 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
 
     // rightNode is AS.createCall(unnest, t, col)
     SqlNode rightNode = Iterables.getOnlyElement((SqlNodeList) sqlNodes.get(0));
-    checkState(rightNode instanceof SqlCall);
+    if (!(rightNode instanceof SqlCall) || !(((SqlCall) rightNode).getOperator() instanceof SqlAsOperator)) {
+      throw new UnsupportedOperationException(format("Unsupported LATERAL VIEW without AS: %s", rightNode));
+    }
     SqlCall aliasCall = (SqlCall) rightNode;
-    checkState(aliasCall.getOperator() instanceof SqlAsOperator);
     List<SqlNode> aliasOperands = aliasCall.getOperandList();
     checkState(aliasOperands.get(0) instanceof SqlCall);
     SqlCall tableFunctionCall = (SqlCall) aliasOperands.get(0);

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -209,16 +209,23 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
     checkState(aliasOperands.get(0) instanceof SqlCall);
     SqlCall tableFunctionCall = (SqlCall) aliasOperands.get(0);
 
+    if (tableFunctionCall.getOperator() instanceof HiveExplodeOperator) {
+      return visitLateralViewExplode(sqlNodes, aliasOperands, tableFunctionCall, isOuter);
+    }
+
     if (tableFunctionCall.getOperator() instanceof HiveJsonTupleOperator) {
       return visitLateralViewJsonTuple(sqlNodes, aliasOperands, tableFunctionCall);
     }
 
+    throw new UnsupportedOperationException(format("Unsupported LATERAL VIEW operator: %s", tableFunctionCall));
+  }
+
+  private SqlNode visitLateralViewExplode(List<SqlNode> sqlNodes, List<SqlNode> aliasOperands,
+      SqlCall tableFunctionCall, boolean isOuter) {
     checkState(aliasOperands.size() == 3);
     // TODO The code below assumes LATERAL VIEW is used with UNNEST EXPLODE only. It should be made more generic.
     SqlCall unnestCall = tableFunctionCall;
     SqlNode unnestOperand = unnestCall.operand(0);
-    // colNode is the column name in aliased table relation
-    SqlNode colNode = aliasCall.operand(2);
 
     if (isOuter) {
       // transforms unnest(b) to unnest( if(b is null or cardinality(b) = 0, [null], b))
@@ -242,7 +249,8 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
     SqlNode rightSelect = new SqlSelect(ZERO, null, new SqlNodeList(ImmutableList.of(SqlIdentifier.star(ZERO)), ZERO),
         unnestAlias, null, null, null, null, null, null, null);
     SqlNode lateralCall = SqlStdOperatorTable.LATERAL.createCall(ZERO, rightSelect);
-    aliasCall = SqlStdOperatorTable.AS.createCall(ZERO, lateralCall, aliasOperands.get(1), aliasOperands.get(2));
+    SqlCall aliasCall =
+        SqlStdOperatorTable.AS.createCall(ZERO, lateralCall, aliasOperands.get(1), aliasOperands.get(2));
     SqlNode joinNode = new SqlJoin(ZERO, sqlNodes.get(1), SqlLiteral.createBoolean(false, ZERO),
         JoinType.COMMA.symbol(ZERO), aliasCall/*lateralCall*/, JoinConditionType.NONE.symbol(ZERO), null);
     return joinNode;


### PR DESCRIPTION
Previously, an `EXPLODE(...)` was assumed.
