### PR TITLE
escape newline for dali row schema string

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -132,6 +132,9 @@ class SchemaUtilities {
     // Then, try dali.row.schema
     if (Strings.isNullOrEmpty(schemaStr)) {
       schemaStr = table.getParameters().get(DALI_ROW_SCHEMA);
+      if (!Strings.isNullOrEmpty(schemaStr)) {
+        schemaStr = schemaStr.replaceAll("\n", "\\\\n");
+      }
     }
 
     if (!Strings.isNullOrEmpty(schemaStr)) {


### PR DESCRIPTION
This change is to fix the issue when schema string returned from dali row schema, newline character exists(most seen in docs fields). The unescaped newline("\n") need to be escaped(replace by "\\\\n") in order to be parsed by Schema.Parser().