### PR TITLE
Avoid throwing exception 'Unable to fetch dependencies' if 'report.hasError()' in ArtifactsResolver

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/ArtifactsResolver.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/ArtifactsResolver.java
@@ -124,7 +124,11 @@ public class ArtifactsResolver {
         .setOutputReport(true).setValidate(true).setTransitive(dependencySpec.transitive);
     resolveOptions.setLog(LogOptions.LOG_QUIET);
     try {
-      return _ivyInstance.resolve(md, resolveOptions);
+      ResolveReport report = _ivyInstance.resolve(md, resolveOptions);
+      if (report.hasError()) {
+        LOG.warn("Unable to fetch dependencies: " + report.getAllProblemMessages());
+      }
+      return report;
     } catch (ParseException | IOException e) {
       throw new RuntimeException("Unable to fetch dependencies", e);
     }

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/ArtifactsResolver.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/ArtifactsResolver.java
@@ -124,7 +124,7 @@ public class ArtifactsResolver {
         .setOutputReport(true).setValidate(true).setTransitive(dependencySpec.transitive);
     resolveOptions.setLog(LogOptions.LOG_QUIET);
     try {
-      ResolveReport report = _ivyInstance.resolve(md, resolveOptions);
+      final ResolveReport report = _ivyInstance.resolve(md, resolveOptions);
       if (report.hasError()) {
         LOG.warn("Unable to fetch dependencies: " + report.getAllProblemMessages());
       }

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/ArtifactsResolver.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/ArtifactsResolver.java
@@ -124,14 +124,8 @@ public class ArtifactsResolver {
         .setOutputReport(true).setValidate(true).setTransitive(dependencySpec.transitive);
     resolveOptions.setLog(LogOptions.LOG_QUIET);
     try {
-      final ResolveReport report = _ivyInstance.resolve(md, resolveOptions);
-      if (report.hasError()) {
-        throw new RuntimeException("Unable to fetch dependencies: " + report.getAllProblemMessages());
-      }
-      return report;
-    } catch (ParseException e) {
-      throw new RuntimeException("Unable to fetch dependencies", e);
-    } catch (IOException e) {
+      return _ivyInstance.resolve(md, resolveOptions);
+    } catch (ParseException | IOException e) {
       throw new RuntimeException("Unable to fetch dependencies", e);
     }
   }


### PR DESCRIPTION
After removing this exception, views which threw the exception `Unable to fetch dependencies: [XXX]` could be translated successfully or threw other known exceptions such as 
`java.lang.RuntimeException: Unable to find org.apache.hadoop.hive.ql.udf.generic.GenericUDF.initialize() on: <UDF>` or `java.lang.RuntimeException: Unable to call org.apache.hadoop.hive.ql.udf.generic.GenericUDF.initialize() on: <UDF>`.

Tested on production views over last 6 month.