### PR TITLE
Return DATE type in Hive date() function

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -268,7 +268,7 @@ public class StaticHiveFunctionRegistry implements HiveFunctionRegistry {
     createAddUserDefinedFunction("unix_timestamp", BIGINT,
         family(ImmutableList.of(SqlTypeFamily.STRING, SqlTypeFamily.STRING), optionalOrd(ImmutableList.of(0, 1))));
     createAddUserDefinedFunction("to_date", HiveReturnTypes.STRING, or(STRING, DATETIME));
-    createAddUserDefinedFunction("date", HiveReturnTypes.STRING, or(STRING, DATETIME));
+    createAddUserDefinedFunction("date", DATE, or(STRING, DATETIME));
     createAddUserDefinedFunction("year", ReturnTypes.INTEGER, STRING);
     createAddUserDefinedFunction("quarter", ReturnTypes.INTEGER, STRING);
     createAddUserDefinedFunction("month", ReturnTypes.INTEGER, STRING);


### PR DESCRIPTION
I'm not sure about old version's and other distribution's behavior, but it returns `DATE` type in HDP 3.1. 

```sql
> CREATE VIEW view_with_date AS SELECT date('2021-08-20') as a;

> DESC view_with_date;

+-----------+------------+----------+
| col_name  | data_type  | comment  |
+-----------+------------+----------+
| a         | date       |          |
+-----------+------------+----------+
```