### PR TITLE
coral-hive: use default catalog and default schema in CalciteCatalogReader

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/RelContextProvider.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/RelContextProvider.java
@@ -25,11 +25,13 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitDef;
 import org.apache.calcite.plan.volcano.VolcanoPlanner;
 import org.apache.calcite.prepare.CalciteCatalogReader;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.runtime.Hook;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.util.ChainedSqlOperatorTable;
+import org.apache.calcite.sql.validate.SqlNameMatchers;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.Frameworks;
@@ -40,6 +42,7 @@ import com.linkedin.coral.hive.hive2rel.functions.HiveFunction;
 import com.linkedin.coral.hive.hive2rel.functions.HiveFunctionRegistry;
 import com.linkedin.coral.hive.hive2rel.functions.StaticHiveFunctionRegistry;
 import com.linkedin.coral.hive.hive2rel.parsetree.ParseTreeBuilder;
+import org.apache.calcite.util.Util;
 
 import static com.linkedin.coral.hive.hive2rel.HiveSqlConformance.HIVE_SQL;
 
@@ -169,6 +172,21 @@ public class RelContextProvider {
   }
 
   /**
+   * This class allows CalciteCatalogReader to have multiple schemaPaths, for example:
+   * ["hive", "default"], ["hive"], and []
+   */
+  public static class MultiSchemaPathCalciteCatalogReader extends CalciteCatalogReader {
+
+    public MultiSchemaPathCalciteCatalogReader(CalciteSchema rootSchema, List<List<String>> schemaPathList,
+                                               RelDataTypeFactory typeFactory, CalciteConnectionConfig config) {
+      super(rootSchema, SqlNameMatchers.withCaseSensitive(config != null && config.caseSensitive()),
+              Util.immutableCopy(schemaPathList),
+              typeFactory, config
+      );
+    }
+  }
+
+  /**
    * Gets calcite catalog reader.
    *
    * @return the calcite catalog reader
@@ -183,8 +201,16 @@ public class RelContextProvider {
       connectionConfig = new CalciteConnectionConfigImpl(properties);
     }
     if (catalogReader == null) {
-      catalogReader = new CalciteCatalogReader(config.getDefaultSchema().unwrap(CalciteSchema.class),
-          ImmutableList.of(HiveSchema.ROOT_SCHEMA), getRelBuilder().getTypeFactory(), connectionConfig);
+      catalogReader = new MultiSchemaPathCalciteCatalogReader(
+              config.getDefaultSchema().unwrap(CalciteSchema.class),
+              ImmutableList.of(
+                      ImmutableList.of(HiveSchema.ROOT_SCHEMA, HiveSchema.DEFAULT_DB),
+                      ImmutableList.of(HiveSchema.ROOT_SCHEMA),
+                      ImmutableList.of()
+              ),
+              getRelBuilder().getTypeFactory(),
+              connectionConfig
+      );
     }
     return catalogReader;
   }

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/RelContextProvider.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/RelContextProvider.java
@@ -37,12 +37,12 @@ import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.Programs;
 import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.Util;
 
 import com.linkedin.coral.hive.hive2rel.functions.HiveFunction;
 import com.linkedin.coral.hive.hive2rel.functions.HiveFunctionRegistry;
 import com.linkedin.coral.hive.hive2rel.functions.StaticHiveFunctionRegistry;
 import com.linkedin.coral.hive.hive2rel.parsetree.ParseTreeBuilder;
-import org.apache.calcite.util.Util;
 
 import static com.linkedin.coral.hive.hive2rel.HiveSqlConformance.HIVE_SQL;
 
@@ -178,11 +178,9 @@ public class RelContextProvider {
   public static class MultiSchemaPathCalciteCatalogReader extends CalciteCatalogReader {
 
     public MultiSchemaPathCalciteCatalogReader(CalciteSchema rootSchema, List<List<String>> schemaPathList,
-                                               RelDataTypeFactory typeFactory, CalciteConnectionConfig config) {
+        RelDataTypeFactory typeFactory, CalciteConnectionConfig config) {
       super(rootSchema, SqlNameMatchers.withCaseSensitive(config != null && config.caseSensitive()),
-              Util.immutableCopy(schemaPathList),
-              typeFactory, config
-      );
+          Util.immutableCopy(schemaPathList), typeFactory, config);
     }
   }
 
@@ -201,16 +199,10 @@ public class RelContextProvider {
       connectionConfig = new CalciteConnectionConfigImpl(properties);
     }
     if (catalogReader == null) {
-      catalogReader = new MultiSchemaPathCalciteCatalogReader(
-              config.getDefaultSchema().unwrap(CalciteSchema.class),
-              ImmutableList.of(
-                      ImmutableList.of(HiveSchema.ROOT_SCHEMA, HiveSchema.DEFAULT_DB),
-                      ImmutableList.of(HiveSchema.ROOT_SCHEMA),
-                      ImmutableList.of()
-              ),
-              getRelBuilder().getTypeFactory(),
-              connectionConfig
-      );
+      catalogReader = new MultiSchemaPathCalciteCatalogReader(config.getDefaultSchema().unwrap(CalciteSchema.class),
+          ImmutableList.of(ImmutableList.of(HiveSchema.ROOT_SCHEMA, HiveSchema.DEFAULT_DB),
+              ImmutableList.of(HiveSchema.ROOT_SCHEMA), ImmutableList.of()),
+          getRelBuilder().getTypeFactory(), connectionConfig);
     }
     return catalogReader;
   }

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -626,20 +626,6 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
     List<SqlNode> sqlNodes = visitChildren(node, ctx);
     List<String> names =
         sqlNodes.stream().map(s -> ((SqlIdentifier) s).names).flatMap(List::stream).collect(Collectors.toList());
-    // TODO: these should be configured in or transformed through
-    // a set of rules
-    if (names.size() == 1) {
-      if (!config.defaultDBName.isEmpty()) {
-        names.add(0, config.defaultDBName);
-      }
-      if (!config.catalogName.isEmpty()) {
-        names.add(0, config.catalogName);
-      }
-    } else if (names.size() == 2) {
-      if (!config.catalogName.isEmpty()) {
-        names.add(0, config.catalogName);
-      }
-    }
 
     return new SqlIdentifier(names, ZERO);
   }


### PR DESCRIPTION
coral-hive: use default catalog and default schema in CalciteCatalogReader instead of hacking the AST tree in ParseTreeBuilder

This is an existing TODO item in the code, which is fixed by this commit.

`./gradlew clean build` passes with this commit.