### PR TITLE
BDP-7396: TransportUdf determine scala version in CoralSpark and return respective artifactory link

### DIFF
--- a/coral-spark/build.gradle
+++ b/coral-spark/build.gradle
@@ -1,4 +1,5 @@
 apply from: "$rootDir/gradle/java-publication.gradle"
+apply from: "spark_itest.gradle"
 
 dependencies {
   compile deps.'gson'
@@ -6,6 +7,7 @@ dependencies {
   compile deps.'slf4j-log4j12'
   compile project(':coral-hive')
 
+  compileOnly deps.'spark'.'sql'
   testCompile(deps.'hive'.'hive-exec-core') {
     exclude group: 'org.apache.avro', module: 'avro-tools'
     // These exclusions are required to prevent duplicate classes since we include
@@ -13,7 +15,6 @@ dependencies {
     exclude group: 'org.apache.calcite', module: 'calcite-core'
     exclude group: 'org.apache.calcite', module: 'calcite-avatica'
   }
-
   testCompile deps.'hadoop'.'hadoop-mapreduce-client-core'
   testCompile deps.'kryo'
 }

--- a/coral-spark/spark_itest.gradle
+++ b/coral-spark/spark_itest.gradle
@@ -1,0 +1,32 @@
+def itests = ['spark', 'spark3']
+
+for (String itest : itests) {
+  sourceSets {
+    create("${itest}test", {
+      java {
+        compileClasspath += main.output
+        runtimeClasspath += main.output
+      }
+    })
+  }
+
+  configurations {
+    getByName("${itest}testCompile").extendsFrom(testCompile)
+    getByName("${itest}testRuntime").extendsFrom(testRuntime)
+  }
+
+  tasks.register("${itest}Test", Test) {
+    description = "Run ${itest} integration tests"
+    testClassesDirs = project.sourceSets.getByName("${itest}test").output.classesDirs
+    classpath = project.sourceSets.getByName("${itest}test").runtimeClasspath
+    shouldRunAfter test
+    useTestNG()
+  }
+
+  check.dependsOn(tasks.getByName("${itest}Test"))
+}
+
+dependencies {
+  sparktestCompile(deps.'spark'.'hive')
+  spark3testCompile(deps.'spark3'.'hive')
+}

--- a/coral-spark/src/spark3test/java/com.linkedin.coral.spark/TransportableUDFMapTest.java
+++ b/coral-spark/src/spark3test/java/com.linkedin.coral.spark/TransportableUDFMapTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.spark;
+
+import org.apache.spark.sql.SparkSession;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.linkedin.coral.spark.exceptions.UnsupportedUDFException;
+
+
+public class TransportableUDFMapTest {
+
+  @Test
+  public void testScalaVersionWithSparkSession() {
+    SparkSession ss = SparkSession.builder().appName(TransportableUDFMapTest.class.getSimpleName()).master("local[1]")
+        .enableHiveSupport().getOrCreate();
+    Assert.assertEquals(TransportableUDFMap.getScalaVersion(), TransportableUDFMap.ScalaVersion.SCALA_2_12);
+    ss.close();
+  }
+
+  @Test
+  public void testDefaultScalaVersion() {
+    // If SparkSession is not active, getScalaVersion should return Scala2.11
+    Assert.assertEquals(TransportableUDFMap.getScalaVersion(), TransportableUDFMap.ScalaVersion.SCALA_2_11);
+  }
+
+  @Test
+  public void testLookupWithSparkSession() {
+    SparkSession ss = SparkSession.builder().appName(TransportableUDFMapTest.class.getSimpleName()).master("local[1]")
+        .enableHiveSupport().getOrCreate();
+    String stdDaliUdf = "com.linkedin.dali.udf.date.hive.EpochToDateFormat";
+    Assert.assertTrue(TransportableUDFMap.lookup(stdDaliUdf).get().getArtifactoryUrls().get(0).toString()
+        .contains("classifier=spark_2.12"));
+    ss.close();
+  }
+
+  @Test
+  public void testDefaultLookup() {
+    // If SparkSession is not active, lookup should return Scala2.11
+    String stdDaliUdf = "com.linkedin.dali.udf.date.hive.EpochToDateFormat";
+    Assert.assertTrue(TransportableUDFMap.lookup(stdDaliUdf).get().getArtifactoryUrls().get(0).toString()
+        .contains("classifier=spark_2.11"));
+  }
+
+  @Test
+  public void testLookupDoesNotExist() {
+    String stdClassName = "com.linkedin.dali.udf.date.hive.UdfDoesNotExist";
+    Assert.assertFalse(TransportableUDFMap.lookup(stdClassName).isPresent());
+  }
+
+  @Test
+  public void testLookupExistButNotReadyForSpark3() {
+    SparkSession ss = SparkSession.builder().appName(TransportableUDFMapTest.class.getSimpleName()).master("local[1]")
+        .enableHiveSupport().getOrCreate();
+    try {
+      String stdClassName = "com.transport.test.hive.Spark3Fail";
+      TransportableUDFMap.add(stdClassName, "com.transport.test.spark.Spark3Fail",
+          "com.transport:spark-udf:0.0.0?classifier=spark", null);
+      TransportableUDFMap.lookup(stdClassName);
+    } catch (Exception ex) {
+      Assert.assertTrue(ex instanceof UnsupportedUDFException);
+    } finally {
+      ss.close();
+    }
+  }
+}

--- a/coral-spark/src/sparktest/java/com.linkedin.coral.spark/TransportableUDFMapTest.java
+++ b/coral-spark/src/sparktest/java/com.linkedin.coral.spark/TransportableUDFMapTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.spark;
+
+import org.apache.spark.sql.SparkSession;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TransportableUDFMapTest {
+
+  @Test
+  public void testScalaVersionWithSparkSession() {
+    SparkSession ss = SparkSession.builder().appName(TransportableUDFMapTest.class.getSimpleName()).master("local[1]")
+        .enableHiveSupport().getOrCreate();
+    Assert.assertEquals(TransportableUDFMap.getScalaVersion(), TransportableUDFMap.ScalaVersion.SCALA_2_11);
+    ss.close();
+  }
+
+  @Test
+  public void testDefaultScalaVersion() {
+    // If SparkSession is not active, getScalaVersion should return Scala2.11
+    Assert.assertEquals(TransportableUDFMap.getScalaVersion(), TransportableUDFMap.ScalaVersion.SCALA_2_11);
+  }
+
+  @Test
+  public void testLookupWithSparkSession() {
+    SparkSession ss = SparkSession.builder().appName(TransportableUDFMapTest.class.getSimpleName()).master("local[1]")
+        .enableHiveSupport().getOrCreate();
+    String stdDaliUdf = "com.linkedin.dali.udf.date.hive.EpochToDateFormat";
+    Assert.assertTrue(TransportableUDFMap.lookup(stdDaliUdf).get().getArtifactoryUrls().get(0).toString()
+        .contains("classifier=spark_2.11"));
+    ss.close();
+  }
+
+  @Test
+  public void testDefaultLookup() {
+    // If SparkSession is not active, lookup should return Scala2.11
+    String stdDaliUdf = "com.linkedin.dali.udf.date.hive.EpochToDateFormat";
+    Assert.assertTrue(TransportableUDFMap.lookup(stdDaliUdf).get().getArtifactoryUrls().get(0).toString()
+        .contains("classifier=spark_2.11"));
+  }
+
+  @Test
+  public void testLookupDoesNotExist() {
+    String stdClassName = "com.linkedin.dali.udf.date.hive.UdfDoesNotExist";
+    Assert.assertFalse(TransportableUDFMap.lookup(stdClassName).isPresent());
+  }
+
+  @Test
+  public void testLookupExistButNotReadyForSpark3() {
+    SparkSession ss = SparkSession.builder().appName(TransportableUDFMapTest.class.getSimpleName()).master("local[1]")
+        .enableHiveSupport().getOrCreate();
+    String stdClassName = "com.transport.test.hive.Spark3Fail";
+    TransportableUDFMap.add(stdClassName, "com.transport.test.spark.Spark3Fail",
+        "com.transport:spark-udf:0.0.0?classifier=spark_2.11", null);
+    assert TransportableUDFMap.lookup(stdClassName).get().getArtifactoryUrls().get(0).toString()
+        .contains("classifier=spark_2.11");
+    ss.close();
+  }
+}

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -49,7 +49,7 @@ public class CoralSparkTest {
     UnsupportedHiveUDFsInSpark.add("com.linkedin.coral.hive.hive2rel.CoralTestUnsupportedUDF");
 
     TransportableUDFMap.add("com.linkedin.coral.hive.hive2rel.CoralTestUDF", "com.linkedin.coral.spark.CoralTestUDF",
-        "ivy://com.linkedin.coral.spark.CoralTestUDF");
+        "ivy://com.linkedin.coral.spark.CoralTestUDF", null);
   }
 
   @Test

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -12,7 +12,9 @@ def versions = [
   'hive': '1.2.2',
   'hadoop': '2.7.0',
   'pig': '0.15.0',
-  'ivy': '2.4.0'
+  'ivy': '2.4.0',
+  'spark': '2.4.0',
+  'spark3': '3.1.1'
 ]
 
 ext.deps = [
@@ -33,7 +35,6 @@ ext.deps = [
     'hive-metastore': "org.apache.hive:hive-metastore:${versions['hive']}",
     'hive-exec-core': "org.apache.hive:hive-exec:${versions['hive']}:core",
     'hive-common': "org.apache.hive:hive-common:${versions['hive']}"
-
   ],
   'hadoop': [
     'hadoop-common': "org.apache.hadoop:hadoop-common:${versions['hadoop']}",
@@ -43,5 +44,12 @@ ext.deps = [
   'pig': [
     'pig': "org.apache.pig:pig:${versions['pig']}:h2",
     'pigunit': "org.apache.pig:pigunit:${versions['pig']}"
+  ],
+  'spark': [
+    'sql': "org.apache.spark:spark-sql_2.11:${versions['spark']}",
+    'hive': "org.apache.spark:spark-hive_2.11:${versions['spark']}"
+  ],
+  'spark3': [
+    'hive': "org.apache.spark:spark-hive_2.12:${versions['spark3']}"
   ]
 ]


### PR DESCRIPTION
Tested on cluster:
```
scala> import com.linkedin.coral.spark.TransportableUDFMap
import com.linkedin.coral.spark.TransportableUDFMap

scala> TransportableUDFMap.lookup("com.linkedin.dali.udf.date.hive.DateFormatToEpoch")
com.linkedin.coral.spark.exceptions.UnsupportedUDFException: Coral Spark does not support following UDF: Transport UDF for class 'com.linkedin.dali.udf.date.hive.DateFormatToEpoch' is not supported for scala SCALA_2_12, please contact the UDF owner for upgrade
  at com.linkedin.coral.spark.TransportableUDFMap.lambda$null$0(TransportableUDFMap.java:200)
  at java.util.Optional.orElseThrow(Optional.java:290)
  at com.linkedin.coral.spark.TransportableUDFMap.lambda$lookup$1(TransportableUDFMap.java:199)
  at java.util.Optional.map(Optional.java:215)
  at com.linkedin.coral.spark.TransportableUDFMap.lookup(TransportableUDFMap.java:197)
  ... 85 elided

```

@wmoustafa @funcheetah 