### PR TITLE
Make Coral-Schema return correct schema while selecting field from a nested struct

### DIFF
--- a/coral-hive/build.gradle
+++ b/coral-hive/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'antlr'
 
 dependencies {
   antlr deps.'antlr'
-  compile('com.linkedin.calcite:calcite-core:1.21.0.146') {
+  compile('com.linkedin.calcite:calcite-core:1.21.0.148') {
     artifact {
       name = 'calcite-core'
       extension = 'jar'

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -417,6 +417,14 @@ class SchemaUtilities {
     return schema;
   }
 
+  static Schema extractIfOption(Schema schema) {
+    if (isNullableType(schema)) {
+      return getOtherTypeFromNullableType(schema);
+    } else {
+      return schema;
+    }
+  }
+
   private static Schema getUnionFieldSchema(@Nonnull Schema leftSchema, @Nonnull Schema rightSchema,
       boolean strictMode) {
     Preconditions.checkNotNull(leftSchema);

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
@@ -95,6 +95,15 @@ public class TestUtils {
     executeCreateTableWithPartitionQuery("default", "basecasepreservation", baseCasePreservation);
     executeCreateTableWithPartitionFieldSchemaQuery("default", "basecomplexfieldschema", baseComplexFieldSchema);
     executeCreateTableWithPartitionQuery("default", "basenestedcomplex", baseNestedComplexSchema);
+
+    // Creates a table with deep nested structs
+    executeQuery("DROP TABLE IF EXISTS basedeepnestedcomplex");
+    executeQuery("CREATE TABLE IF NOT EXISTS basedeepnestedcomplex("
+        + "struct_col_1 struct<struct_col_2:struct<struct_col_3:struct<int_field_1:int>>>, "
+        + "array_col_1 array<struct<array_col_2:array<struct<int_field_2:int>>>>, "
+        + "map_col_1 map<string, struct<map_col_2:map<string, struct<int_field_3:int>>>>, "
+        + "struct_col_4 struct<map_col_3: map<string, struct<struct_col_5:struct<int_field_4:int>>>, "
+        + "array_col_3: array<struct<struct_col_6:struct<int_field_5:int>>>>)");
   }
 
   private static void initializeUdfs() {

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -626,6 +626,21 @@ public class ViewToAvroSchemaConverterTests {
   }
 
   @Test
+  public void testSelectDeepNestStructFieldFromDeepNestComplex() {
+    String viewSql = "CREATE VIEW v AS SELECT struct_col_1.struct_col_2.struct_col_3.int_field_1 Int_Field_1, "
+        + "array_col_1[0].array_col_2[0].int_field_2 Int_Field_2, map_col_1['x'].map_col_2['y'].int_field_3 Int_Field_3, "
+        + "struct_col_4.map_col_3['x'].struct_col_5.int_field_4 Int_Field_4, "
+        + "struct_col_4.array_col_3[0].struct_col_6.int_field_5 Int_Field_5 FROM basedeepnestedcomplex";
+    TestUtils.executeCreateViewQuery("default", "v", viewSql);
+
+    ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);
+    Schema actualSchema = viewToAvroSchemaConverter.toAvroSchema("default", "v");
+
+    Assert.assertEquals(actualSchema.toString(true),
+        TestUtils.loadSchema("testSelectDeepNestedStructFieldFromDeepNestComplex-expected.avsc"));
+  }
+
+  @Test
   public void testProjectStructInnerField() {
     String viewSql = "CREATE VIEW v AS "
         + "SELECT bc.Id AS Id_View_Col, Struct_Col.Bool_Field AS Struct_Inner_Bool_Col, Struct_Col.Int_Field AS Struct_Inner_Int_Col, Struct_Col.Bigint_Field AS Struct_Inner_Bigint_Col "

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -612,6 +612,19 @@ public class ViewToAvroSchemaConverterTests {
         TestUtils.loadSchema("testSelectStarFromNestComplex-expected.avsc"));
   }
 
+  @Test(enabled = false)
+  public void testSelectNestedStructFieldFromNestComplex() {
+    String viewSql =
+        "CREATE VIEW v AS SELECT array_col[0].Int_Field Int_Field, map_col['x'].Int_Field2 Int_Field2, struct_col.inner_struct_col.Int_Field3 Int_Field3 FROM basenestedcomplex";
+    TestUtils.executeCreateViewQuery("default", "v", viewSql);
+
+    ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);
+    Schema actualSchema = viewToAvroSchemaConverter.toAvroSchema("default", "v");
+
+    Assert.assertEquals(actualSchema.toString(true),
+        TestUtils.loadSchema("testSelectStarFromNestComplex-expected.avsc"));
+  }
+
   @Test
   public void testProjectStructInnerField() {
     String viewSql = "CREATE VIEW v AS "

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -612,7 +612,7 @@ public class ViewToAvroSchemaConverterTests {
         TestUtils.loadSchema("testSelectStarFromNestComplex-expected.avsc"));
   }
 
-  @Test(enabled = false)
+  @Test
   public void testSelectNestedStructFieldFromNestComplex() {
     String viewSql =
         "CREATE VIEW v AS SELECT array_col[0].Int_Field Int_Field, map_col['x'].Int_Field2 Int_Field2, struct_col.inner_struct_col.Int_Field3 Int_Field3 FROM basenestedcomplex";
@@ -622,7 +622,7 @@ public class ViewToAvroSchemaConverterTests {
     Schema actualSchema = viewToAvroSchemaConverter.toAvroSchema("default", "v");
 
     Assert.assertEquals(actualSchema.toString(true),
-        TestUtils.loadSchema("testSelectStarFromNestComplex-expected.avsc"));
+        TestUtils.loadSchema("testSelectNestedStructFieldFromNestComplex-expected.avsc"));
   }
 
   @Test

--- a/coral-schema/src/test/resources/base-nested-complex.avsc
+++ b/coral-schema/src/test/resources/base-nested-complex.avsc
@@ -83,6 +83,21 @@
     } ],
     "default" : null
   }, {
+    "name" : "map_col",
+    "type" : [ "null", {
+      "type" : "map",
+      "values" : [ "null", {
+        "type" : "record",
+        "name" : "Map_col",
+        "namespace" : "coral.schema.avro.base.nested.complex.basenestedcomplex",
+        "fields" : [ {
+          "name" : "Int_Field2",
+          "type" : [ "null", "int" ]
+        } ]
+      } ]
+    } ],
+    "default" : null
+  }, {
     "name" : "struct_col",
     "type" : [ "null", {
       "type" : "record",
@@ -116,6 +131,18 @@
         "name" : "string_field",
         "type" : [ "null", "string" ],
         "default" : null
+      }, {
+        "name": "inner_struct_col",
+        "type": {
+          "name" : "Inner_Struct_col",
+          "type" : "record",
+          "namespace" : "coral.schema.avro.base.nested.complex.basenestedcomplex",
+          "fields" : [ {
+            "name" : "Int_Field3",
+            "type" : [ "null", "int" ],
+            "default" : null
+          }]
+        }
       } ]
     } ],
     "default" : null

--- a/coral-schema/src/test/resources/testSelectDeepNestedStructFieldFromDeepNestComplex-expected.avsc
+++ b/coral-schema/src/test/resources/testSelectDeepNestedStructFieldFromDeepNestComplex-expected.avsc
@@ -1,0 +1,26 @@
+{
+  "type" : "record",
+  "name" : "v",
+  "namespace" : "default.v",
+  "fields" : [ {
+    "name" : "Int_Field_1",
+    "type" : [ "null", "int" ],
+    "default" : null
+  }, {
+    "name" : "Int_Field_2",
+    "type" : [ "null", "int" ],
+    "default" : null
+  }, {
+    "name" : "Int_Field_3",
+    "type" : [ "null", "int" ],
+    "default" : null
+  }, {
+    "name" : "Int_Field_4",
+    "type" : [ "null", "int" ],
+    "default" : null
+  }, {
+    "name" : "Int_Field_5",
+    "type" : [ "null", "int" ],
+    "default" : null
+  } ]
+}

--- a/coral-schema/src/test/resources/testSelectNestedStructFieldFromNestComplex-expected.avsc
+++ b/coral-schema/src/test/resources/testSelectNestedStructFieldFromNestComplex-expected.avsc
@@ -1,0 +1,16 @@
+{
+  "type" : "record",
+  "name" : "v",
+  "namespace" : "default.v",
+  "fields" : [ {
+    "name" : "Int_Field",
+    "type" : [ "null", "int" ]
+  }, {
+    "name" : "Int_Field2",
+    "type" : [ "null", "int" ]
+  }, {
+    "name" : "Int_Field3",
+    "type" : [ "null", "int" ],
+    "default" : null
+  } ]
+}

--- a/coral-schema/src/test/resources/testSelectStarFromNestComplex-expected.avsc
+++ b/coral-schema/src/test/resources/testSelectStarFromNestComplex-expected.avsc
@@ -83,6 +83,21 @@
     } ],
     "default" : null
   }, {
+    "name" : "map_col",
+    "type" : [ "null", {
+      "type" : "map",
+      "values" : [ "null", {
+        "type" : "record",
+        "name" : "Map_col",
+        "namespace" : "default.v.v",
+        "fields" : [ {
+          "name" : "Int_Field2",
+          "type" : [ "null", "int" ]
+        } ]
+      } ]
+    } ],
+    "default" : null
+  }, {
     "name" : "struct_col",
     "type" : [ "null", {
       "type" : "record",
@@ -116,6 +131,18 @@
         "name" : "string_field",
         "type" : [ "null", "string" ],
         "default" : null
+      }, {
+        "name" : "inner_struct_col",
+        "type" : {
+          "type" : "record",
+          "name" : "Inner_Struct_col",
+          "namespace" : "default.v.v.Struct_col",
+          "fields" : [ {
+            "name" : "Int_Field3",
+            "type" : [ "null", "int" ],
+            "default" : null
+          } ]
+        }
       } ]
     } ],
     "default" : null


### PR DESCRIPTION
Previously, `RelToAvroSchemaConverter.visitFieldAccess` just handles the case `SELECT struct_col.int_field`, if the struct is nested in map/array/another struct, coral-schema fails to return the correct schema. This patch adds the support for these cases.

Tests:
1. unit test
2. tested on affected production views, could return the correct schema
3. integration test, no regression