### PR TITLE
Change the way of getting RelDataType for fuzzy union

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionSqlRewriter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionSqlRewriter.java
@@ -168,6 +168,8 @@ class FuzzyUnionSqlRewriter extends SqlShuttle {
    * @return SqlNode that has its schema fixed to the schema of the table
    */
   private SqlNode addFuzzyUnionToUnionBranch(SqlNode unionBranch, RelDataType expectedDataType) {
+    // Get the base tables' (rather than intermediate base views') RelDataType of unionBranch, so that it can pass the type
+    // validation of calcite because calcite uses base tables' RelDataType to do the type validation for union.
     RelDataType fromNodeDataType = relContextProvider.getSqlToRelConverter()
         .convertQuery(unionBranch.accept(new FuzzyUnionSqlRewriter(tableName, relContextProvider)), true, true).rel
             .getRowType();

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionSqlRewriter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionSqlRewriter.java
@@ -168,9 +168,9 @@ class FuzzyUnionSqlRewriter extends SqlShuttle {
    * @return SqlNode that has its schema fixed to the schema of the table
    */
   private SqlNode addFuzzyUnionToUnionBranch(SqlNode unionBranch, RelDataType expectedDataType) {
-    RelDataType fromNodeDataType = relContextProvider.getSqlToRelConverter().convertQuery(
-        unionBranch.accept(new FuzzyUnionSqlRewriter(tableName, relContextProvider)), true, true)
-        .rel.getRowType();
+    RelDataType fromNodeDataType = relContextProvider.getSqlToRelConverter()
+        .convertQuery(unionBranch.accept(new FuzzyUnionSqlRewriter(tableName, relContextProvider)), true, true).rel
+            .getRowType();
 
     // Create a SqlNode that has a string equivalent to the following query:
     // SELECT table_name.col1, generic_project(table_name.col2), ... FROM (unionBranch) as table_name

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionTest.java
@@ -194,4 +194,22 @@ public class FuzzyUnionTest {
     String expandedSql = nodeToStr(node);
     assertEquals(expandedSql, expectedSql);
   }
+
+  @Test
+  public void testUnionViewWithBaseTableChange() throws TException {
+    String database = "fuzzy_union";
+    String view = "union_view_with_base_table_change";
+    SqlNode node = getFuzzyUnionView(database, view);
+
+    String expectedSql = "SELECT \"a\", \"generic_project\"(\"b\", 'b') AS \"b\"\n" + "FROM (SELECT *\n"
+        + "FROM \"hive\".\"fuzzy_union\".\"tablep\"\n" + "UNION ALL\n"
+        + "SELECT \"a\", \"generic_project\"(\"b\", 'b') AS \"b\"\n"
+        + "FROM \"hive\".\"fuzzy_union\".\"tableq\") AS \"t0\"\n" + "UNION ALL\n" + "SELECT *\n" + "FROM (SELECT *\n"
+        + "FROM \"hive\".\"fuzzy_union\".\"tabler\"\n" + "UNION ALL\n" + "SELECT *\n"
+        + "FROM \"hive\".\"fuzzy_union\".\"tables\") AS \"t\"";
+
+    getRelContextProvider().getHiveSqlValidator().validate(node);
+    String expandedSql = nodeToStr(node);
+    assertEquals(expandedSql, expectedSql);
+  }
 }

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/TestUtils.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/TestUtils.java
@@ -138,6 +138,19 @@ public class TestUtils {
       driver.run("ALTER TABLE fuzzy_union.tableN CHANGE COLUMN b b struct<b2:double, b1:string, b0:int>");
       driver.run("ALTER TABLE fuzzy_union.tableO CHANGE COLUMN b b struct<b0:int, b1:string, b2:int>");
 
+      driver.run("CREATE TABLE IF NOT EXISTS fuzzy_union.tableP(a int, b struct<b1:string>)");
+      driver.run("CREATE TABLE IF NOT EXISTS fuzzy_union.tableQ(a int, b struct<b1:string>)");
+      driver.run(
+          "CREATE VIEW IF NOT EXISTS fuzzy_union.view_in_union_1 AS SELECT * from fuzzy_union.tableP union all SELECT * from fuzzy_union.tableQ");
+      driver.run("CREATE TABLE IF NOT EXISTS fuzzy_union.tableR(a int, b struct<b1:string>)");
+      driver.run("CREATE TABLE IF NOT EXISTS fuzzy_union.tableS(a int, b struct<b1:string>)");
+      driver.run(
+          "CREATE VIEW IF NOT EXISTS fuzzy_union.view_in_union_2 AS SELECT * from fuzzy_union.tableR union all SELECT * from fuzzy_union.tableS");
+      driver.run(
+          "CREATE VIEW IF NOT EXISTS fuzzy_union.union_view_with_base_table_change AS SELECT * from fuzzy_union.view_in_union_1 union all SELECT * from fuzzy_union.view_in_union_2");
+      driver.run("ALTER TABLE fuzzy_union.tableP CHANGE COLUMN b b struct<b2:double, b1:string, b0:int>");
+      driver.run("ALTER TABLE fuzzy_union.tableQ CHANGE COLUMN b b struct<b0:int, b1:string, b2:int>");
+
       driver.run("CREATE TABLE IF NOT EXISTS foo(a int, b varchar(30), c double)");
       driver.run("CREATE TABLE IF NOT EXISTS bar(x int, y double)");
       driver.run("CREATE VIEW IF NOT EXISTS foo_view AS SELECT b as bcol, sum(c) as sum_c from foo group by b");


### PR DESCRIPTION
If we union 2 views, and change the schema of the base tables of one view (like the unit test in `TestUtils.java` added), previous fuzzy union would not add necessary `generic_project` and cause null pointer exception during validation. It is because previous way of getting union branch's `RelDataType` can only get the intermediate view's schema rather than base table's schema. This patch changes the way of getting union branch's `RelDataType`, so that we can get the base table's schema and add `generic_project` correctly.

Tests:
1. Unit test, which fails without this patch, succeeds with the patch.
2. Test on affected production views, which could be translated successfully with this patch.
3. Integration test, no regression after verification.