### PR TITLE
Add timestamp type support in RelDataTypeToAvroType for Coral-Schema

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
@@ -102,6 +102,10 @@ class RelDataTypeToAvroType {
         return Schema.create(Schema.Type.NULL);
       case ANY:
         return Schema.create(Schema.Type.BYTES);
+      case TIMESTAMP:
+        Schema schema = Schema.create(Schema.Type.LONG);
+        schema.addProp("logicalType", "timestamp");
+        return schema;
       default:
         throw new UnsupportedOperationException(relDataType.getSqlTypeName() + " is not supported.");
     }

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroTypeTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroTypeTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 LinkedIn Corporation. All rights reserved.
+ * Copyright 2020-2021 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -36,4 +36,16 @@ public class RelDataTypeToAvroTypeTests {
     Assert.assertEquals(actualAvroType.toString(true), TestUtils.loadSchema("rel2avro-testNestedRecord-expected.avsc"));
   }
 
+  @Test
+  public void testTimestampTypeField() {
+    String viewSql = "CREATE VIEW v AS SELECT * FROM basetimestamptypefield";
+
+    TestUtils.executeCreateViewQuery("default", "v", viewSql);
+    RelNode relNode = hiveToRelConverter.convertView("default", "v");
+    Schema actualAvroType =
+        RelDataTypeToAvroType.relDataTypeToAvroTypeNonNullable(relNode.getRowType(), "timestampTypeField");
+
+    Assert.assertEquals(actualAvroType.toString(true),
+        TestUtils.loadSchema("rel2avro-testTimestampTypeField-expected.avsc"));
+  }
 }

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
@@ -83,6 +83,7 @@ public class TestUtils {
     String baseComplexFieldSchema = loadSchema("base-complex-fieldschema");
     String baseNestedComplexSchema = loadSchema("base-nested-complex.avsc");
     String baseNullTypeFieldSchema = loadSchema("base-null-type-field.avsc");
+    String baseTimestampTypeFieldSchema = loadSchema("base-timestamp-type-field.avsc");
 
     executeCreateTableQuery("default", "basecomplex", baseComplexSchema);
     executeCreateTableQuery("default", "basecomplexunioncompatible", baseComplexUnionCompatible);
@@ -90,6 +91,7 @@ public class TestUtils {
     executeCreateTableQuery("default", "baselateralview", baseLateralViewSchema);
     executeCreateTableQuery("default", "basenullability", baseNullabilitySchema);
     executeCreateTableQuery("default", "basenulltypefield", baseNullTypeFieldSchema);
+    executeCreateTableQuery("default", "basetimestamptypefield", baseTimestampTypeFieldSchema);
     executeCreateTableWithPartitionQuery("default", "basecasepreservation", baseCasePreservation);
     executeCreateTableWithPartitionFieldSchemaQuery("default", "basecomplexfieldschema", baseComplexFieldSchema);
     executeCreateTableWithPartitionQuery("default", "basenestedcomplex", baseNestedComplexSchema);

--- a/coral-schema/src/test/resources/base-timestamp-type-field.avsc
+++ b/coral-schema/src/test/resources/base-timestamp-type-field.avsc
@@ -1,0 +1,12 @@
+{
+  "type" : "record",
+  "name" : "basetimestamptypefield",
+  "namespace" : "coral.schema.avro.base.timestamp.type.field",
+  "fields" : [ {
+    "name" : "Timestamp_Field",
+    "type" : [ "null", {
+      "type" : "long",
+      "logicalType" : "timestamp-millis"
+    } ]
+  } ]
+}

--- a/coral-schema/src/test/resources/rel2avro-testTimestampTypeField-expected.avsc
+++ b/coral-schema/src/test/resources/rel2avro-testTimestampTypeField-expected.avsc
@@ -1,0 +1,12 @@
+{
+  "type" : "record",
+  "name" : "timestampTypeField",
+  "namespace" : "rel_avro",
+  "fields" : [ {
+    "name" : "timestamp_field",
+    "type" : [ "null", {
+      "type" : "long",
+      "logicalType" : "timestamp"
+    } ]
+  } ]
+}


### PR DESCRIPTION
This patch added the `TIMESTAMP` type support in `RelDataTypeToAvroType` to avoid the exception `java.lang.UnsupportedOperationException: TIMESTAMP is not supported.`

For `TIMESTAMP` RelDataType, we convert it to the following avro schema:
```
{
      "type" : "long",
      "logicalType" : "timestamp"
}
```
, which aligns with our internal handling of avro schema in Spark.

Tests:
1. unit test
2. test on the affected production views, which could be translated well
3. Integration test, no regression after verification