### PR TITLE
Decoupling coral-schema from AvroSerdeUtils

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/AvroSerdeUtils.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/AvroSerdeUtils.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2021 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.schema.avro;
+
+import java.util.List;
+
+import org.apache.avro.Schema;
+
+
+/**
+ * Utilities useful only to the Hive AvroSerde itself.
+ * Please refer {@link org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils} for original implementation
+ */
+final class AvroSerdeUtils {
+
+  public static final String AVRO_SCHEMA_LITERAL = "avro.schema.literal";
+
+  private AvroSerdeUtils() {
+
+  }
+
+  /**
+   * Determine if an Avro schema is of type Union[T, NULL].  Avro supports nullable
+   * types via a union of type T and null.  This is a very common use case.
+   * As such, we want to silently convert it to just T and allow the value to be null.
+   *
+   * @return true if type represents Union[T, Null], false otherwise
+   */
+  public static boolean isNullableType(Schema schema) {
+    return schema.getType().equals(Schema.Type.UNION) && schema.getTypes().size() == 2
+        && (schema.getTypes().get(0).getType().equals(Schema.Type.NULL)
+            || schema.getTypes().get(1).getType().equals(Schema.Type.NULL));
+    // [null, null] not allowed, so this check is ok.
+  }
+
+  /**
+   * In a nullable type, get the schema for the non-nullable type.  This method
+   * does no checking that the provides Schema is nullable.
+   */
+  public static Schema getOtherTypeFromNullableType(Schema schema) {
+    List<Schema> types = schema.getTypes();
+    return types.get(0).getType().equals(Schema.Type.NULL) ? types.get(1) : types.get(0);
+  }
+}

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -26,7 +26,6 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Table;
-import org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.codehaus.jackson.JsonNode;
@@ -674,15 +673,14 @@ class SchemaUtilities {
   private static String readSchemaFromSchemaLiteral(@Nonnull Table table) {
     Preconditions.checkNotNull(table);
 
-    String schemaStr = table.getParameters().get(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName());
+    String schemaStr = table.getParameters().get(AvroSerdeUtils.AVRO_SCHEMA_LITERAL);
     if (Strings.isNullOrEmpty(schemaStr)) {
-      schemaStr = table.getSd().getSerdeInfo().getParameters()
-          .get(AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName());
+      schemaStr = table.getSd().getSerdeInfo().getParameters().get(AvroSerdeUtils.AVRO_SCHEMA_LITERAL);
     }
 
     if (Strings.isNullOrEmpty(schemaStr)) {
       LOG.debug("No avro schema defined under table or serde property {} for table {}",
-          AvroSerdeUtils.AvroTableProperties.SCHEMA_LITERAL.getPropName(), getCompleteName(table));
+          AvroSerdeUtils.AVRO_SCHEMA_LITERAL, getCompleteName(table));
     }
 
     return schemaStr;

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/TypeInfoToAvroSchemaConverter.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/TypeInfoToAvroSchemaConverter.java
@@ -12,7 +12,6 @@ import java.util.List;
 import org.apache.avro.Schema;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.serde2.avro.AvroSerDe;
-import org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;


### PR DESCRIPTION
Based on the doc of org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils as below,
/**
 * Utilities useful only to the AvroSerde itself.  Not mean to be used by
 * end-users but public for interop to the ql package.
 */

It is actually not encouraged to be used by end-users. Right now, there is a transitive dependency such as coral-schema -> hive.serde2.avro.AvroSerdeUtils -> org.apache.avro.Schema. That will cause problem if we want to shade avro ONLY and exclude hive package at upperstreaming package.