### PR TITLE
Allow empty array

### DIFF
--- a/coral-hive/build.gradle
+++ b/coral-hive/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'antlr'
 
 dependencies {
   antlr deps.'antlr'
-  compile('com.linkedin.calcite:calcite-core:1.21.0.148') {
+  compile('com.linkedin.calcite:calcite-core:1.21.0.149') {
     artifact {
       name = 'calcite-core'
       extension = 'jar'

--- a/coral-hive/build.gradle
+++ b/coral-hive/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'antlr'
 
 dependencies {
   antlr deps.'antlr'
-  compile('com.linkedin.calcite:calcite-core:1.21.0.146') {
+  compile('com.linkedin.calcite:calcite-core:1.21.0.148') {
     artifact {
       name = 'calcite-core'
       extension = 'jar'

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
@@ -192,6 +192,21 @@ public class HiveToRelConverterTest {
   }
 
   @Test
+  public void testSelectEmptyArray() {
+    final String sql = "SELECT array()";
+    final String expected = "LogicalProject(EXPR$0=[ARRAY()])\n" + "  LogicalValues(tuples=[[{ 0 }]])\n";
+    assertEquals(RelOptUtil.toString(converter.convertSql(sql)), expected);
+  }
+
+  @Test
+  public void testEmptyArrayInFilter() {
+    String sql = "SELECT 1 WHERE array_contains(array(), '1')";
+    String expected = "LogicalProject(EXPR$0=[1])\n" + "  LogicalFilter(condition=[array_contains(ARRAY(), '1')])\n"
+        + "    LogicalValues(tuples=[[{ 0 }]])\n";
+    assertEquals(RelOptUtil.toString(converter.convertSql(sql)), expected);
+  }
+
+  @Test
   public void testSelectArrayElement() {
     final String sql = "SELECT c[0] from complex";
     final String expectedRel =


### PR DESCRIPTION
Pin to the latest calcite which supports empty array: https://github.com/linkedin/linkedin-calcite/pull/43

Tests:
1. Unit tests (empty array in select items and where clause)
2. Integration test, no regression