### PR TITLE
Avoid using keys in `HIVE_REGISTRY` as UDF name for coral-trino

### DIFF
--- a/coral-hive/build.gradle
+++ b/coral-hive/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'antlr'
 
 dependencies {
   antlr deps.'antlr'
-  compile('com.linkedin.calcite:calcite-core:1.21.0.146') {
+  compile('com.linkedin.calcite:calcite-core:1.21.0.148') {
     artifact {
       name = 'calcite-core'
       extension = 'jar'


### PR DESCRIPTION
As the keys are lowercased in `HIVE_REGISTRY`, we cannot use them as UDF names, because the convertor can only converts UPPER_CAMEL format to LOWER_UNDERSCORE format (i.e. `PortalLookup -> portal_lookup`). Therefore, we need to call `getHiveFunctionName` to get the UDF name to preserve the case information for correct conversion.

Tests:
1. Tested on affected views, UDF name was correct with this patch
2. Integration test, no regression