### PR TITLE
Add lowercase `regexp` and `rlike` to StaticHiveFunctionRegistry

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -73,7 +73,9 @@ public class StaticHiveFunctionRegistry implements HiveFunctionRegistry {
 
     // operators
     addFunctionEntry("RLIKE", HiveRLikeOperator.RLIKE);
+    addFunctionEntry("rlike", HiveRLikeOperator.RLIKE);
     addFunctionEntry("REGEXP", HiveRLikeOperator.REGEXP);
+    addFunctionEntry("regexp", HiveRLikeOperator.REGEXP);
     addFunctionEntry("!=", NOT_EQUALS);
     addFunctionEntry("==", EQUALS);
 

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -72,6 +72,9 @@ public class StaticHiveFunctionRegistry implements HiveFunctionRegistry {
     //addFunctionEntry("in", SqlStdOperatorTable.IN);
 
     // operators
+    // We need to add both lower and upper cases for operators because DaliOperatorTable.lookupOperatorOverloads
+    // resolves the operator functions case-sensitively. If we just add the lowercase operator,
+    // DaliOperatorTable.lookupOperatorOverloads can't resolve the uppercase operator, and there will be null pointer exception.
     addFunctionEntry("RLIKE", HiveRLikeOperator.RLIKE);
     addFunctionEntry("rlike", HiveRLikeOperator.RLIKE);
     addFunctionEntry("REGEXP", HiveRLikeOperator.REGEXP);


### PR DESCRIPTION
Tested on the production views which failed because of the exception:
```
com.linkedin.coral.hive.hive2rel.functions.UnknownSqlFunctionException: Unknown function name: regexp
```
They could be translated well with this patch.