### PR TITLE
Manually add some UDFs to static registry

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -360,6 +360,27 @@ public class StaticHiveFunctionRegistry implements HiveFunctionRegistry {
     createAddUserDefinedFunction("com.linkedin.dali.udf.sanitize.hive.Sanitize", HiveReturnTypes.STRING, STRING);
     createAddUserDefinedFunction("org.apache.hadoop.hive.ql.udf.generic.GenericProject", ARG0,
         family(SqlTypeFamily.ANY, SqlTypeFamily.STRING));
+    createAddUserDefinedFunction("com.linkedin.dali.view.udf.entityhandles.GetIdFromUrn", BIGINT, STRING);
+    createAddUserDefinedFunction("com.linkedin.dali.view.udf.entityhandles.GetPermissionsString",
+        HiveReturnTypes.STRING, family(SqlTypeFamily.ARRAY));
+    createAddUserDefinedFunction("com.linkedin.dali.view.udf.entityhandles.EpochTimeInSeconds", BIGINT, STRING);
+    createAddUserDefinedFunction("com.linkedin.dali.view.udf.entityhandles.EpochTimeInSecondsNullable", BIGINT_NULLABLE,
+        STRING);
+    createAddUserDefinedFunction("com.linkedin.dali.view.udf.entityhandles.PhoneNumberNormalizer",
+        HiveReturnTypes.STRING, STRING_STRING_STRING);
+    createAddUserDefinedFunction("com.linkedin.dwh.udf.profile.GetProfileUrl", HiveReturnTypes.STRING, family(
+        SqlTypeFamily.NUMERIC, SqlTypeFamily.STRING, SqlTypeFamily.STRING, SqlTypeFamily.STRING, SqlTypeFamily.STRING));
+    createAddUserDefinedFunction("com.linkedin.dali.views.premium.udf.GetFamily", HiveReturnTypes.STRING,
+        family(SqlTypeFamily.MAP));
+    createAddUserDefinedFunction("com.linkedin.dali.views.premium.udf.GetOrderUrn", HiveReturnTypes.STRING,
+        family(SqlTypeFamily.MAP, SqlTypeFamily.STRING));
+    createAddUserDefinedFunction("com.linkedin.dali.views.premium.udf.GetChooserId", HiveReturnTypes.STRING,
+        family(SqlTypeFamily.MAP));
+    createAddUserDefinedFunction("com.linkedin.etg.business.common.udfs.MapSfdcProductName", HiveReturnTypes.STRING,
+        STRING);
+    createAddUserDefinedFunction("com.linkedin.etg.business.common.udfs.MapSfdcProductCode", HiveReturnTypes.STRING,
+        STRING);
+    createAddUserDefinedFunction("com.linkedin.etg.business.common.udfs.MapSfdcProductId", ReturnTypes.INTEGER, STRING);
 
     // LIHADOOP-48502: The following UDFs are already defined using Transport UDF.
     // The class name is the corresponding Hive UDF.


### PR DESCRIPTION
Some UDFs are added to `StaticHiveFunctionRegistry` to avoid the exception:
```
java.lang.RuntimeException: Unable to find org.apache.hadoop.hive.ql.udf.generic.GenericUDF.initialize() on: <UDF>
```
Tested on affected production views over last 6 month, which can be translated successfully with this patch.