### PR TITLE
Parse map(k1,v1,k2,v2) from hive to trino

### DIFF
--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -130,6 +130,8 @@ public class HiveToTrinoConverterTest {
             + "\"if\"(\"REGEXP_LIKE\"('rocks', '^[^\\\"]*$'), CAST(\"json_extract\"(\"$cor0\".\"b\".\"b1\", '$[\"' || 'rocks' || '\"]') AS VARCHAR(65535)), NULL) AS \"f\"\n"
             + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")) AS \"t0\"" },
 
-        { "test", "get_json_object_view", "SELECT \"json_extract\"(\"b\".\"b1\", '$.name')\nFROM \"test\".\"tablea\"" } };
+        { "test", "get_json_object_view", "SELECT \"json_extract\"(\"b\".\"b1\", '$.name')\nFROM \"test\".\"tablea\"" },
+
+        { "test", "map_array_view", "SELECT MAP (ARRAY[ 'key1', 'key2' ], ARRAY[ 'value1', 'value2']) AS \"col_map\"\nFROM \"test\".\"tablea\"" } };
   }
 }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
@@ -282,6 +282,8 @@ public class TestUtils {
         + "SELECT `t`.`a`, `jt`.`d`, `jt`.`e`, `jt`.`f` FROM `test`.`tableA` AS `t` LATERAL VIEW json_tuple(`t`.`b`.`b1`, \"trino\", \"always\", \"rocks\") `jt` AS `d`, `e`, `f`");
     run(driver, "CREATE VIEW IF NOT EXISTS test.get_json_object_view AS \n"
         + "SELECT get_json_object(b.b1, '$.name') FROM test.tableA");
+    run(driver, "CREATE VIEW IF NOT EXISTS test.map_array_view AS \n"
+        + "SELECT MAP('key1', 'value1', 'key2', 'value2') AS col_map FROM test.tableA");
   }
 
   public static RelNode convertView(String db, String view) {


### PR DESCRIPTION
For hive, `SELECT MAP(k1, v1, k2, v2)` is 
> {k1=v1, k2=v2};

but for trino, sql should be `SELECT MAP(ARRAY[k1,k2], ARRAY[v1,v2])`