### PR TITLE
Chang the Fuzzy Union to set evolved schemas to be the subset of columns in the branches of a UNION

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionSqlRewriter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionSqlRewriter.java
@@ -174,13 +174,13 @@ class FuzzyUnionSqlRewriter extends SqlShuttle {
     // Otherwise, return the passed in SqlNode.
     // The SqlShuttle will derive the view graph bottom up (from base tables to views above it).
     // In this case, the SqlValidator will always fix the schemas from tables to the view and will not fail.
-//        RelDataType fromNodeDataType = relContextProvider.getHiveSqlValidator().getValidatedNodeTypeIfKnown(unionBranch);
-//        if (fromNodeDataType == null) {
-//    relContextProvider.getHiveSqlValidator().validate(unionBranch);
-//    RelDataType fromNodeDataType = relContextProvider.getHiveSqlValidator().getValidatedNodeType(unionBranch);
-//        }
-    RelDataType fromNodeDataType =
-        relContextProvider.getSqlToRelConverter().convertQuery(unionBranch, true, true).rel.getRowType();
+        RelDataType fromNodeDataType = relContextProvider.getHiveSqlValidator().getValidatedNodeTypeIfKnown(unionBranch);
+        if (fromNodeDataType == null) {
+    relContextProvider.getHiveSqlValidator().validate(unionBranch);
+    fromNodeDataType = relContextProvider.getHiveSqlValidator().getValidatedNodeType(unionBranch);
+        }
+//    RelDataType fromNodeDataType =
+//        relContextProvider.getSqlToRelConverter().convertQuery(unionBranch, true, true).rel.getRowType();
 
     // Create a SqlNode that has a string equivalent to the following query:
     // SELECT table_name.col1, generic_project(table_name.col2), ... FROM (unionBranch) as table_name
@@ -363,6 +363,5 @@ class FuzzyUnionSqlRewriter extends SqlShuttle {
     }
 
     return true;
-    "[\"null\",{\"type\" : \"int\",\"logicalType\": \"date\"}]"
   }
 }

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionSqlRewriter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionSqlRewriter.java
@@ -5,6 +5,7 @@
  */
 package com.linkedin.coral.hive.hive2rel;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -12,10 +13,11 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
-import org.apache.calcite.schema.Table;
 import org.apache.calcite.sql.SqlAsOperator;
 import org.apache.calcite.sql.SqlBasicCall;
 import org.apache.calcite.sql.SqlCall;
@@ -26,6 +28,7 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.util.SqlShuttle;
 
 import com.linkedin.coral.hive.hive2rel.functions.GenericProjectFunction;
@@ -85,22 +88,26 @@ import com.linkedin.coral.hive.hive2rel.functions.GenericProjectFunction;
 class FuzzyUnionSqlRewriter extends SqlShuttle {
 
   private final String tableName;
-  private final RelDataType tableDataType;
   private final RelContextProvider relContextProvider;
-  private final List<String> columnNames;
 
-  public FuzzyUnionSqlRewriter(@Nonnull Table table, @Nonnull String tableName,
-      @Nonnull RelContextProvider relContextProvider) {
+  public FuzzyUnionSqlRewriter(@Nonnull String tableName, @Nonnull RelContextProvider relContextProvider) {
     this.relContextProvider = relContextProvider;
     this.tableName = tableName;
-    this.tableDataType = table.getRowType(relContextProvider.getHiveSqlValidator().getTypeFactory());
-    this.columnNames = tableDataType.getFieldNames();
   }
 
   @Override
   public SqlNode visit(SqlCall call) {
     if (call.getOperator().getKind() == SqlKind.UNION) {
-      call = addFuzzyUnionToUnionCall(call);
+      // Since a union is represented as a binary operator in calcite, chaining unions would have an AST like:
+      // Given A UNION B UNION C, the SqlNode AST would look something like:
+      //      U
+      //     / \
+      //    A   U
+      //       / \
+      //      B   C
+      // We need to compare the schemas of all leaves of the union (A,B,C) and adjust if necessary.
+      final RelDataType expectedDataType = getUnionDataType(call);
+      call = addFuzzyUnionToUnionCall(call, expectedDataType);
     }
     ArgHandler<SqlNode> argHandler = new CallCopyingArgHandler(call, false);
     call.getOperator().acceptCall(this, call, false, argHandler);
@@ -111,13 +118,12 @@ class FuzzyUnionSqlRewriter extends SqlShuttle {
    * Create a SqlNode that calls GenericProject for the given column
    * @param columnName The name of the column that is to be fixed
    */
-  private SqlNode createGenericProject(String columnName) {
+  private SqlNode createGenericProject(String columnName, RelDataType expectedType) {
     SqlNode[] genericProjectOperands = new SqlNode[2];
     genericProjectOperands[0] = new SqlIdentifier(ImmutableList.of(tableName, columnName), SqlParserPos.ZERO);
     genericProjectOperands[1] = SqlLiteral.createCharString(columnName, SqlParserPos.ZERO);
-    RelDataTypeField columnField = tableDataType.getField(columnName, false, true);
     SqlBasicCall genericProjectCall =
-        new SqlBasicCall(new GenericProjectFunction(columnField.getType()), genericProjectOperands, SqlParserPos.ZERO);
+        new SqlBasicCall(new GenericProjectFunction(expectedType), genericProjectOperands, SqlParserPos.ZERO);
     SqlNode[] castAsColumnOperands = new SqlNode[2];
     castAsColumnOperands[0] = genericProjectCall;
     castAsColumnOperands[1] = new SqlIdentifier(columnName, SqlParserPos.ZERO);
@@ -137,17 +143,14 @@ class FuzzyUnionSqlRewriter extends SqlShuttle {
    *           - else
    *             - use a generic projection over the struct column fixing the schema to be tableDataType.structField
    */
-  private SqlNodeList createProjectedFieldsNodeList(RelDataType fromNodeDataType) {
-    SqlNodeList projectedFields = new SqlNodeList(SqlParserPos.ZERO);
-    for (RelDataTypeField field : tableDataType.getFieldList()) {
-      SqlNode projectedField;
-      RelDataTypeField schemaDataTypeField = tableDataType.getField(field.getName(), false, false);
-      RelDataTypeField inputDataTypeField = fromNodeDataType.getField(field.getName(), false, false);
-      if (field.getType().getFullTypeString().contains("RecordType")
-          && !schemaDataTypeField.equals(inputDataTypeField)) {
-        projectedField = createGenericProject(field.getName());
-      } else {
-        projectedField = new SqlIdentifier(ImmutableList.of(tableName, field.getName()), SqlParserPos.ZERO);
+  private SqlNodeList createProjectedFieldsNodeList(RelDataType fromNodeDataType, RelDataType expectedDataType) {
+    final SqlNodeList projectedFields = new SqlNodeList(SqlParserPos.ZERO);
+
+    for (final RelDataTypeField expectedField : expectedDataType.getFieldList()) {
+      final RelDataTypeField inputField = fromNodeDataType.getField(expectedField.getName(), false, false);
+      SqlNode projectedField = new SqlIdentifier(ImmutableList.of(tableName, inputField.getName()), SqlParserPos.ZERO);
+      if (!equivalentDataTypes(expectedField.getType(), inputField.getType())) {
+        projectedField = createGenericProject(inputField.getName(), expectedField.getType());
       }
       projectedFields.add(projectedField);
     }
@@ -160,44 +163,27 @@ class FuzzyUnionSqlRewriter extends SqlShuttle {
    * a RelDataType that is a superset of the fields that exist in the tableDataType and is not strictly the equivalent
    * to tableDataType.
    * @param unionBranch SqlNode node that is a branch in a union
+   * @param expectedDataType The expected data type for the UNION branch
    * @return SqlNode that has its schema fixed to the schema of the table
    */
-  private SqlNode addFuzzyUnionToUnionBranch(SqlNode unionBranch) {
+  private SqlNode addFuzzyUnionToUnionBranch(SqlNode unionBranch, RelDataType expectedDataType) {
 
     // Retrieve the datatype of the node if known.
     // If it is known, retrieve it from the node.
     // Otherwise, return the passed in SqlNode.
     // The SqlShuttle will derive the view graph bottom up (from base tables to views above it).
     // In this case, the SqlValidator will always fix the schemas from tables to the view and will not fail.
-    RelDataType fromNodeDataType = relContextProvider.getHiveSqlValidator().getValidatedNodeTypeIfKnown(unionBranch);
-    if (fromNodeDataType == null) {
-      relContextProvider.getHiveSqlValidator().validate(unionBranch);
-      fromNodeDataType = relContextProvider.getHiveSqlValidator().getValidatedNodeType(unionBranch);
-    }
-    // tableDataType is always a view RelDataType. View RelDataTypes are inferred from Hive's storage
-    // descriptor. Unlike view RelDataTypes, base table RelDataTypes are inferred from Hive SerDe
-    // library corresponding to the table. See {@link com.linkedin.coral.hive.hive2rel.HiveTable.getRowType}
-    // for more details. This results in the view schema (tableDataType) being always lower-cased, and the
-    // (potentially) base table schema (fromNodeDataType) being properly cased. Case difference
-    // between view schema and underlying union branch schema should not warrant a fuzzy union,
-    // and hence we ignore cases when comparing fromNodeDataType and tableDataType.
-    if (tableDataType.getFullTypeString().equalsIgnoreCase(fromNodeDataType.getFullTypeString())
-        || !fromNodeDataType.isStruct() || fromNodeDataType.getFieldCount() < tableDataType.getFieldCount()) {
-      return unionBranch;
-    }
-
-    // The table schema will be projected over a branch if and only if the branch contains a superset of the
-    // fields in the provided table schema and does not have the same schema as the table schema.
-    Set<String> fromNodeFieldNames =
-        fromNodeDataType.getFieldList().stream().map(f -> f.getName()).collect(Collectors.toSet());
-
-    if (!fromNodeFieldNames.containsAll(columnNames)) {
-      return unionBranch;
-    }
+    //    RelDataType fromNodeDataType = relContextProvider.getHiveSqlValidator().getValidatedNodeTypeIfKnown(unionBranch);
+    //    if (fromNodeDataType == null) {
+    //      relContextProvider.getHiveSqlValidator().validate(unionBranch);
+    //      fromNodeDataType = relContextProvider.getHiveSqlValidator().getValidatedNodeType(unionBranch);
+    //    }
+    RelDataType fromNodeDataType =
+        relContextProvider.getSqlToRelConverter().convertQuery(unionBranch, true, true).rel.getRowType();
 
     // Create a SqlNode that has a string equivalent to the following query:
     // SELECT table_name.col1, generic_project(table_name.col2), ... FROM (unionBranch) as table_name
-    SqlNodeList projectedFields = createProjectedFieldsNodeList(fromNodeDataType);
+    SqlNodeList projectedFields = createProjectedFieldsNodeList(fromNodeDataType, expectedDataType);
     SqlNode[] castTableOperands = { unionBranch, new SqlIdentifier(tableName, SqlParserPos.ZERO) };
     SqlBasicCall castTableCall = new SqlBasicCall(new SqlAsOperator(), castTableOperands, SqlParserPos.ZERO);
     SqlSelect selectOperator = new SqlSelect(SqlParserPos.ZERO, new SqlNodeList(SqlParserPos.ZERO), projectedFields,
@@ -212,24 +198,126 @@ class FuzzyUnionSqlRewriter extends SqlShuttle {
    * @param unionCall Union operator SqlCall
    * @return a Union operator SqlCall with fuzzy union semantics
    */
-  private SqlCall addFuzzyUnionToUnionCall(SqlCall unionCall) {
+  private SqlCall addFuzzyUnionToUnionCall(SqlCall unionCall, RelDataType expectedDataType) {
     for (int i = 0; i < unionCall.operandCount(); ++i) {
       SqlNode operand = unionCall.operand(i);
-      // Since a union is represented as a binary operator in calcite, chaining unions would have an AST like:
-      // Given A UNION B UNION C, the SqlNode AST would look something like:
-      //      U
-      //     / \
-      //    A   U
-      //       / \
-      //      B   C
-      // From the root node, we can see that one of the operands is another union.
       // In this case, we do not need to apply fuzzy union semantics to the union itself.
       // The fuzzy union semantics only need to be applied to the children of ths union.
       if (!isUnionOperator(operand)) {
-        unionCall.setOperand(i, addFuzzyUnionToUnionBranch(operand));
+        unionCall.setOperand(i, addFuzzyUnionToUnionBranch(operand, expectedDataType));
+      } else {
+        unionCall.setOperand(i, addFuzzyUnionToUnionCall((SqlCall) operand, expectedDataType));
       }
     }
     return unionCall;
+  }
+
+  /**
+   * Returns data type given by the common subset of columns in the branches of the UNION call.
+   */
+  private RelDataType getUnionDataType(final SqlCall unionCall) {
+    final List<SqlNode> leafNodes = getUnionLeafNodes(unionCall);
+    final List<RelDataType> leafNodeDataTypes = new ArrayList<>();
+    for (final SqlNode node : leafNodes) {
+      RelDataType fromNodeDataType = relContextProvider.getHiveSqlValidator().getValidatedNodeTypeIfKnown(node);
+      if (fromNodeDataType == null) {
+        relContextProvider.getHiveSqlValidator().validate(node);
+        fromNodeDataType = relContextProvider.getHiveSqlValidator().getValidatedNodeType(node);
+      }
+      leafNodeDataTypes.add(fromNodeDataType);
+    }
+
+    return getUnionDataType(leafNodeDataTypes);
+  }
+
+  /**
+   * Returns data type given by the common subset of columns in the given dataTypes.
+   */
+  private RelDataType getUnionDataType(final List<RelDataType> dataTypes) {
+    // Use the first dataType as the model/base type.
+    // Assumes that all dataTypes in the list once shared a common type
+    // and only evolved in a backwards compatible fashion.
+    final RelDataType baseDataType = dataTypes.get(0);
+
+    if (!(baseDataType.isStruct()) && !(baseDataType.getSqlTypeName() == SqlTypeName.ARRAY)
+        && !(baseDataType.getSqlTypeName() == SqlTypeName.MAP)) {
+      return relContextProvider.getRelBuilder().getTypeFactory().createTypeWithNullability(baseDataType, true);
+    }
+
+    RelDataType expectedCommonType = null;
+
+    if (baseDataType.isStruct()) {
+      // Build the common UNION type using the first branch that appears in the query
+      final RelDataTypeFactory.Builder builder =
+          new RelDataTypeFactory.Builder(relContextProvider.getRelBuilder().getTypeFactory());
+
+      // Build a set of common fields by name in the given dataTypes
+      Set<String> commonFieldNames =
+          baseDataType.getFieldNames().stream().map(String::toLowerCase).collect(Collectors.toSet());
+      for (int i = 1; i < dataTypes.size(); ++i) {
+        final Set<String> branchFieldNames =
+            dataTypes.get(i).getFieldNames().stream().map(String::toLowerCase).collect(Collectors.toSet());
+        commonFieldNames = Sets.intersection(commonFieldNames, branchFieldNames);
+      }
+
+      // Build a new struct with the common fields using the baseDataType's struct ordering
+      for (final RelDataTypeField field : baseDataType.getFieldList()) {
+        if (!commonFieldNames.contains(field.getName().toLowerCase())) {
+          continue;
+        }
+
+        final List<RelDataType> fieldTypes = dataTypes.stream()
+            .map(type -> type.getField(field.getName(), false, false).getType()).collect(Collectors.toList());
+
+        // Recursively derive the common types for all fields of the struct
+        final RelDataType columnType = getUnionDataType(fieldTypes);
+
+        builder.add(field.getName(),
+            relContextProvider.getRelBuilder().getTypeFactory().createTypeWithNullability(columnType, true));
+      }
+
+      expectedCommonType =
+          relContextProvider.getRelBuilder().getTypeFactory().createTypeWithNullability(builder.build(), true);
+    }
+
+    if (baseDataType.getSqlTypeName() == SqlTypeName.ARRAY) {
+      // Recursively derive the common type of the component in the array
+      final List<RelDataType> nestedArrayTypes =
+          dataTypes.stream().map(RelDataType::getComponentType).collect(Collectors.toList());
+      final RelDataType expectedArrayType = getUnionDataType(nestedArrayTypes);
+      expectedCommonType = relContextProvider.getRelBuilder().getTypeFactory().createArrayType(expectedArrayType, -1);
+    }
+
+    if (baseDataType.getSqlTypeName() == SqlTypeName.MAP) {
+      // Recursively derive the common type of the value type in the map
+      final List<RelDataType> nestedValueTypes =
+          dataTypes.stream().map(RelDataType::getValueType).collect(Collectors.toList());
+      final RelDataType expectedValueType = getUnionDataType(nestedValueTypes);
+      final RelDataType expectedKeyType = relContextProvider.getRelBuilder().getTypeFactory()
+          .createTypeWithNullability(baseDataType.getKeyType(), true);
+      expectedCommonType =
+          relContextProvider.getRelBuilder().getTypeFactory().createMapType(expectedKeyType, expectedValueType);
+    }
+
+    return expectedCommonType;
+  }
+
+  /**
+   * Return a list of SqlNode branches in the UNION call ordered based on the query string.
+   * Example:
+   *     'A UNION B UNION C' => [SqlNode_A, SqlNode_B, SqlNode_C]
+   */
+  private List<SqlNode> getUnionLeafNodes(SqlCall unionCall) {
+    final List<SqlNode> leafNodes = new ArrayList<>();
+    for (int i = 0; i < unionCall.operandCount(); ++i) {
+      final SqlNode operand = unionCall.operand(i);
+      if (isUnionOperator(operand)) {
+        leafNodes.addAll(getUnionLeafNodes((SqlCall) operand));
+      } else {
+        leafNodes.add(operand);
+      }
+    }
+    return leafNodes;
   }
 
   /**
@@ -239,5 +327,40 @@ class FuzzyUnionSqlRewriter extends SqlShuttle {
    */
   private boolean isUnionOperator(SqlNode node) {
     return (node instanceof SqlCall) && ((SqlCall) node).getOperator().getKind() == SqlKind.UNION;
+  }
+
+  /**
+   * Return true if the RelDataTypes t1 and t2 are equivalent.
+   *
+   * NOTE:
+   * We don't actually check the types of columns.
+   * We just want to check that the data types have the same structure and ordering of columns.
+   */
+  private boolean equivalentDataTypes(RelDataType t1, RelDataType t2) {
+    if (t1.isStruct()) {
+      if (t1.getFieldCount() != t2.getFieldCount()) {
+        return false;
+      }
+
+      for (int i = 0; i < t1.getFieldCount(); ++i) {
+        final RelDataTypeField f1 = t1.getFieldList().get(i);
+        final RelDataTypeField f2 = t2.getFieldList().get(i);
+
+        if (!f1.getName().equalsIgnoreCase(f2.getName()) || !equivalentDataTypes(f1.getType(), f2.getType())) {
+          return false;
+        }
+      }
+    }
+
+    if (t1.getSqlTypeName() == SqlTypeName.ARRAY
+        && !equivalentDataTypes(t1.getComponentType(), t2.getComponentType())) {
+      return false;
+    }
+
+    if (t1.getSqlTypeName() == SqlTypeName.MAP && !equivalentDataTypes(t1.getValueType(), t2.getValueType())) {
+      return false;
+    }
+
+    return true;
   }
 }

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionSqlRewriter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionSqlRewriter.java
@@ -174,13 +174,11 @@ class FuzzyUnionSqlRewriter extends SqlShuttle {
     // Otherwise, return the passed in SqlNode.
     // The SqlShuttle will derive the view graph bottom up (from base tables to views above it).
     // In this case, the SqlValidator will always fix the schemas from tables to the view and will not fail.
-        RelDataType fromNodeDataType = relContextProvider.getHiveSqlValidator().getValidatedNodeTypeIfKnown(unionBranch);
-        if (fromNodeDataType == null) {
-    relContextProvider.getHiveSqlValidator().validate(unionBranch);
-    fromNodeDataType = relContextProvider.getHiveSqlValidator().getValidatedNodeType(unionBranch);
-        }
-//    RelDataType fromNodeDataType =
-//        relContextProvider.getSqlToRelConverter().convertQuery(unionBranch, true, true).rel.getRowType();
+     RelDataType fromNodeDataType = relContextProvider.getHiveSqlValidator().getValidatedNodeTypeIfKnown(unionBranch);
+     if (fromNodeDataType == null) {
+       relContextProvider.getHiveSqlValidator().validate(unionBranch);
+       fromNodeDataType = relContextProvider.getHiveSqlValidator().getValidatedNodeType(unionBranch);
+     }
 
     // Create a SqlNode that has a string equivalent to the following query:
     // SELECT table_name.col1, generic_project(table_name.col2), ... FROM (unionBranch) as table_name

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverter.java
@@ -105,7 +105,7 @@ public class HiveToRelConverter {
     SqlNode sqlNode = getTreeBuilder().processView(hiveDbName, hiveViewName);
     Table view = relContextProvider.getHiveSchema().getSubSchema(hiveDbName).getTable(hiveViewName);
     if (view != null) {
-      sqlNode.accept(new FuzzyUnionSqlRewriter(view, hiveViewName, relContextProvider));
+      sqlNode.accept(new FuzzyUnionSqlRewriter(hiveViewName, relContextProvider));
     }
     return toRel(sqlNode);
   }

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveViewExpander.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveViewExpander.java
@@ -53,7 +53,8 @@ public class HiveViewExpander implements RelOptTable.ViewExpander {
     }
     ParseTreeBuilder treeBuilder = new ParseTreeBuilder(msc, relContextProvider.getParseTreeBuilderConfig(),
         relContextProvider.getHiveFunctionRegistry(), relContextProvider.getDynamicHiveFunctionRegistry());
-    SqlNode viewNode = treeBuilder.processViewOrTable(table);
+    SqlNode viewNode =
+        treeBuilder.processViewOrTable(table).accept(new FuzzyUnionSqlRewriter(tableName, relContextProvider));
     return relContextProvider.getSqlToRelConverter().convertQuery(viewNode, true, true);
   }
 }

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/TestUtils.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/TestUtils.java
@@ -131,6 +131,13 @@ public class TestUtils {
       driver.run(
           "ALTER TABLE fuzzy_union.tableL CHANGE COLUMN b b struct<b1:string, b2:struct<b3:string, b4:struct<b5:string, b6:string>>>");
 
+      driver.run("CREATE TABLE IF NOT EXISTS fuzzy_union.tableN(a int, b struct<b1:string>)");
+      driver.run("CREATE TABLE IF NOT EXISTS fuzzy_union.tableO(a int, b struct<b1:string>)");
+      driver.run(
+          "CREATE VIEW IF NOT EXISTS fuzzy_union.union_view_same_schema_evolution_with_different_ordering AS SELECT * from fuzzy_union.tableN union all SELECT * from fuzzy_union.tableO");
+      driver.run("ALTER TABLE fuzzy_union.tableN CHANGE COLUMN b b struct<b2:double, b1:string, b0:int>");
+      driver.run("ALTER TABLE fuzzy_union.tableO CHANGE COLUMN b b struct<b0:int, b1:string, b2:int>");
+
       driver.run("CREATE TABLE IF NOT EXISTS foo(a int, b varchar(30), c double)");
       driver.run("CREATE TABLE IF NOT EXISTS bar(x int, y double)");
       driver.run("CREATE VIEW IF NOT EXISTS foo_view AS SELECT b as bcol, sum(c) as sum_c from foo group by b");
@@ -162,7 +169,7 @@ public class TestUtils {
                       "union_view_with_alias", "union_view_single_branch_evolved",
                       "union_view_double_branch_evolved_different", "union_view_map_with_struct_value_evolved",
                       "union_view_array_with_struct_value_evolved", "union_view_deeply_nested_struct_evolved",
-                      "union_view_more_than_two_branches_evolved")));
+                      "union_view_more_than_two_branches_evolved", "union_view_same_schema_evolution_with_different_ordering")));
 
       // add some Dali functions to table properties
       IMetaStoreClient msc = testHive.getMetastoreClient();

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/FuzzyUnionViewTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/FuzzyUnionViewTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2020 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -93,11 +93,8 @@ public class FuzzyUnionViewTest {
     // This query currently does not have any generic_projections despite the top level view schema being inconsistent
     // because the schemas of the branches evolved the same way.
     // This unit test illustrates this behaviour; however, we can re-evaluate our desired behaviour later on.
-    String expectedSql = ""
-        + "SELECT a, generic_project(b, '{\"type\":\"struct\",\"fields\":[{\"type\":\"string\",\"name\":\"b1\",\"nullable\":true,\"metadata\":{}}]}') b\n"
-        + "FROM fuzzy_union.tabled\n" + "UNION ALL\n"
-        + "SELECT a, generic_project(b, '{\"type\":\"struct\",\"fields\":[{\"type\":\"string\",\"name\":\"b1\",\"nullable\":true,\"metadata\":{}}]}') b\n"
-        + "FROM fuzzy_union.tablee";
+    String expectedSql =
+        "SELECT *\n" + "FROM fuzzy_union.tabled\n" + "UNION ALL\n" + "SELECT *\n" + "FROM fuzzy_union.tablee";
 
     assertEquals(expandedSql, expectedSql);
   }
@@ -179,6 +176,21 @@ public class FuzzyUnionViewTest {
     String expectedSql = ""
         + "SELECT a, generic_project(b, '{\"type\":\"struct\",\"fields\":[{\"type\":\"string\",\"name\":\"b1\",\"nullable\":true,\"metadata\":{}},{\"type\":{\"type\":\"struct\",\"fields\":[{\"type\":\"string\",\"name\":\"b3\",\"nullable\":true,\"metadata\":{}},{\"type\":{\"type\":\"struct\",\"fields\":[{\"type\":\"string\",\"name\":\"b5\",\"nullable\":true,\"metadata\":{}}]},\"name\":\"b4\",\"nullable\":true,\"metadata\":{}}]},\"name\":\"b2\",\"nullable\":true,\"metadata\":{}}]}') b\n"
         + "FROM fuzzy_union.tablel\n" + "UNION ALL\n" + "SELECT *\n" + "FROM fuzzy_union.tablem";
+
+    assertEquals(expandedSql, expectedSql);
+  }
+
+  @Test
+  public void testSameSchemaEvolutionWithDifferentOrdering() throws TException {
+    String database = "fuzzy_union";
+    String view = "union_view_same_schema_evolution_with_different_ordering";
+    RelNode relNode = TestUtils.toRelNode(database, view);
+    CoralSpark coralSpark = CoralSpark.create(relNode);
+    String expandedSql = coralSpark.getSparkSql();
+
+    String expectedSql = "SELECT *\n" + "FROM fuzzy_union.tablen\n" + "UNION ALL\n"
+        + "SELECT a, generic_project(b, '{\"type\":\"struct\",\"fields\":[{\"type\":\"double\",\"name\":\"b2\",\"nullable\":true,\"metadata\":{}},{\"type\":\"string\",\"name\":\"b1\",\"nullable\":true,\"metadata\":{}},{\"type\":\"integer\",\"name\":\"b0\",\"nullable\":true,\"metadata\":{}}]}') b\n"
+        + "FROM fuzzy_union.tableo";
 
     assertEquals(expandedSql, expectedSql);
   }

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2020 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -163,6 +163,18 @@ public class TestUtils {
         "AS", "SELECT *", "from fuzzy_union.tableL", "union all", "SELECT *", "from fuzzy_union.tableM"));
     run(driver, String.join("\n", "",
         "ALTER TABLE fuzzy_union.tableL CHANGE COLUMN b b struct<b1:string, b2:struct<b3:string, b4:struct<b5:string, b6:string>>>"));
+
+    run(driver, String.join("\n", "", "CREATE TABLE IF NOT EXISTS fuzzy_union.tableN(a int, b struct<b1:string>)"));
+    run(driver, String.join("\n", "", "CREATE TABLE IF NOT EXISTS fuzzy_union.tableO(a int, b struct<b1:string>)"));
+    run(driver,
+        String.join("\n", "",
+            "CREATE VIEW IF NOT EXISTS fuzzy_union.union_view_same_schema_evolution_with_different_ordering", "AS",
+            "SELECT *", "from fuzzy_union.tableN", "union all", "SELECT *", "from fuzzy_union.tableO"));
+    run(driver,
+        String.join("\n", "", "ALTER TABLE fuzzy_union.tableN CHANGE COLUMN b b struct<b2:double, b1:string, b0:int>"));
+    run(driver,
+        String.join("\n", "", "ALTER TABLE fuzzy_union.tableO CHANGE COLUMN b b struct<b0:int, b1:string, b2:int>"));
+
     run(driver, String.join("\n", "", "CREATE TABLE IF NOT EXISTS schema_promotion(a int, b array<int>)"));
     run(driver,
         String.join("\n", "", "CREATE VIEW IF NOT EXISTS view_schema_promotion AS SELECT * from schema_promotion"));

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -64,9 +64,9 @@ public class HiveToTrinoConverterTest {
             + "SELECT \"a\", \"b\"\nFROM \"test\".\"tableb\"\nUNION ALL\n"
             + "SELECT \"a\", CAST(row(b.b1) as row(b1 varchar)) AS \"b\"\nFROM \"test\".\"tablec\") AS \"t1\"" },
 
-        { "test", "fuzzy_union_view_double_branch_evolved_same", "SELECT \"a\", \"b\"\nFROM ("
-            + "SELECT \"a\", CAST(row(b.b1) as row(b1 varchar)) AS \"b\"\nFROM \"test\".\"tabled\"\nUNION ALL\n"
-            + "SELECT \"a\", CAST(row(b.b1) as row(b1 varchar)) AS \"b\"\nFROM \"test\".\"tablee\") AS \"t1\"" },
+        { "test", "fuzzy_union_view_double_branch_evolved_same", "SELECT \"a\", \"b\"\n" + "FROM (SELECT \"a\", \"b\"\n"
+            + "FROM \"test\".\"tabled\"\n" + "UNION ALL\n" + "SELECT \"a\", \"b\"\n"
+            + "FROM \"test\".\"tablee\") AS \"t1\"" },
 
         { "test", "fuzzy_union_view_double_branch_evolved_different", "SELECT \"a\", \"b\"\nFROM ("
             + "SELECT \"a\", CAST(row(b.b1) as row(b1 varchar)) AS \"b\"\nFROM \"test\".\"tablef\"\nUNION ALL\n"
@@ -92,6 +92,11 @@ public class HiveToTrinoConverterTest {
         { "test", "fuzzy_union_view_deeply_nested_complex_struct_evolved", "" + "SELECT \"a\", \"b\"\nFROM ("
             + "SELECT \"a\", CAST(row(b.b1, transform_values(b.m1, (k, v) -> cast(row(v.b1, transform(v.a1, x -> cast(row(x.b1) as row(b1 varchar)))) as row(b1 varchar, a1 array(row(b1 varchar)))))) as row(b1 varchar, m1 map(varchar, row(b1 varchar, a1 array(row(b1 varchar)))))) AS \"b\"\nFROM \"test\".\"tablen\"\nUNION ALL\n"
             + "SELECT \"a\", \"b\"\n" + "FROM \"test\".\"tableo\") AS \"t1\"" },
+
+        { "test", "union_view_same_schema_evolution_with_different_ordering", "" + "SELECT \"a\", \"b\"\n"
+            + "FROM (SELECT \"a\", \"b\"\n" + "FROM \"test\".\"tablep\"\n" + "UNION ALL\n"
+            + "SELECT \"a\", CAST(row(b.b2, b.b1, b.b0) as row(b2 double, b1 varchar, b0 integer)) AS \"b\"\n"
+            + "FROM \"test\".\"tableq\") AS \"t1\"" },
 
         { "test", "view_with_explode_string_array", "SELECT \"$cor0\".\"a\" AS \"a\", \"t1\".\"c\" AS \"c\"\n"
             + "FROM \"test\".\"table_with_string_array\" AS \"$cor0\"\n"

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
@@ -256,6 +256,15 @@ public class TestUtils {
     run(driver,
         "ALTER TABLE test.tableN CHANGE COLUMN b b struct<b1:string, m1:map<string, struct<b1:string, a1:array<struct<b0:string, b1:string>>>>>");
 
+    run(driver, String.join("\n", "", "CREATE TABLE IF NOT EXISTS test.tableP(a int, b struct<b1:string>)"));
+    run(driver, String.join("\n", "", "CREATE TABLE IF NOT EXISTS test.tableQ(a int, b struct<b1:string>)"));
+    run(driver,
+        String.join("\n", "", "CREATE VIEW IF NOT EXISTS test.union_view_same_schema_evolution_with_different_ordering",
+            "AS", "SELECT *", "from test.tableP", "union all", "SELECT *", "from test.tableQ"));
+    run(driver,
+        String.join("\n", "", "ALTER TABLE test.tableP CHANGE COLUMN b b struct<b2:double, b1:string, b0:int>"));
+    run(driver, String.join("\n", "", "ALTER TABLE test.tableQ CHANGE COLUMN b b struct<b0:int, b1:string, b2:int>"));
+
     run(driver, "CREATE TABLE test.table_with_string_array(a int, b array<string>)");
     run(driver,
         "CREATE VIEW test.view_with_explode_string_array AS SELECT a, c FROM test.table_with_string_array LATERAL VIEW EXPLODE(b) t AS c");


### PR DESCRIPTION
Previously, the schema was taken from the top-level view, which did not allow automatic schema evolution.
This PR changes the Fuzzy Union implementation to set evolved schemas to be the subset of columns in the branches of a UNION.

Tests:
1. unit tests
2. test on production views over last 6 month