### PR TITLE
Use default value for HIVE_QUOTEDID_SUPPORT when hiveConf=null

### DIFF
--- a/coral-hive/src/main/antlr/roots/com/linkedin/coral/hive/hive2rel/parsetree/parser/HiveLexer.g
+++ b/coral-hive/src/main/antlr/roots/com/linkedin/coral/hive/hive2rel/parsetree/parser/HiveLexer.g
@@ -34,7 +34,12 @@ import org.apache.hadoop.hive.conf.HiveConf;
   }
 
   protected boolean allowQuotedId() {
-    String supportedQIds = HiveConf.getVar(hiveConf, HiveConf.ConfVars.HIVE_QUOTEDID_SUPPORT);
+    String supportedQIds;
+    if (hiveConf == null) {
+      supportedQIds = HiveConf.ConfVars.HIVE_QUOTEDID_SUPPORT.getDefaultValue();
+    } else {
+      supportedQIds = HiveConf.getVar(hiveConf, HiveConf.ConfVars.HIVE_QUOTEDID_SUPPORT);
+    }
     return !"none".equals(supportedQIds);
   }
 }


### PR DESCRIPTION
This patch aims to prevent the NullPointerException we get when the hiveConf is Null. This patch is similar to 
https://issues.apache.org/jira/secure/attachment/12788767/HIVE-13101.1.patch