### PR TITLE
Make `StaticHiveFunctionRegistry.lookup` case-insensitive for all functions

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/DaliOperatorTable.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/DaliOperatorTable.java
@@ -41,7 +41,7 @@ public class DaliOperatorTable implements SqlOperatorTable {
   /**
    * Resolves functions names to corresponding Calcite UDF. HiveFunctionResolver ensures that
    * {@code sqlIdentifier} has function name or corresponding class name for Dali functions. All function registry
-   * lookups performed by this class are case-sensitive.
+   * lookups performed by this class are case-insensitive.
    *
    * Calcite invokes this function multiple times during analysis phase to validate SqlCall operators. This is
    * also used to resolve overloaded function names by using number and type of function parameters.
@@ -50,7 +50,7 @@ public class DaliOperatorTable implements SqlOperatorTable {
   public void lookupOperatorOverloads(SqlIdentifier sqlIdentifier, SqlFunctionCategory sqlFunctionCategory,
       SqlSyntax sqlSyntax, List<SqlOperator> list, SqlNameMatcher sqlNameMatcher) {
     String functionName = Util.last(sqlIdentifier.names);
-    Collection<HiveFunction> functions = funcResolver.resolve(functionName, true);
+    Collection<HiveFunction> functions = funcResolver.resolve(functionName);
     functions.stream().map(HiveFunction::getSqlOperator).collect(Collectors.toCollection(() -> list));
   }
 

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveFunctionRegistry.java
@@ -13,13 +13,12 @@ import java.util.Collection;
  */
 public interface HiveFunctionRegistry {
   /**
-   * Returns a list of functions matching given name This returns empty list if the
+   * Returns a list of functions matching given name case-insensitively. This returns empty list if the
    * function name is not found
    *
    * @param functionName function name to match
-   * @param isCaseSensitive whether to perform case-sensitive match for function name
    * @return collection of HiveFunctions with given function name
    * or empty list if there is no match
    */
-  Collection<HiveFunction> lookup(String functionName, boolean isCaseSensitive);
+  Collection<HiveFunction> lookup(String functionName);
 }

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -56,8 +56,7 @@ public class StaticHiveFunctionRegistry implements HiveFunctionRegistry {
   static final Multimap<String, HiveFunction> FUNCTION_MAP = HashMultimap.create();
 
   static {
-    // NOTE: all built-in keyword-based function names should be lowercase for case-insensitive comparison.
-    // All Dali UDFs should have case sensitive function class names when we do comparison to look up.
+    // NOTE: All function names will be added as lowercase for case-insensitive comparison.
     // FIXME: This mapping is currently incomplete
     // aggregation functions
     addFunctionEntry("sum", SUM);
@@ -72,8 +71,8 @@ public class StaticHiveFunctionRegistry implements HiveFunctionRegistry {
     //addFunctionEntry("in", SqlStdOperatorTable.IN);
 
     // operators
-    addFunctionEntry("RLIKE", HiveRLikeOperator.RLIKE);
-    addFunctionEntry("REGEXP", HiveRLikeOperator.REGEXP);
+    addFunctionEntry("rlike", HiveRLikeOperator.RLIKE);
+    addFunctionEntry("regexp", HiveRLikeOperator.REGEXP);
     addFunctionEntry("!=", NOT_EQUALS);
     addFunctionEntry("==", EQUALS);
 
@@ -433,13 +432,13 @@ public class StaticHiveFunctionRegistry implements HiveFunctionRegistry {
   }
 
   /**
-   * Returns a list of functions matching given name. This returns empty list if the
-   * function name is not found
+   * Returns a list of functions matching given name case-insensitively. This returns empty list if the
+   * function name is not found,
    * @param functionName function name to match
    * @return list of matching HiveFunctions or empty collection.
    */
   @Override
-  public Collection<HiveFunction> lookup(String functionName, boolean isCaseSensitive) {
+  public Collection<HiveFunction> lookup(String functionName) {
     return FUNCTION_MAP.get(functionName.toLowerCase());
   }
 
@@ -450,8 +449,11 @@ public class StaticHiveFunctionRegistry implements HiveFunctionRegistry {
     return ImmutableMultimap.copyOf(FUNCTION_MAP);
   }
 
+  /**
+   * Add the function to registry, the key is lowercase function name to make lookup case-insensitive.
+   */
   private static void addFunctionEntry(String functionName, SqlOperator operator) {
-    FUNCTION_MAP.put(functionName.toLowerCase(), new HiveFunction(functionName.toLowerCase(), operator));
+    FUNCTION_MAP.put(functionName.toLowerCase(), new HiveFunction(functionName, operator));
   }
 
   public static void createAddUserDefinedFunction(String functionName, SqlReturnTypeInference returnTypeInference,

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -440,8 +440,7 @@ public class StaticHiveFunctionRegistry implements HiveFunctionRegistry {
    */
   @Override
   public Collection<HiveFunction> lookup(String functionName, boolean isCaseSensitive) {
-    String name = isCaseSensitive ? functionName : functionName.toLowerCase();
-    return FUNCTION_MAP.get(name);
+    return FUNCTION_MAP.get(functionName.toLowerCase());
   }
 
   /**
@@ -452,7 +451,7 @@ public class StaticHiveFunctionRegistry implements HiveFunctionRegistry {
   }
 
   private static void addFunctionEntry(String functionName, SqlOperator operator) {
-    FUNCTION_MAP.put(functionName, new HiveFunction(functionName, operator));
+    FUNCTION_MAP.put(functionName.toLowerCase(), new HiveFunction(functionName.toLowerCase(), operator));
   }
 
   public static void createAddUserDefinedFunction(String functionName, SqlReturnTypeInference returnTypeInference,

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -433,7 +433,7 @@ public class StaticHiveFunctionRegistry implements HiveFunctionRegistry {
 
   /**
    * Returns a list of functions matching given name case-insensitively. This returns empty list if the
-   * function name is not found,
+   * function name is not found.
    * @param functionName function name to match
    * @return list of matching HiveFunctions or empty collection.
    */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -450,7 +450,7 @@ public class StaticHiveFunctionRegistry implements HiveFunctionRegistry {
   }
 
   /**
-   * Add the function to registry, the key is lowercase function name to make lookup case-insensitive.
+   * Adds the function to registry, the key is lowercase functionName to make lookup case-insensitive.
    */
   private static void addFunctionEntry(String functionName, SqlOperator operator) {
     FUNCTION_MAP.put(functionName.toLowerCase(), new HiveFunction(functionName, operator));

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -236,7 +236,7 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
       // array of [null] should be 3rd param to if function. With our type inference, calcite acts
       // smart and for unnest(array[null]) determines return type to be null
       SqlNode arrOfNull = SqlStdOperatorTable.ARRAY_VALUE_CONSTRUCTOR.createCall(ZERO, SqlLiteral.createNull(ZERO));
-      HiveFunction hiveIfFunction = functionResolver.tryResolve("if", false, null, 1);
+      HiveFunction hiveIfFunction = functionResolver.tryResolve("if", null, 1);
       SqlCall ifFunctionCall = hiveIfFunction.createCall(SqlLiteral.createCharString("if", ZERO),
           ImmutableList.of(ifCondition, unnestOperand, arrOfNull), null);
       unnestOperand = ifFunctionCall;
@@ -269,8 +269,8 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
      TODO the relation alias `jt` is being lost by downstream transformations
      */
 
-    HiveFunction getJsonObjectFunction = functionResolver.tryResolve("get_json_object", false, null, 2);
-    HiveFunction ifFunction = functionResolver.tryResolve("if", false, null, 3);
+    HiveFunction getJsonObjectFunction = functionResolver.tryResolve("get_json_object", null, 2);
+    HiveFunction ifFunction = functionResolver.tryResolve("if", null, 3);
 
     List<SqlNode> jsonTupleOperands = sqlCall.getOperandList();
     SqlNode jsonInput = jsonTupleOperands.get(0);
@@ -519,7 +519,7 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
     ASTNode functionNode = (ASTNode) children.get(0);
     String functionName = functionNode.getText();
     List<SqlNode> sqlOperands = visitChildren(children, ctx);
-    HiveFunction hiveFunction = functionResolver.tryResolve(functionName, false, ctx.hiveTable.orElse(null),
+    HiveFunction hiveFunction = functionResolver.tryResolve(functionName, ctx.hiveTable.orElse(null),
         // The first element of sqlOperands is the operator itself. The actual # of operands is sqlOperands.size() - 1
         sqlOperands.size() - 1);
     return hiveFunction.createCall(sqlOperands.get(0), sqlOperands.subList(1, sqlOperands.size()), quantifier);

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CalciteTrinoUDFMap.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CalciteTrinoUDFMap.java
@@ -122,12 +122,12 @@ public class CalciteTrinoUDFMap {
   }
 
   private static SqlOperator hiveToCalciteOp(String functionName) {
-    Collection<HiveFunction> lookup = HIVE_REGISTRY.lookup(functionName, false);
+    Collection<HiveFunction> lookup = HIVE_REGISTRY.lookup(functionName);
     // TODO: provide overloaded function resolution
     return lookup.iterator().next().getSqlOperator();
   }
 
   private static SqlOperator daliToCalciteOp(String className) {
-    return HIVE_REGISTRY.lookup(className, true).iterator().next().getSqlOperator();
+    return HIVE_REGISTRY.lookup(className).iterator().next().getSqlOperator();
   }
 }

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CalciteTrinoUDFMap.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CalciteTrinoUDFMap.java
@@ -122,7 +122,7 @@ public class CalciteTrinoUDFMap {
   }
 
   /**
-   * Look up Hive functions using functionName case-insensitively.
+   * Looks up Hive functions using functionName case-insensitively.
    */
   private static SqlOperator hiveToCalciteOp(String functionName) {
     Collection<HiveFunction> lookup = HIVE_REGISTRY.lookup(functionName);
@@ -131,7 +131,7 @@ public class CalciteTrinoUDFMap {
   }
 
   /**
-   * Look up Dali functions using className case-insensitively.
+   * Looks up Dali functions using className case-insensitively.
    */
   private static SqlOperator daliToCalciteOp(String className) {
     return HIVE_REGISTRY.lookup(className).iterator().next().getSqlOperator();

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CalciteTrinoUDFMap.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CalciteTrinoUDFMap.java
@@ -121,12 +121,18 @@ public class CalciteTrinoUDFMap {
     return getUDFTransformer(classString, numOperands) != null;
   }
 
+  /**
+   * Look up Hive functions using functionName case-insensitively.
+   */
   private static SqlOperator hiveToCalciteOp(String functionName) {
     Collection<HiveFunction> lookup = HIVE_REGISTRY.lookup(functionName);
     // TODO: provide overloaded function resolution
     return lookup.iterator().next().getSqlOperator();
   }
 
+  /**
+   * Look up Dali functions using className case-insensitively.
+   */
   private static SqlOperator daliToCalciteOp(String className) {
     return HIVE_REGISTRY.lookup(className).iterator().next().getSqlOperator();
   }


### PR DESCRIPTION
Previously, `StaticHiveFunctionRegistry.lookup` treats built-in functions case-insensitively and Dali UDFs case-sensitively, which might bring some issues. For example, `RLIKE` and `rlike` need to be registered twice.

This patch makes `StaticHiveFunctionRegistry.lookup` case-insensitive for all functions including Dali UDFs, because there is very low chance of having two different UDF classes that have the same package and class name but only differ in casing.

Tests:
1. `./gradlew clean build`
2. views affected by exception: `com.linkedin.coral.hive.hive2rel.functions.UnknownSqlFunctionException: Unknown function name: regexp`, which can be translated with this patch
3. Integration test, no regression
