### PR TITLE
Parse Hive SQL surrounded by parentheses

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -127,7 +127,7 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
     checkNotNull(hiveView);
     String stringViewExpandedText = null;
     if (hiveView.getTableType().equals("VIRTUAL_VIEW")) {
-      stringViewExpandedText = hiveView.getViewExpandedText();
+      stringViewExpandedText = trimParenthesis(hiveView.getViewExpandedText());
     } else {
       // It is a table, not a view.
       stringViewExpandedText = "SELECT * FROM " + hiveView.getDbName() + "." + hiveView.getTableName();
@@ -158,7 +158,7 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
    * @return Calcite SqlNode representing parse tree that calcite framework can understand
    */
   public SqlNode processSql(String sql) {
-    return process(sql, null);
+    return process(trimParenthesis(sql), null);
   }
 
   SqlNode process(String sql, @Nullable Table hiveView) {
@@ -840,6 +840,14 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
     } else {
       return hiveMetastoreClient;
     }
+  }
+
+  private static String trimParenthesis(String value) {
+    String str = value.trim();
+    if (str.startsWith("(") && str.endsWith(")")) {
+      return trimParenthesis(str.substring(1, str.length() - 1));
+    }
+    return str;
   }
 
   public static class Config {

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
@@ -101,6 +101,11 @@ public class ParseTreeBuilderTest {
         // order by
         "SELECT * from foo order by a",
 
+        // outer parenthesis
+        "( SELECT 1 AS c1 )", " ( SELECT 1 AS c1 ) ", "(( SELECT 1 AS c1 ))", "( ( SELECT 1 AS c1 ) )",
+        "(( SELECT 1 AS c1 ) )", "( ( SELECT 1 AS c1 ))",
+        "(SELECT a,b from foo AS f where NOT EXISTS (select x from bar))",
+
         //NiladicParentheses
         "SELECT current_timestamp", "SELECT current_date"
 


### PR DESCRIPTION
HMS view_expanded_text allows outer parentheses. 

```
SELECT tbls.view_expanded_text FROM sys.tbls LIMIT 1;

+--------------------------+
| tbls.view_expanded_text  |
+--------------------------+
| ( (select 1 as `c1`) )   |
+--------------------------+
```

Relates to https://github.com/trinodb/trino/issues/8789