### PR TITLE
Add warn log to `useSQL11ReservedKeywordsForIdentifier`

### DIFF
--- a/coral-hive/build.gradle
+++ b/coral-hive/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'antlr'
 
 dependencies {
   antlr deps.'antlr'
-  compile('com.linkedin.calcite:calcite-core:1.21.0.146') {
+  compile('com.linkedin.calcite:calcite-core:1.21.0.148') {
     artifact {
       name = 'calcite-core'
       extension = 'jar'

--- a/coral-hive/src/main/antlr/roots/com/linkedin/coral/hive/hive2rel/parsetree/parser/HiveParser.g
+++ b/coral-hive/src/main/antlr/roots/com/linkedin/coral/hive/hive2rel/parsetree/parser/HiveParser.g
@@ -371,10 +371,13 @@ import java.util.Collection;
 import java.util.HashMap;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 }
 
 
 @members {
+  private static final Logger LOG = LoggerFactory.getLogger(HiveParser.class);
   ArrayList<ParseError> errors = new ArrayList<ParseError>();
   Stack msgs = new Stack<String>();
 
@@ -656,6 +659,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
     try {
       return !HiveConf.getBoolVar(hiveConf, HiveConf.ConfVars.HIVE_SUPPORT_SQL11_RESERVED_KEYWORDS);
     } catch (Throwable throwable) {
+      LOG.warn(throwable.getMessage());
       return false;
     }
   }


### PR DESCRIPTION
Add warn log if there is an error in `useSQL11ReservedKeywordsForIdentifier`
No regression in integration test.