### PR TITLE
Parse map(k1,v1,k2,v2) from hive to trino

### DIFF
--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoSqlDialect.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoSqlDialect.java
@@ -6,6 +6,7 @@
 package com.linkedin.coral.trino.rel2trino;
 
 import org.apache.calcite.config.NullCollation;
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
@@ -31,6 +32,17 @@ public class TrinoSqlDialect extends SqlDialect {
 
   public void unparseOffsetFetch(SqlWriter writer, SqlNode offset, SqlNode fetch) {
     unparseFetchUsingLimit(writer, offset, fetch);
+  }
+
+  @Override
+  public void unparseCall(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+    switch (call.getOperator().kind) {
+      case MAP_VALUE_CONSTRUCTOR:
+        unparseMapValueConstructor(writer, call, leftPrec, rightPrec);
+        break;
+      default:
+        super.unparseCall(writer, call, leftPrec, rightPrec);
+    }
   }
 
   @Override
@@ -61,5 +73,15 @@ public class TrinoSqlDialect extends SqlDialect {
 
   public boolean requireCastOnString() {
     return true;
+  }
+
+  private void unparseMapValueConstructor(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+    writer.keyword(call.getOperator().getName()); // "MAP"
+    final SqlWriter.Frame frame = writer.startList("(", ")"); // not "[" and "]"
+    for (int i = 0; i < call.operandCount(); i++) {
+      writer.sep(",");
+      call.operand(i).unparse(writer, leftPrec, rightPrec);
+    }
+    writer.endList(frame);
   }
 }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -120,7 +120,10 @@ public class HiveToTrinoConverterTest {
 
         { "test", "view_with_outer_explode_map", "SELECT \"$cor0\".\"a\" AS \"a\", \"t1\".\"KEY\" AS \"c\", \"t1\".\"VALUE\" AS \"d\"\n"
             + "FROM \"test\".\"table_with_map\" AS \"$cor0\"\n" + "CROSS JOIN LATERAL (SELECT \"KEY\", \"VALUE\"\n"
-            + "FROM UNNEST(\"if\"(\"$cor0\".\"b\" IS NOT NULL AND CARDINALITY(\"$cor0\".\"b\") > 0, \"$cor0\".\"b\", MAP[NULL, NULL])) AS \"t0\" (\"KEY\", \"VALUE\")) AS \"t1\"" },
+            + "FROM UNNEST(\"if\"(\"$cor0\".\"b\" IS NOT NULL AND CARDINALITY(\"$cor0\".\"b\") > 0, \"$cor0\".\"b\", MAP (ARRAY[NULL], ARRAY[NULL]))) AS \"t0\" (\"KEY\", \"VALUE\")) AS \"t1\"" },
+
+        { "test", "map_array_view", "SELECT MAP (ARRAY['key1', 'key2'], ARRAY['value1', 'value2']) AS \"simple_map_col\", "
+            + "MAP (ARRAY['key1', 'key2'], ARRAY[MAP (ARRAY['a', 'c'], ARRAY['b', 'd']), MAP (ARRAY['a', 'c'], ARRAY['b', 'd'])]) AS \"nested_map_col\"\nFROM \"test\".\"tablea\"" },
 
         { "test", "current_date_and_timestamp_view", "SELECT CURRENT_TIMESTAMP, TRIM(CAST(CURRENT_TIMESTAMP AS VARCHAR(65535))) AS \"ct\", CURRENT_DATE, CURRENT_DATE AS \"cd\", \"a\"\nFROM \"test\".\"tablea\"" },
 

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
@@ -289,6 +289,10 @@ public class TestUtils {
     run(driver, "CREATE VIEW IF NOT EXISTS test.get_json_object_view AS \n"
         + "SELECT get_json_object(b.b1, '$.name') FROM test.tableA");
 
+    run(driver, "CREATE VIEW IF NOT EXISTS test.map_array_view AS \n"
+        + "SELECT MAP('key1', 'value1', 'key2', 'value2') AS simple_map_col, "
+        + "MAP('key1', MAP('a', 'b', 'c', 'd'), 'key2', MAP('a', 'b', 'c', 'd')) AS nested_map_col FROM test.tableA");
+
     run(driver,
         "CREATE TABLE test.table_from_utc_timestamp (a_tinyint tinyint, a_smallint smallint, "
             + "a_integer int, a_bigint bigint, a_float float, a_double double, "


### PR DESCRIPTION
Hi, everybody! 
  I'm interested in converting SQL from hive to trino. This is my first PR.  Here's a little bit of my work:

For hive, `SELECT MAP(k1, v1, k2, v2)` is

> {k1=v1, k2=v2};

but for trino, sql should be `SELECT MAP(ARRAY[k1,k2], ARRAY[v1,v2])`

Welcome your suggestions.