### PR TITLE
Make SchemaUtilities be independent on ...hive.serde2.avro.AvroSerdeUtils

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvro.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvro.java
@@ -24,7 +24,7 @@ import org.codehaus.jackson.node.JsonNodeFactory;
 
 import com.linkedin.coral.com.google.common.base.Preconditions;
 
-import static org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils.*;
+import static com.linkedin.coral.schema.avro.AvroSerdeUtils.*;
 
 
 /**

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -39,9 +39,8 @@ import com.linkedin.coral.com.google.common.base.Preconditions;
 import com.linkedin.coral.com.google.common.base.Strings;
 import com.linkedin.coral.schema.avro.exceptions.SchemaNotFoundException;
 
+import static com.linkedin.coral.schema.avro.AvroSerdeUtils.*;
 import static org.apache.avro.Schema.Type.NULL;
-import static org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils.getOtherTypeFromNullableType;
-import static org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils.isNullableType;
 
 
 class SchemaUtilities {


### PR DESCRIPTION
AvroSerdeUtils in org.apache.hadoop.hive.serde2.avro package is an internal Utils function.
If SchemaUtilities depends on that, it may cause potential issue when coral-schema is shaded in referred packaged.
Let's make SchemaUtilities depending on the coral-schema's interal AvroSerdeUtils which is a partial copy of org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils.  