### PR TITLE
Passing docstring from underlying sources to views.

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
@@ -294,7 +294,7 @@ public class RelToAvroSchemaConverter {
       for (Pair<AggregateCall, String> aggCall : logicalAggregate.getNamedAggCalls()) {
         String fieldName = SchemaUtilities.toAvroQualifiedName(aggCall.right);
         RelDataType fieldType = aggCall.left.getType();
-        SchemaUtilities.appendField(fieldName, fieldType, logicalAggregateFieldAssembler, true);
+        SchemaUtilities.appendField(fieldName, fieldType, null, logicalAggregateFieldAssembler, true);
       }
 
       schemaMap.put(logicalAggregate, logicalAggregateFieldAssembler.endRecord());
@@ -328,7 +328,7 @@ public class RelToAvroSchemaConverter {
             SchemaBuilder.record("LateralViews").namespace("LateralViews").fields();
 
         for (RelDataTypeField field : relNode.getRowType().getFieldList()) {
-          SchemaUtilities.appendField(field.getName(), field.getType(), hiveUncollectFieldAssembler, true);
+          SchemaUtilities.appendField(field.getName(), field.getType(), null, hiveUncollectFieldAssembler, true);
         }
 
         schemaMap.put(relNode, hiveUncollectFieldAssembler.endRecord());
@@ -397,11 +397,14 @@ public class RelToAvroSchemaConverter {
       return super.visitLocalRef(rexLocalRef);
     }
 
+    /*
+     * TODO: Populate doc for queries with literal.
+     */
     @Override
     public RexNode visitLiteral(RexLiteral rexLiteral) {
       RexNode rexNode = super.visitLiteral(rexLiteral);
       RelDataType fieldType = rexLiteral.getType();
-      appendField(fieldType, true);
+      appendField(fieldType, true, null);
 
       return rexNode;
     }
@@ -412,11 +415,12 @@ public class RelToAvroSchemaConverter {
         /**
          * For SqlUserDefinedFunction and SqlOperator RexCall, no need to handle it recursively
          * and only return type of udf or sql operator is relevant
+         * TODO: Populate doc for queries with rex call.
          */
         RelDataType fieldType = rexCall.getType();
         boolean isNullable = SchemaUtilities.isFieldNullable(rexCall, inputSchema);
 
-        appendField(fieldType, isNullable);
+        appendField(fieldType, isNullable, null);
 
         return rexCall;
       } else {
@@ -497,9 +501,9 @@ public class RelToAvroSchemaConverter {
       return super.visitPatternFieldRef(rexPatternFieldRef);
     }
 
-    private void appendField(RelDataType fieldType, boolean isNullable) {
+    private void appendField(RelDataType fieldType, boolean isNullable, String doc) {
       String fieldName = SchemaUtilities.getFieldName("", suggestedFieldNames.poll());
-      SchemaUtilities.appendField(fieldName, fieldType, fieldAssembler, isNullable);
+      SchemaUtilities.appendField(fieldName, fieldType, doc, fieldAssembler, isNullable);
     }
 
     /**

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -14,10 +14,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import javax.annotation.Nullable;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.calcite.rel.type.RelDataType;
@@ -154,10 +154,8 @@ class SchemaUtilities {
 
     JsonNode defaultValue = field.defaultValue();
 
-    SchemaBuilder.GenericDefault genericDefault = fieldAssembler
-        .name(field.name())
-        .doc(field.doc())
-        .type(field.schema());
+    SchemaBuilder.GenericDefault genericDefault =
+        fieldAssembler.name(field.name()).doc(field.doc()).type(field.schema());
     if (defaultValue != null) {
       genericDefault.withDefault(defaultValue);
     } else {

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -17,6 +17,7 @@ import javax.annotation.Nonnull;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import javax.annotation.Nullable;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.calcite.rel.type.RelDataType;
@@ -153,7 +154,10 @@ class SchemaUtilities {
 
     JsonNode defaultValue = field.defaultValue();
 
-    SchemaBuilder.GenericDefault genericDefault = fieldAssembler.name(field.name()).type(field.schema());
+    SchemaBuilder.GenericDefault genericDefault = fieldAssembler
+        .name(field.name())
+        .doc(field.doc())
+        .type(field.schema());
     if (defaultValue != null) {
       genericDefault.withDefault(defaultValue);
     } else {
@@ -166,9 +170,10 @@ class SchemaUtilities {
    *
    * @param fieldName
    * @param fieldRelDataType
+   * @param doc
    * @param fieldAssembler
    */
-  static void appendField(@Nonnull String fieldName, @Nonnull RelDataType fieldRelDataType,
+  static void appendField(@Nonnull String fieldName, @Nonnull RelDataType fieldRelDataType, @Nullable String doc,
       @Nonnull SchemaBuilder.FieldAssembler<Schema> fieldAssembler, @Nonnull boolean isNullable) {
     Preconditions.checkNotNull(fieldName);
     Preconditions.checkNotNull(fieldRelDataType);
@@ -179,9 +184,9 @@ class SchemaUtilities {
     // TODO: handle default value properly
     if (isNullable && fieldSchema.getType() != Schema.Type.NULL) {
       Schema fieldSchemaNullable = Schema.createUnion(Arrays.asList(fieldSchema, Schema.create(Schema.Type.NULL)));
-      fieldAssembler.name(fieldName).type(fieldSchemaNullable).noDefault();
+      fieldAssembler.name(fieldName).doc(doc).type(fieldSchemaNullable).noDefault();
     } else {
-      fieldAssembler.name(fieldName).type(fieldSchema).noDefault();
+      fieldAssembler.name(fieldName).doc(doc).type(fieldSchema).noDefault();
     }
   }
 
@@ -219,7 +224,7 @@ class SchemaUtilities {
 
     JsonNode defaultValue = field.defaultValue();
 
-    SchemaBuilder.GenericDefault genericDefault = fieldAssembler.name(fieldName).type(field.schema());
+    SchemaBuilder.GenericDefault genericDefault = fieldAssembler.name(fieldName).doc(field.doc()).type(field.schema());
     if (defaultValue != null) {
       genericDefault.withDefault(defaultValue);
     } else {
@@ -517,7 +522,7 @@ class SchemaUtilities {
     }
 
     JsonNode defaultValue = field.defaultValue();
-    SchemaBuilder.GenericDefault genericDefault = fieldAssembler.name(field.name()).type(fieldSchema);
+    SchemaBuilder.GenericDefault genericDefault = fieldAssembler.name(field.name()).doc(field.doc()).type(fieldSchema);
     if (defaultValue != null) {
       genericDefault.withDefault(defaultValue);
     } else {

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
@@ -96,6 +96,13 @@ public class TestUtils {
     executeCreateTableWithPartitionFieldSchemaQuery("default", "basecomplexfieldschema", baseComplexFieldSchema);
     executeCreateTableWithPartitionQuery("default", "basenestedcomplex", baseNestedComplexSchema);
 
+    String baseComplexSchemaWithDoc = loadSchema("docTestResources/base-complex-with-doc.avsc");
+    String baseEnumSchemaWithDoc = loadSchema("docTestResources/base-enum-with-doc.avsc");
+    String baseLateralViewSchemaWithDoc = loadSchema("docTestResources/base-lateralview-with-doc.avsc");
+    executeCreateTableQuery("default", "basecomplexwithdoc", baseComplexSchemaWithDoc);
+    executeCreateTableQuery("default", "baseenumwithdoc", baseEnumSchemaWithDoc);
+    executeCreateTableQuery("default", "baselateralviewwithdoc", baseLateralViewSchemaWithDoc);
+
     // Creates a table with deep nested structs
     executeQuery("DROP TABLE IF EXISTS basedeepnestedcomplex");
     executeQuery("CREATE TABLE IF NOT EXISTS basedeepnestedcomplex("

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -751,11 +751,9 @@ public class ViewToAvroSchemaConverterTests {
 
   @Test
   public void testFullOuterJoinWithDoc() {
-    String viewSql = "CREATE VIEW v AS "
-        + "SELECT bc.id, bc.struct_col, be.enum_top_col "
-        + "FROM basecomplexwithdoc bc "
-        + "FULL OUTER JOIN baseenumwithdoc be ON bc.id = be.id "
-        + "WHERE bc.id > 0 AND bc.struct_col IS NOT NULL";
+    String viewSql =
+        "CREATE VIEW v AS " + "SELECT bc.id, bc.struct_col, be.enum_top_col " + "FROM basecomplexwithdoc bc "
+            + "FULL OUTER JOIN baseenumwithdoc be ON bc.id = be.id " + "WHERE bc.id > 0 AND bc.struct_col IS NOT NULL";
 
     TestUtils.executeCreateViewQuery("default", "v", viewSql);
 
@@ -766,16 +764,14 @@ public class ViewToAvroSchemaConverterTests {
         TestUtils.loadSchema("docTestResources/testJoin-expected-with-doc.avsc"));
   }
 
-
   /*
    * TODO : Discuss how to deal with expressions.
    */
   @Test
   public void testSelectWithLiteralsWithDoc() {
-    String viewSql = "CREATE VIEW v AS "
-        + "SELECT bc.Id AS Id_View_Col, 100 AS Additional_Int, 200, bc.Array_Col AS Array_View_Col "
-        + "FROM basecomplexwithdoc bc "
-        + "WHERE bc.Id > 0 AND bc.Struct_Col IS NOT NULL";
+    String viewSql =
+        "CREATE VIEW v AS " + "SELECT bc.Id AS Id_View_Col, 100 AS Additional_Int, 200, bc.Array_Col AS Array_View_Col "
+            + "FROM basecomplexwithdoc bc " + "WHERE bc.Id > 0 AND bc.Struct_Col IS NOT NULL";
 
     TestUtils.executeCreateViewQuery("default", "v", viewSql);
 
@@ -791,17 +787,16 @@ public class ViewToAvroSchemaConverterTests {
    */
   @Test
   public void testAggregateRenameWithDoc() {
-    String viewSql =
-        "CREATE VIEW v AS " + "SELECT bc.Id AS Id_View_Col, COUNT(*) AS Count_Col " + "FROM basecomplexwithdoc bc " + "WHERE bc.Id > 0 "
-            + "GROUP BY bc.Id";
+    String viewSql = "CREATE VIEW v AS " + "SELECT bc.Id AS Id_View_Col, COUNT(*) AS Count_Col "
+        + "FROM basecomplexwithdoc bc " + "WHERE bc.Id > 0 " + "GROUP BY bc.Id";
 
     TestUtils.executeCreateViewQuery("default", "v", viewSql);
 
     ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);
     Schema actualSchema = viewToAvroSchemaConverter.toAvroSchema("default", "v");
 
-    Assert.assertEquals(actualSchema.toString(true), TestUtils.loadSchema(
-        "docTestResources/testAggregateRename-expected-with-doc.avsc"));
+    Assert.assertEquals(actualSchema.toString(true),
+        TestUtils.loadSchema("docTestResources/testAggregateRename-expected-with-doc.avsc"));
   }
 
   /*
@@ -809,9 +804,7 @@ public class ViewToAvroSchemaConverterTests {
    */
   @Test
   public void testRexCallAggregateWithDoc() {
-    String viewSql = "CREATE VIEW v AS "
-        + "SELECT 22*COUNT(bc.Id) AS Temp "
-        + "FROM basecomplexwithdoc bc";
+    String viewSql = "CREATE VIEW v AS " + "SELECT 22*COUNT(bc.Id) AS Temp " + "FROM basecomplexwithdoc bc";
 
     TestUtils.executeCreateViewQuery("default", "v", viewSql);
 
@@ -830,12 +823,10 @@ public class ViewToAvroSchemaConverterTests {
     String viewSql = "CREATE VIEW foo_dali_multiple_udfs "
         + "tblproperties('functions' = 'LessThanHundred:com.linkedin.coral.hive.hive2rel.CoralTestUDF1 GreaterThanHundred:com.linkedin.coral.hive.hive2rel.CoralTestUDF2 FuncSquare:com.linkedin.coral.hive.hive2rel.CoralTestUDF3', "
         + "              'dependencies' = 'ivy://com.linkedin:udf:1.0 ivy://com.linkedin:udf:1.0 ivy://com.linkedin:udf:1.0') "
-        + "AS "
-        + "SELECT Id AS Id_Viewc_Col, "
+        + "AS " + "SELECT Id AS Id_Viewc_Col, "
         + "default_foo_dali_multiple_udfs_LessThanHundred(Id) AS Id_View_LessThanHundred_Col,"
         + "default_foo_dali_multiple_udfs_GreaterThanHundred(Id) AS Id_View_GreaterThanHundred_Col, "
-        + "default_foo_dali_multiple_udfs_FuncSquare(Id) AS Id_View_FuncSquare_Col "
-        + "FROM basecomplexwithdoc";
+        + "default_foo_dali_multiple_udfs_FuncSquare(Id) AS Id_View_FuncSquare_Col " + "FROM basecomplexwithdoc";
 
     TestUtils.executeCreateViewQuery("default", "foo_dali_multiple_udfs", viewSql);
 

--- a/coral-schema/src/test/resources/docTestResources/base-complex-with-doc.avsc
+++ b/coral-schema/src/test/resources/docTestResources/base-complex-with-doc.avsc
@@ -1,0 +1,68 @@
+{
+  "type" : "record",
+  "name" : "basecomplex",
+  "namespace" : "coral.schema.avro.base.complex",
+  "fields" : [ {
+    "name" : "Id",
+    "type" : "int",
+    "doc" : "Sample id of the record."
+  }, {
+    "name" : "Array_Col",
+    "type" : [ "null", {
+      "type" : "array",
+      "items" : [ "null", "string" ]
+    } ],
+    "doc" : "Sample array col.",
+    "default" : null
+  }, {
+    "name" : "Map_Col",
+    "type" : [ "null", {
+      "type" : "map",
+      "values" : [ "null", "string" ]
+    } ],
+    "doc" : "Sample map col.",
+    "default" : null
+  }, {
+    "name" : "Struct_Col",
+    "type" : [ "null", {
+      "type" : "record",
+      "name" : "Struct_col",
+      "namespace" : "coral.schema.avro.base.complex.basecomplex",
+      "fields" : [ {
+        "name" : "Bool_Field",
+        "type" : "boolean",
+        "doc" : "Sample boolean field."
+      }, {
+        "name" : "Int_Field",
+        "type" : [ "null", "int" ],
+        "doc" : "Sample int field.",
+        "default" : null
+      }, {
+        "name" : "Bigint_Field",
+        "type" : "long",
+        "doc" : "Sample long field."
+      }, {
+        "name" : "Float_Field",
+        "type" : [ "null", "float" ],
+        "doc" : "Sample float field.",
+        "default" : null
+      }, {
+        "name" : "Double_Field",
+        "type" : "double",
+        "doc" : "Sample double field."
+      }, {
+        "name" : "Date_String_Field",
+        "type" : [ "null", "string" ],
+        "doc" : "Sample string representing date field.",
+        "default" : null
+      }, {
+        "name" : "String_Field",
+        "type" : [ "null", "string" ],
+        "doc" : "Sample string field.",
+        "default" : null
+      } ]
+    } ],
+    "doc" : "Sample struct col.",
+    "default" : null
+  } ]
+}

--- a/coral-schema/src/test/resources/docTestResources/base-enum-with-doc.avsc
+++ b/coral-schema/src/test/resources/docTestResources/base-enum-with-doc.avsc
@@ -1,0 +1,85 @@
+{
+  "type" : "record",
+  "name" : "baseenum",
+  "namespace" : "coral.schema.avro.base.enum",
+  "fields" : [ {
+    "name" : "Id",
+    "type" : "int",
+    "doc" : "Id field."
+  }, {
+    "name" : "Array_Col",
+    "type" : [ "null", {
+      "type" : "array",
+      "items" : [ "null", "string" ],
+      "doc" : "Array col field."
+    } ],
+    "default" : null
+  }, {
+    "name" : "Map_Col",
+    "type" : [ "null", {
+      "type" : "map",
+      "values" : [ "null", "string" ],
+      "doc" : "Map col field."
+    } ],
+    "default" : null
+  }, {
+    "name" : "Enum_Top_Col",
+    "type" : {
+      "type" : "enum",
+      "name" : "Enum_Top_col",
+      "symbols" : [ "Spark", "Pig", "Hive", "MR" ],
+      "doc" : "Enum top col"
+    },
+    "doc" : "Enum top col."
+  }, {
+    "name" : "Struct_Col",
+    "type" : [ "null", {
+      "type" : "record",
+      "name" : "Struct_col",
+      "namespace" : "coral.schema.avro.base.enum.baseenum",
+      "fields" : [ {
+        "name" : "Bool_Field",
+        "type" : "boolean",
+        "doc" : "Boolean field"
+      }, {
+        "name" : "Int_Field",
+        "type" : [ "null", "int" ],
+        "doc" : "Int field",
+        "default" : null
+      }, {
+        "name" : "Bigint_Field",
+        "type" : "long",
+        "doc" : "Big int field."
+      }, {
+        "name" : "Float_Field",
+        "type" : [ "null", "float" ],
+        "doc" : "Float field.",
+        "default" : null
+      }, {
+        "name" : "Enum_Inner_Col",
+        "type" : {
+          "type" : "enum",
+          "name" : "Enum_Inner_col",
+          "symbols" : [ "Red", "Blue", "Green" ],
+          "doc" : "Inner enum col."
+        }
+      }, {
+        "name" : "Double_Field",
+        "type" : "double",
+        "doc" : "Double field."
+      }, {
+        "name" : "Date_String_Field",
+        "type" : [ "null", "string" ],
+        "doc" : "Date string field",
+        "default" : null
+      }, {
+        "name" : "String_Field",
+        "type" : [ "null", "string" ],
+        "doc" : "String field",
+        "default" : null
+      } ]
+    } ],
+    "doc" : "Struct col.",
+    "default" : null
+  } ]
+}

--- a/coral-schema/src/test/resources/docTestResources/base-lateralview-with-doc.avsc
+++ b/coral-schema/src/test/resources/docTestResources/base-lateralview-with-doc.avsc
@@ -1,0 +1,87 @@
+{
+  "type" : "record",
+  "name" : "baselateralview",
+  "namespace" : "coral.schema.avro.base.lateralview",
+  "fields" : [ {
+    "name" : "Id",
+    "type" : "int",
+    "doc" : "Sample id of the record."
+  }, {
+    "name" : "Array_Col_String",
+    "type" : [ "null", {
+      "type" : "array",
+      "items" : [ "null", "string" ]
+
+    } ],
+    "doc" : "sample",
+    "default" : null
+  }, {
+    "name" : "Array_Col_Double",
+    "type" : [ "null", {
+      "type" : "array",
+      "items" : [ "null", "double" ]
+    } ],
+    "doc" : "Array col double.",
+    "default" : null
+  }, {
+    "name" : "Array_Col_Struct",
+    "type" : [ "null", {
+      "type" : "array",
+      "items" : {
+        "type" : "record",
+        "name" : "Struct_Col",
+        "fields" : [ {
+          "name" : "Bool_Field",
+          "type" : "boolean",
+          "doc" : "Sample boolean field."
+        }, {
+          "name" : "Int_Field",
+          "type" : [ "null", "int" ],
+          "default" : null,
+          "doc": "Sample int field."
+        }, {
+          "name" : "Bigint_Field",
+          "type" : "long",
+          "doc" : "Sample long field."
+        }, {
+          "name" : "Float_Field",
+          "type" : [ "null", "float" ],
+          "default" : null,
+          "doc" : "Sample float field."
+        }, {
+          "name" : "Double_Field",
+          "type" : "double",
+          "doc" : "Sample double field."
+        }, {
+          "name" : "Date_String_Field",
+          "type" : [ "null", "string" ],
+          "default" : null,
+          "doc" : "Sample string representing date field."
+        }, {
+          "name" : "String_Field",
+          "type" : [ "null", "string" ],
+          "default" : null,
+          "doc" : "Sample string field."
+        } ]
+      }
+    } ],
+    "doc" : "Array col struct.",
+    "default" : null
+  }, {
+    "name" : "Map_Col_String",
+    "type" : [ "null", {
+      "type" : "map",
+      "values" : [ "null", "string" ]
+    } ],
+    "doc" : "Map col string.",
+    "default" : null
+  }, {
+    "name" : "Map_Col_Int",
+    "type" : [ "null", {
+      "type" : "map",
+      "values" : [ "null", "int" ]
+    } ],
+    "doc" : "Map col Integer",
+    "default" : null
+  } ]
+}

--- a/coral-schema/src/test/resources/docTestResources/testAggregateRename-expected-with-doc.avsc
+++ b/coral-schema/src/test/resources/docTestResources/testAggregateRename-expected-with-doc.avsc
@@ -1,0 +1,13 @@
+{
+  "type" : "record",
+  "name" : "v",
+  "namespace" : "default.v",
+  "fields" : [ {
+    "name" : "Id_View_Col",
+    "type" : "int",
+    "doc" : "Sample id of the record."
+  }, {
+    "name" : "Count_Col",
+    "type" : [ "null", "long" ]
+  } ]
+}

--- a/coral-schema/src/test/resources/docTestResources/testJoin-expected-with-doc.avsc
+++ b/coral-schema/src/test/resources/docTestResources/testJoin-expected-with-doc.avsc
@@ -1,0 +1,62 @@
+{
+  "type" : "record",
+  "name" : "v",
+  "namespace" : "default.v",
+  "fields" : [ {
+    "name" : "Id",
+    "type" : "int",
+    "doc" : "Sample id of the record."
+  }, {
+    "name" : "Struct_Col",
+    "type" : [ "null", {
+      "type" : "record",
+      "name" : "Struct_col",
+      "namespace" : "default.v.v",
+      "fields" : [ {
+        "name" : "Bool_Field",
+        "type" : "boolean",
+        "doc" : "Sample boolean field."
+      }, {
+        "name" : "Int_Field",
+        "type" : [ "null", "int" ],
+        "doc" : "Sample int field.",
+        "default" : null
+      }, {
+        "name" : "Bigint_Field",
+        "type" : "long",
+        "doc" : "Sample long field."
+      }, {
+        "name" : "Float_Field",
+        "type" : [ "null", "float" ],
+        "doc" : "Sample float field.",
+        "default" : null
+      }, {
+        "name" : "Double_Field",
+        "type" : "double",
+        "doc" : "Sample double field."
+      }, {
+        "name" : "Date_String_Field",
+        "type" : [ "null", "string" ],
+        "doc" : "Sample string representing date field.",
+        "default" : null
+      }, {
+        "name" : "String_Field",
+        "type" : [ "null", "string" ],
+        "doc" : "Sample string field.",
+        "default" : null
+      } ]
+    } ],
+    "doc" : "Sample struct col.",
+    "default" : null
+  }, {
+    "name" : "Enum_Top_Col",
+    "type" : {
+      "type" : "enum",
+      "name" : "Enum_Top_col",
+      "namespace" : "default.v.v",
+      "doc" : "Enum top col",
+      "symbols" : [ "Spark", "Pig", "Hive", "MR" ]
+    },
+    "doc" : "Enum top col."
+  } ]
+}

--- a/coral-schema/src/test/resources/docTestResources/testMultipleLateralViewDifferentArrayType-expected-with-doc.avsc
+++ b/coral-schema/src/test/resources/docTestResources/testMultipleLateralViewDifferentArrayType-expected-with-doc.avsc
@@ -1,0 +1,16 @@
+{
+  "type" : "record",
+  "name" : "v",
+  "namespace" : "default.v",
+  "fields" : [ {
+    "name" : "Id_View_Col",
+    "type" : "int",
+    "doc" : "Sample id of the record."
+  }, {
+    "name" : "Array_Lateral_View_String_Col",
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "Array_Lateral_View_Double_Col",
+    "type" : [ "null", "double" ]
+  } ]
+}

--- a/coral-schema/src/test/resources/docTestResources/testMultipleUdfs-expected-with-doc.avsc
+++ b/coral-schema/src/test/resources/docTestResources/testMultipleUdfs-expected-with-doc.avsc
@@ -1,0 +1,19 @@
+{
+  "type" : "record",
+  "name" : "foo_dali_multiple_udfs",
+  "namespace" : "default.foo_dali_multiple_udfs",
+  "fields" : [ {
+    "name" : "Id_Viewc_Col",
+    "type" : "int",
+    "doc" : "Sample id of the record."
+  }, {
+    "name" : "Id_View_LessThanHundred_Col",
+    "type" : "boolean"
+  }, {
+    "name" : "Id_View_GreaterThanHundred_Col",
+    "type" : "boolean"
+  }, {
+    "name" : "Id_View_FuncSquare_Col",
+    "type" : "int"
+  } ]
+}

--- a/coral-schema/src/test/resources/docTestResources/testRexCallAggregate-expected-with-doc.avsc
+++ b/coral-schema/src/test/resources/docTestResources/testRexCallAggregate-expected-with-doc.avsc
@@ -1,0 +1,9 @@
+{
+  "type" : "record",
+  "name" : "v",
+  "namespace" : "default.v",
+  "fields" : [ {
+    "name" : "Temp",
+    "type" : [ "null", "int" ]
+  } ]
+}

--- a/coral-schema/src/test/resources/docTestResources/testSelectWithLiterals-expected-with-doc.avsc
+++ b/coral-schema/src/test/resources/docTestResources/testSelectWithLiterals-expected-with-doc.avsc
@@ -1,0 +1,24 @@
+{
+  "type" : "record",
+  "name" : "v",
+  "namespace" : "default.v",
+  "fields" : [ {
+    "name" : "Id_View_Col",
+    "type" : "int",
+    "doc" : "Sample id of the record."
+  }, {
+    "name" : "Additional_Int",
+    "type" : [ "null", "int" ]
+  }, {
+    "name" : "EXPR_2",
+    "type" : [ "null", "int" ]
+  }, {
+    "name" : "Array_View_Col",
+    "type" : [ "null", {
+      "type" : "array",
+      "items" : [ "null", "string" ]
+    } ],
+    "doc" : "Sample array col.",
+    "default" : null
+  } ]
+}

--- a/coral-schema/src/test/resources/testSelectStarFromNestComplex-expected.avsc
+++ b/coral-schema/src/test/resources/testSelectStarFromNestComplex-expected.avsc
@@ -148,6 +148,7 @@
     "default" : null
   }, {
     "name" : "datepartition",
-    "type" : "string"
+    "type" : "string",
+    "doc" : "This is the partition column. Partition columns, if present in the schema, should also be projected in the data."
   } ]
 }

--- a/coral-schema/src/test/resources/testSelectStarWithPartition.avsc
+++ b/coral-schema/src/test/resources/testSelectStarWithPartition.avsc
@@ -32,6 +32,7 @@
     } ]
   }, {
     "name" : "datepartition",
-    "type" : "string"
+    "type" : "string",
+    "doc" : "This is the partition column. Partition columns, if present in the schema, should also be projected in the data."
   } ]
 }

--- a/coral-schema/src/test/resources/testUnionPreserveNamespace.avsc
+++ b/coral-schema/src/test/resources/testUnionPreserveNamespace.avsc
@@ -32,6 +32,7 @@
     } ]
   }, {
     "name" : "datepartition",
-    "type" : "string"
+    "type" : "string",
+    "doc" : "This is the partition column. Partition columns, if present in the schema, should also be projected in the data."
   } ]
 }


### PR DESCRIPTION
Code changes to support passing down docstring from underlying tables to views created on top of them. 
6 UTs added covering different scenarios. 
Some special cases like literals, etc. still need to be handled.