### PR TITLE
Adds try catch to avoid throwing error for `useSQL11ReservedKeywordsForIdentifier`

### DIFF
--- a/coral-hive/build.gradle
+++ b/coral-hive/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'antlr'
 
 dependencies {
   antlr deps.'antlr'
-  compile('com.linkedin.calcite:calcite-core:1.21.0.146') {
+  compile('com.linkedin.calcite:calcite-core:1.21.0.148') {
     artifact {
       name = 'calcite-core'
       extension = 'jar'

--- a/coral-hive/src/main/antlr/roots/com/linkedin/coral/hive/hive2rel/parsetree/parser/HiveParser.g
+++ b/coral-hive/src/main/antlr/roots/com/linkedin/coral/hive/hive2rel/parsetree/parser/HiveParser.g
@@ -653,7 +653,11 @@ import org.apache.hadoop.hive.conf.HiveConf;
     this.hiveConf = hiveConf;
   }
   protected boolean useSQL11ReservedKeywordsForIdentifier() {
-    return !HiveConf.getBoolVar(hiveConf, HiveConf.ConfVars.HIVE_SUPPORT_SQL11_RESERVED_KEYWORDS);
+    try {
+      return !HiveConf.getBoolVar(hiveConf, HiveConf.ConfVars.HIVE_SUPPORT_SQL11_RESERVED_KEYWORDS);
+    } catch (Throwable throwable) {
+      return false;
+    }
   }
 }
 


### PR DESCRIPTION
Return the default value (false) for `useSQL11ReservedKeywordsForIdentifier` while there is an issue like:
```
java.lang.NoSuchFieldError: HIVE_SUPPORT_SQL11_RESERVED_KEYWORDS
```