### PR TITLE
Use trino mod implemented hive pmod

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -121,6 +121,7 @@ public class StaticHiveFunctionRegistry implements HiveFunctionRegistry {
 
     // mathematical functions
     // we need to define new strategy for hive to allow null operands by default for everything
+    createAddUserDefinedFunction("pmod", HiveReturnTypes.BIGINT, NUMERIC_NUMERIC);
     createAddUserDefinedFunction("round", DOUBLE_NULLABLE,
         family(ImmutableList.of(SqlTypeFamily.NUMERIC, SqlTypeFamily.INTEGER), optionalOrd(1)));
     createAddUserDefinedFunction("bround", DOUBLE_NULLABLE,

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CalciteTrinoUDFMap.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CalciteTrinoUDFMap.java
@@ -54,6 +54,9 @@ public class CalciteTrinoUDFMap {
     createUDFMapEntry(UDF_MAP, hiveToCalciteOp("get_json_object"), 2, "json_extract");
 
     // map various hive functions
+    createUDFMapEntry(UDF_MAP, hiveToCalciteOp("pmod"), 2, "mod",
+        "[{\"op\":\"+\",\"operands\":[{\"op\":\"%\",\"operands\":[{\"input\":1},{\"input\":2}]},{\"input\":2}]},{\"input\":2}]",
+        null);
     createUDFMapEntry(UDF_MAP, hiveToCalciteOp("base64"), 1, "to_base64");
     createUDFMapEntry(UDF_MAP, hiveToCalciteOp("unbase64"), 1, "from_base64");
     createUDFMapEntry(UDF_MAP, hiveToCalciteOp("hex"), 1, "to_hex");

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/UDFTransformer.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/UDFTransformer.java
@@ -124,6 +124,7 @@ public class UDFTransformer {
     OP_MAP.put("*", SqlStdOperatorTable.MULTIPLY);
     OP_MAP.put("/", SqlStdOperatorTable.DIVIDE);
     OP_MAP.put("^", SqlStdOperatorTable.POWER);
+    OP_MAP.put("%", SqlStdOperatorTable.MOD);
     OP_MAP.put("hive_pattern_to_trino",
         new SqlUserDefinedFunction(new SqlIdentifier("hive_pattern_to_trino", SqlParserPos.ZERO),
             HiveReturnTypes.STRING, null, OperandTypes.STRING, null, null));

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -151,6 +151,8 @@ public class HiveToTrinoConverterTest {
             + "CAST(\"at_timezone\"(\"from_unixtime\"(CAST(\"a_decimal_zero\" AS DOUBLE)), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), "
             + "CAST(\"at_timezone\"(\"from_unixtime\"(\"to_unixtime\"(\"with_timezone\"(\"a_timestamp\", 'UTC'))), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), "
             + "CAST(\"at_timezone\"(\"from_unixtime\"(\"to_unixtime\"(\"with_timezone\"(\"a_date\", 'UTC'))), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3))\n"
-            + "FROM \"test\".\"table_from_utc_timestamp\"" }, };
+            + "FROM \"test\".\"table_from_utc_timestamp\"" },
+
+        { "test", "pmod_view", "SELECT MOD(MOD(- 9, 4) + 4, 4)\nFROM \"test\".\"tablea\"" }, };
   }
 }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
@@ -304,6 +304,8 @@ public class TestUtils {
             + "from_utc_timestamp(a_decimal_zero, 'America/Los_Angeles'), "
             + "from_utc_timestamp(a_timestamp, 'America/Los_Angeles'), "
             + "from_utc_timestamp(a_date, 'America/Los_Angeles')" + "FROM test.table_from_utc_timestamp");
+
+    run(driver, "CREATE VIEW IF NOT EXISTS test.pmod_view AS \n" + "SELECT pmod(-9, 4) FROM test.tableA");
   }
 
   public static RelNode convertView(String db, String view) {

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/UDFTransformerTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/UDFTransformerTest.java
@@ -161,7 +161,7 @@ public class UDFTransformerTest {
         "{\"op\":\"+\",\"operands\":[{\"input\":0},{\"input\":3}]}", null, "targetFunc(icol * dcol, scol) + dcol");
 
     testFailedTransformation(tableOneQuery, tableOneConfig, targetUDF,
-        "[{\"op\":\"%\",\"operands\":[{\"input\":2},{\"input\":3}]}, {\"input\":1}]", null, null,
+        "[{\"op\":\"@\",\"operands\":[{\"input\":2},{\"input\":3}]}, {\"input\":1}]", null, null,
         UnsupportedOperationException.class);
   }
 


### PR DESCRIPTION
We know `pmod` is is different from `mod`, here are reasons:
1. `pmod(input1, input2)` is equivalent to `((input1 % input2) + input2) % input2`, you can see the [GenericUDFPosMod ](https://github.com/apache/hive/blob/7b3ecf617a6d46f48a3b6f77e0339fd4ad95a420/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFPosMod.java#L91)in hive
2. `mod(a, b)` is equivalent  to `a % b`, you can see the [mod](https://github.com/trinodb/trino/blob/fe608f2723842037ff620d612a706900e79c52c8/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java#L513) in trino

So I use operandTransformer implemented it.