### PR TITLE
coral-schema: supporting projection of inner field of Record type by implementing visitFieldAccess

### DIFF
--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -613,6 +613,20 @@ public class ViewToAvroSchemaConverterTests {
   }
 
   @Test
+  public void testProjectStructInnerField() {
+    String viewSql = "CREATE VIEW v AS "
+        + "SELECT bc.Id AS Id_View_Col, Struct_Col.Bool_Field AS Struct_Inner_Bool_Col, Struct_Col.Int_Field AS Struct_Inner_Int_Col, Struct_Col.Bigint_Field AS Struct_Inner_Bigint_Col "
+        + "FROM basecomplex bc " + "WHERE bc.Id > 0 AND bc.Struct_Col IS NOT NULL";
+
+    TestUtils.executeCreateViewQuery("default", "v", viewSql);
+
+    ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);
+    Schema actualSchema = viewToAvroSchemaConverter.toAvroSchema("default", "v");
+
+    Assert.assertEquals(actualSchema.toString(true), TestUtils.loadSchema("testProjectStructInnerField-expected.avsc"));
+  }
+
+  @Test
   public void testSubQueryWhere() {
     // TODO: implement this test
   }

--- a/coral-schema/src/test/resources/testProjectStructInnerField-expected.avsc
+++ b/coral-schema/src/test/resources/testProjectStructInnerField-expected.avsc
@@ -1,0 +1,19 @@
+{
+  "type" : "record",
+  "name" : "v",
+  "namespace" : "default.v",
+  "fields" : [ {
+    "name" : "Id_View_Col",
+    "type" : "int"
+  }, {
+    "name" : "Struct_Inner_Bool_Col",
+    "type" : "boolean"
+  }, {
+    "name" : "Struct_Inner_Int_Col",
+    "type" : [ "null", "int" ],
+    "default" : null
+  }, {
+    "name" : "Struct_Inner_Bigint_Col",
+    "type" : "long"
+  } ]
+}


### PR DESCRIPTION
This PR implements visitFieldAccess to support projection of inner field of Record type in coral-schema.

Consider the follow view definition:
`SELECT Struct_Col.Inner_Field AS Struct_Inner_Field FROM Table`

Without this change, coral-schema returns Record type for `Struct_Inner_Field`. After this change, coral-schema returns the actual type of `Inner_Field` for `Struct_Inner_Field`
