### PR TITLE
Support 'SELECT NULL null_field' and union schemas with NULL type field in coral-schema

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -171,7 +171,7 @@ class SchemaUtilities {
     Schema fieldSchema = RelDataTypeToAvroType.relDataTypeToAvroTypeNonNullable(fieldRelDataType, fieldName);
 
     // TODO: handle default value properly
-    if (isNullable) {
+    if (isNullable && fieldSchema.getType() != Schema.Type.NULL) {
       Schema fieldSchemaNullable = Schema.createUnion(Arrays.asList(fieldSchema, Schema.create(Schema.Type.NULL)));
       fieldAssembler.name(fieldName).type(fieldSchemaNullable).noDefault();
     } else {
@@ -436,6 +436,7 @@ class SchemaUtilities {
       case INT:
       case LONG:
       case STRING:
+      case NULL:
         return leftSchema.getType() == rightSchema.getType();
       case FIXED:
         boolean isSameType = leftSchema.getType() == rightSchema.getType();
@@ -526,6 +527,7 @@ class SchemaUtilities {
         case LONG:
         case STRING:
         case FIXED:
+        case NULL:
           // TODO: verify whether FIXED type has namespace
           appendField(field, fieldAssembler);
           break;

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -618,4 +618,15 @@ public class ViewToAvroSchemaConverterTests {
   }
 
   // TODO: add more unit tests
+  @Test
+  public void testSelectNull() {
+    String viewSql = "CREATE VIEW v AS SELECT NULL Null_Field FROM basecomplex";
+
+    TestUtils.executeCreateViewQuery("default", "v", viewSql);
+
+    ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);
+    Schema actualSchema = viewToAvroSchemaConverter.toAvroSchema("default", "v", false);
+
+    Assert.assertEquals(actualSchema.toString(true), TestUtils.loadSchema("testSelectNull-expected.avsc"));
+  }
 }

--- a/coral-schema/src/test/resources/base-complex-union-compatible.avsc
+++ b/coral-schema/src/test/resources/base-complex-union-compatible.avsc
@@ -53,5 +53,8 @@
       } ]
     } ],
     "default" : null
+  }, {
+    "name" : "Null_Field",
+    "type" : "null"
   } ]
 }

--- a/coral-schema/src/test/resources/base-complex.avsc
+++ b/coral-schema/src/test/resources/base-complex.avsc
@@ -53,5 +53,8 @@
       } ]
     } ],
     "default" : null
+  }, {
+    "name" : "Null_Field",
+    "type" : "null"
   } ]
 }

--- a/coral-schema/src/test/resources/testCompatibleUnion-expected.avsc
+++ b/coral-schema/src/test/resources/testCompatibleUnion-expected.avsc
@@ -53,5 +53,8 @@
       } ]
     } ],
     "default" : null
+  }, {
+    "name" : "Null_Field",
+    "type" : "null"
   } ]
 }

--- a/coral-schema/src/test/resources/testSelectNull-expected.avsc
+++ b/coral-schema/src/test/resources/testSelectNull-expected.avsc
@@ -1,0 +1,9 @@
+{
+  "type" : "record",
+  "name" : "v",
+  "namespace" : "default.v",
+  "fields" : [ {
+    "name" : "Null_Field",
+    "type" : "null"
+  } ]
+}


### PR DESCRIPTION
Views like `premium_mp.inapp_payment_event` are created using SQL like 
```
SELECT NULL null_field, ..., FROM table1
UNION ALL
SELECT ... FROM table2
```
There are 2 issues when coral-schema process views like it.
1. While visiting `SELECT NULL null_field`, `SchemaUtilities.appendField` is called to append `NULL` to the type of `null_field`, but there is no check to determine if the provided `null_field`'s type is NULL or not. This PR adds the checking before union NULL with the provided field type to avoid union 2 NULL values.
2. After checking and leaving the type of `null_field` as NULL, there is no support for NULL type in `SchemaUtilities.isUnionRecordSchemaCompatible` and `SchemaUtilities.setupNestedNamespaceForRecord`. This PR also adds the NULL in the cases.