### PR TITLE
Support Hive->Trino for LATERAL VIEW EXPLODE over ARRAY of STRUCTS

### DIFF
--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
@@ -12,34 +12,26 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.core.Correlate;
-import org.apache.calcite.rel.core.Project;
-import org.apache.calcite.rel.core.TableScan;
-import org.apache.calcite.rel.core.Uncollect;
-import org.apache.calcite.rel.core.Values;
-import org.apache.calcite.rel.core.Window;
+import org.apache.calcite.rel.core.*;
 import org.apache.calcite.rel.rel2sql.RelToSqlConverter;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
+import org.apache.calcite.rel.type.RelRecordType;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.sql.JoinConditionType;
-import org.apache.calcite.sql.JoinType;
-import org.apache.calcite.sql.SqlCall;
-import org.apache.calcite.sql.SqlIdentifier;
-import org.apache.calcite.sql.SqlJoin;
-import org.apache.calcite.sql.SqlKind;
-import org.apache.calcite.sql.SqlLiteral;
-import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.*;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
 import org.apache.calcite.util.Util;
 
 import com.linkedin.coral.com.google.common.collect.ImmutableList;
+import com.linkedin.coral.hive.hive2rel.rel.HiveUncollect;
+import com.linkedin.coral.trino.rel2trino.functions.TrinoArrayTransformFunction;
 
-import static com.linkedin.coral.trino.rel2trino.Calcite2TrinoUDFConverter.*;
+import static com.linkedin.coral.trino.rel2trino.Calcite2TrinoUDFConverter.convertRel;
 
 
 public class RelToTrinoConverter extends RelToSqlConverter {
@@ -130,7 +122,44 @@ public class RelToTrinoConverter extends RelToSqlConverter {
     // Build <unnestColumns>
     final List<SqlNode> unnestOperands = new ArrayList<>();
     for (RexNode unnestCol : ((Project) e.getInput()).getChildExps()) {
-      unnestOperands.add(x.qualifiedContext().toSql(null, unnestCol));
+      if (e instanceof HiveUncollect && unnestCol.getType().getSqlTypeName().equals(SqlTypeName.ARRAY)
+          && unnestCol.getType().getComponentType().getSqlTypeName().equals(SqlTypeName.ROW)) {
+
+        // wrapper Record type with single column.
+        // It is needed as Trino follows SQL standard when unnesting
+        // ARRAY of ROWs, exposing each field in a ROW as separate column. This is not in-line with what
+        // Hive's LATERAL VIEW EXPLODE does, exposing whole ROW (struct) as a single column.
+        // Adding extra artificial wrapping ROW with single field simulates Hive semantics in Trino.
+        //
+        // Example transformation:
+        //
+        // Given table with an array of structs column:
+        //   CREATE TABLE example_table(id INTEGER, arr array<struct<sa: int, sb: string>>)
+        // We rewrite view defined as:
+        //  SELECT id, arr_exp FROM example_table LATERAL VIEW EXPLODE(arr) t AS arr_exp
+        // To:
+        //  SELECT "$cor0".id AS id, t1.arr_exp AS arr_exp
+        //    FROM example_table AS "$cor0"
+        //    CROSS JOIN LATERAL (SELECT arr_exp
+        //    FROM UNNEST(TRANSFORM("$cor0".arr, x -> ROW(x))) AS t0 (arr_exp)) AS t1
+        //
+        // The crucial part in abave transformation is call to TRANSFORM with lambda which adds extra layer of
+        // ROW wrapping.
+
+        RelRecordType transformDataType = new RelRecordType(
+            ImmutableList.of(new RelDataTypeFieldImpl("wrapper_field", 0, unnestCol.getType().getComponentType())));
+
+        // wrap unnested field to type defined above using transform(field, x -> ROW(x))
+        TrinoArrayTransformFunction tranformFunction = new TrinoArrayTransformFunction(transformDataType);
+        SqlNode fieldRef = x.qualifiedContext().toSql(null, unnestCol);
+        String fieldRefString = fieldRef.toSqlString(TrinoSqlDialect.INSTANCE).getSql();
+        SqlCharStringLiteral transformArgsLiteral =
+            SqlLiteral.createCharString(String.format("%s, x -> ROW(x)", fieldRefString), POS);
+
+        unnestOperands.add(tranformFunction.createCall(POS, transformArgsLiteral));
+      } else {
+        unnestOperands.add(x.qualifiedContext().toSql(null, unnestCol));
+      }
     }
 
     // Build UNNEST(<unnestColumns>)

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
@@ -143,7 +143,7 @@ public class RelToTrinoConverter extends RelToSqlConverter {
         //    CROSS JOIN LATERAL (SELECT arr_exp
         //    FROM UNNEST(TRANSFORM("$cor0".arr, x -> ROW(x))) AS t0 (arr_exp)) AS t1
         //
-        // The crucial part in abave transformation is call to TRANSFORM with lambda which adds extra layer of
+        // The crucial part in above transformation is call to TRANSFORM with lambda which adds extra layer of
         // ROW wrapping.
 
         RelRecordType transformDataType = new RelRecordType(

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/functions/TrinoArrayTransformFunction.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/functions/TrinoArrayTransformFunction.java
@@ -19,7 +19,7 @@ import org.apache.calcite.rel.type.RelDataType;
  * Instead, we represent the input to this UDF as a string and we set its return type is passed as a parameter
  * on creation.
  */
-class TrinoArrayTransformFunction extends GenericTemplateFunction {
+public class TrinoArrayTransformFunction extends GenericTemplateFunction {
   public TrinoArrayTransformFunction(RelDataType transformDataType) {
     super(transformDataType, "transform");
   }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -106,6 +106,14 @@ public class HiveToTrinoConverterTest {
             + "FROM \"test\".\"table_with_string_array\" AS \"$cor0\"\n"
             + "CROSS JOIN LATERAL (SELECT \"c\"\nFROM UNNEST(\"if\"(\"$cor0\".\"b\" IS NOT NULL AND CARDINALITY(\"$cor0\".\"b\") > 0, \"$cor0\".\"b\", ARRAY[NULL])) AS \"t0\" (\"c\")) AS \"t1\"" },
 
+        { "test", "view_with_explode_struct_array", "SELECT \"$cor0\".\"a\" AS \"a\", \"t1\".\"c\" AS \"c\"\n"
+            + "FROM \"test\".\"table_with_struct_array\" AS \"$cor0\"\n"
+            + "CROSS JOIN LATERAL (SELECT \"c\"\nFROM UNNEST(TRANSFORM(\"$cor0\".\"b\", x -> ROW(x))) AS \"t0\" (\"c\")) AS \"t1\"" },
+
+        { "test", "view_with_outer_explode_struct_array", "SELECT \"$cor0\".\"a\" AS \"a\", \"t1\".\"c\" AS \"c\"\n"
+            + "FROM \"test\".\"table_with_struct_array\" AS \"$cor0\"\n"
+            + "CROSS JOIN LATERAL (SELECT \"c\"\nFROM UNNEST(TRANSFORM(\"if\"(\"$cor0\".\"b\" IS NOT NULL AND CARDINALITY(\"$cor0\".\"b\") > 0, \"$cor0\".\"b\", ARRAY[NULL]), x -> ROW(x))) AS \"t0\" (\"c\")) AS \"t1\"" },
+
         { "test", "current_date_and_timestamp_view", "SELECT CURRENT_TIMESTAMP, TRIM(CAST(CURRENT_TIMESTAMP AS VARCHAR(65535))) AS \"ct\", CURRENT_DATE, CURRENT_DATE AS \"cd\", \"a\"\nFROM \"test\".\"tablea\"" },
 
         { "test", "lateral_view_json_tuple_view", "SELECT \"$cor0\".\"a\" AS \"a\", \"t0\".\"d\" AS \"d\", \"t0\".\"e\" AS \"e\", \"t0\".\"f\" AS \"f\"\n"

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -102,24 +102,24 @@ public class HiveToTrinoConverterTest {
             + "FROM \"test\".\"table_with_string_array\" AS \"$cor0\"\n"
             + "CROSS JOIN LATERAL (SELECT \"c\"\nFROM UNNEST(\"$cor0\".\"b\") AS \"t0\" (\"c\")) AS \"t1\"" },
 
-        { "test", "view_with_outer_explode_string_array", "SELECT \"$cor1\".\"a\" AS \"a\", \"t1\".\"c\" AS \"c\"\n"
-            + "FROM \"test\".\"table_with_string_array\" AS \"$cor1\"\n"
-            + "CROSS JOIN LATERAL (SELECT \"c\"\nFROM UNNEST(\"if\"(\"$cor1\".\"b\" IS NOT NULL AND CARDINALITY(\"$cor1\".\"b\") > 0, \"$cor1\".\"b\", ARRAY[NULL])) AS \"t0\" (\"c\")) AS \"t1\"" },
+        { "test", "view_with_outer_explode_string_array", "SELECT \"$cor0\".\"a\" AS \"a\", \"t1\".\"c\" AS \"c\"\n"
+            + "FROM \"test\".\"table_with_string_array\" AS \"$cor0\"\n"
+            + "CROSS JOIN LATERAL (SELECT \"c\"\nFROM UNNEST(\"if\"(\"$cor0\".\"b\" IS NOT NULL AND CARDINALITY(\"$cor0\".\"b\") > 0, \"$cor0\".\"b\", ARRAY[NULL])) AS \"t0\" (\"c\")) AS \"t1\"" },
 
         { "test", "current_date_and_timestamp_view", "SELECT CURRENT_TIMESTAMP, TRIM(CAST(CURRENT_TIMESTAMP AS VARCHAR(65535))) AS \"ct\", CURRENT_DATE, CURRENT_DATE AS \"cd\", \"a\"\nFROM \"test\".\"tablea\"" },
 
-        { "test", "lateral_view_json_tuple_view", "SELECT \"$cor4\".\"a\" AS \"a\", \"t0\".\"d\" AS \"d\", \"t0\".\"e\" AS \"e\", \"t0\".\"f\" AS \"f\"\n"
-            + "FROM \"test\".\"tablea\" AS \"$cor4\"\nCROSS JOIN LATERAL (SELECT "
-            + "\"if\"(\"REGEXP_LIKE\"('trino', '^[^\\\"]*$'), CAST(\"json_extract\"(\"$cor4\".\"b\".\"b1\", '$[\"' || 'trino' || '\"]') AS VARCHAR(65535)), NULL) AS \"d\", "
-            + "\"if\"(\"REGEXP_LIKE\"('always', '^[^\\\"]*$'), CAST(\"json_extract\"(\"$cor4\".\"b\".\"b1\", '$[\"' || 'always' || '\"]') AS VARCHAR(65535)), NULL) AS \"e\", "
-            + "\"if\"(\"REGEXP_LIKE\"('rocks', '^[^\\\"]*$'), CAST(\"json_extract\"(\"$cor4\".\"b\".\"b1\", '$[\"' || 'rocks' || '\"]') AS VARCHAR(65535)), NULL) AS \"f\"\n"
+        { "test", "lateral_view_json_tuple_view", "SELECT \"$cor0\".\"a\" AS \"a\", \"t0\".\"d\" AS \"d\", \"t0\".\"e\" AS \"e\", \"t0\".\"f\" AS \"f\"\n"
+            + "FROM \"test\".\"tablea\" AS \"$cor0\"\nCROSS JOIN LATERAL (SELECT "
+            + "\"if\"(\"REGEXP_LIKE\"('trino', '^[^\\\"]*$'), CAST(\"json_extract\"(\"$cor0\".\"b\".\"b1\", '$[\"' || 'trino' || '\"]') AS VARCHAR(65535)), NULL) AS \"d\", "
+            + "\"if\"(\"REGEXP_LIKE\"('always', '^[^\\\"]*$'), CAST(\"json_extract\"(\"$cor0\".\"b\".\"b1\", '$[\"' || 'always' || '\"]') AS VARCHAR(65535)), NULL) AS \"e\", "
+            + "\"if\"(\"REGEXP_LIKE\"('rocks', '^[^\\\"]*$'), CAST(\"json_extract\"(\"$cor0\".\"b\".\"b1\", '$[\"' || 'rocks' || '\"]') AS VARCHAR(65535)), NULL) AS \"f\"\n"
             + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")) AS \"t0\"" },
 
-        { "test", "lateral_view_json_tuple_view_qualified", "SELECT \"$cor7\".\"a\" AS \"a\", \"t0\".\"d\" AS \"d\", \"t0\".\"e\" AS \"e\", \"t0\".\"f\" AS \"f\"\n"
-            + "FROM \"test\".\"tablea\" AS \"$cor7\"\nCROSS JOIN LATERAL (SELECT "
-            + "\"if\"(\"REGEXP_LIKE\"('trino', '^[^\\\"]*$'), CAST(\"json_extract\"(\"$cor7\".\"b\".\"b1\", '$[\"' || 'trino' || '\"]') AS VARCHAR(65535)), NULL) AS \"d\", "
-            + "\"if\"(\"REGEXP_LIKE\"('always', '^[^\\\"]*$'), CAST(\"json_extract\"(\"$cor7\".\"b\".\"b1\", '$[\"' || 'always' || '\"]') AS VARCHAR(65535)), NULL) AS \"e\", "
-            + "\"if\"(\"REGEXP_LIKE\"('rocks', '^[^\\\"]*$'), CAST(\"json_extract\"(\"$cor7\".\"b\".\"b1\", '$[\"' || 'rocks' || '\"]') AS VARCHAR(65535)), NULL) AS \"f\"\n"
+        { "test", "lateral_view_json_tuple_view_qualified", "SELECT \"$cor0\".\"a\" AS \"a\", \"t0\".\"d\" AS \"d\", \"t0\".\"e\" AS \"e\", \"t0\".\"f\" AS \"f\"\n"
+            + "FROM \"test\".\"tablea\" AS \"$cor0\"\nCROSS JOIN LATERAL (SELECT "
+            + "\"if\"(\"REGEXP_LIKE\"('trino', '^[^\\\"]*$'), CAST(\"json_extract\"(\"$cor0\".\"b\".\"b1\", '$[\"' || 'trino' || '\"]') AS VARCHAR(65535)), NULL) AS \"d\", "
+            + "\"if\"(\"REGEXP_LIKE\"('always', '^[^\\\"]*$'), CAST(\"json_extract\"(\"$cor0\".\"b\".\"b1\", '$[\"' || 'always' || '\"]') AS VARCHAR(65535)), NULL) AS \"e\", "
+            + "\"if\"(\"REGEXP_LIKE\"('rocks', '^[^\\\"]*$'), CAST(\"json_extract\"(\"$cor0\".\"b\".\"b1\", '$[\"' || 'rocks' || '\"]') AS VARCHAR(65535)), NULL) AS \"f\"\n"
             + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")) AS \"t0\"" },
 
         { "test", "get_json_object_view", "SELECT \"json_extract\"(\"b\".\"b1\", '$.name')\nFROM \"test\".\"tablea\"" } };

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
@@ -268,6 +268,12 @@ public class TestUtils {
     run(driver,
         "CREATE VIEW test.view_with_outer_explode_string_array AS SELECT a, c FROM test.table_with_string_array LATERAL VIEW OUTER EXPLODE(b) t AS c");
 
+    run(driver, "CREATE TABLE test.table_with_struct_array(a int, b array<struct<sa: int, sb: string>>)");
+    run(driver,
+        "CREATE VIEW test.view_with_explode_struct_array AS SELECT a, c FROM test.table_with_struct_array LATERAL VIEW EXPLODE(b) t AS c");
+    run(driver,
+        "CREATE VIEW test.view_with_outer_explode_struct_array AS SELECT a, c FROM test.table_with_struct_array LATERAL VIEW OUTER EXPLODE(b) t AS c");
+
     run(driver, "CREATE VIEW IF NOT EXISTS test.current_date_and_timestamp_view AS \n"
         + "SELECT CURRENT_TIMESTAMP, trim(cast(CURRENT_TIMESTAMP as string)) as ct, CURRENT_DATE, CURRENT_DATE as cd, a from test.tableA");
     run(driver, "CREATE VIEW IF NOT EXISTS test.lateral_view_json_tuple_view AS \n"

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorResponse;
 import org.apache.hadoop.hive.ql.session.SessionState;
 
-import com.linkedin.coral.hive.hive2rel.HiveMetastoreClient;
 import com.linkedin.coral.hive.hive2rel.HiveMscAdapter;
 import com.linkedin.coral.hive.hive2rel.HiveToRelConverter;
 
@@ -45,8 +44,7 @@ import static java.lang.String.format;
 
 
 public class TestUtils {
-
-  static HiveToRelConverter hiveToRelConverter;
+  private static HiveMscAdapter hiveMetastoreClient;
 
   public static FrameworkConfig createFrameworkConfig(TestTable... tables) {
     SchemaPlus rootSchema = Frameworks.createRootSchema(true);
@@ -190,8 +188,7 @@ public class TestUtils {
     conf.set("javax.jdo.option.ConnectionURL", format("jdbc:derby:;databaseName=%s;create=true", metastoreDbDirectory));
     SessionState.start(conf);
     Driver driver = new Driver(conf);
-    HiveMetastoreClient hiveMetastoreClient = new HiveMscAdapter(Hive.get(conf).getMSC());
-    hiveToRelConverter = HiveToRelConverter.create(hiveMetastoreClient);
+    hiveMetastoreClient = new HiveMscAdapter(Hive.get(conf).getMSC());
 
     // Views and tables used in HiveToTrinoConverterTest
     run(driver, "CREATE DATABASE IF NOT EXISTS test");
@@ -282,7 +279,7 @@ public class TestUtils {
   }
 
   public static RelNode convertView(String db, String view) {
-    return hiveToRelConverter.convertView(db, view);
+    return HiveToRelConverter.create(hiveMetastoreClient).convertView(db, view);
   }
 
   private static HiveConf loadResourceHiveConf() {


### PR DESCRIPTION
This PR adds a wrapper Record type with single column when unnesting an `ARRAY` of `ROW`s. This is not in-line with what Hive's `LATERAL VIEW EXPLODE` does, exposing whole `ROW` (struct) as a single column. Therefore, we add an extra artificial wrapping `ROW` with single field simulates Hive semantics in Trino.

Example transformation:

Given table with an array of structs column:
`CREATE TABLE example_table(id INTEGER, arr array<struct<sa: int, sb: string>>)`

We rewrite view defined as:
`SELECT id, arr_exp FROM example_table LATERAL VIEW EXPLODE(arr) t AS arr_exp`

To:

```
SELECT "$cor0".id AS id, t1.arr_exp AS arr_exp
FROM example_table AS "$cor0"
CROSS JOIN LATERAL (SELECT arr_exp
FROM UNNEST(TRANSFORM("$cor0".arr, x -> ROW(x))) AS t0 (arr_exp)) AS t1
```
The crucial part in above transformation is call to TRANSFORM with lambda which adds extra layer of `ROW` wrapping.