### PR TITLE
coral-hive: added window function support

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -22,6 +22,7 @@ import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlOperandCountRange;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SameOperandTypeChecker;
@@ -73,6 +74,24 @@ public class StaticHiveFunctionRegistry implements HiveFunctionRegistry {
     addFunctionEntry("avg", AVG);
     addFunctionEntry("min", MIN);
     addFunctionEntry("max", MAX);
+
+    // window functions
+    addFunctionEntry("row_number", ROW_NUMBER);
+    addFunctionEntry("rank", SqlStdOperatorTable.RANK); // qualification required due to naming conflict
+    addFunctionEntry("dense_rank", DENSE_RANK);
+    addFunctionEntry("cume_dist", CUME_DIST);
+    addFunctionEntry("percent_rank", PERCENT_RANK);
+    addFunctionEntry("first_value", FIRST_VALUE);
+    addFunctionEntry("last_value", LAST_VALUE);
+    addFunctionEntry("nth_value", NTH_VALUE);
+    addFunctionEntry("lag", LAG);
+    addFunctionEntry("lead", LEAD);
+    addFunctionEntry("stddev", STDDEV);
+    addFunctionEntry("stddev_samp", STDDEV_SAMP);
+    addFunctionEntry("stddev_pop", STDDEV_POP);
+    addFunctionEntry("variance", VARIANCE);
+    addFunctionEntry("var_samp", VAR_SAMP);
+    addFunctionEntry("var_pop", VAR_POP);
 
     //addFunctionEntry("in", HiveInOperator.IN);
     FUNCTION_MAP.put("in", HiveFunction.IN);

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/AbstractASTVisitor.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/AbstractASTVisitor.java
@@ -188,6 +188,7 @@ public abstract class AbstractASTVisitor<R, C> {
       case HiveParser.KW_ARRAY:
       case HiveParser.KW_MAP:
       case HiveParser.KW_STRUCT:
+      case HiveParser.KW_UNBOUNDED:
         return visitKeywordLiteral(node, ctx);
 
       case HiveParser.TOK_BOOLEAN:
@@ -266,6 +267,30 @@ public abstract class AbstractASTVisitor<R, C> {
       case HiveParser.TOK_CTE:
         return visitCTE(node, ctx);
 
+      case HiveParser.TOK_WINDOWSPEC:
+        return visitWindowSpec(node, ctx);
+
+      case HiveParser.TOK_PARTITIONINGSPEC:
+        return visitPartitioningSpec(node, ctx);
+
+      case HiveParser.TOK_DISTRIBUTEBY:
+        return visitDistributeBy(node, ctx);
+
+      case HiveParser.TOK_WINDOWRANGE:
+        return visitWindowRange(node, ctx);
+
+      case HiveParser.TOK_WINDOWVALUES:
+        return visitWindowValues(node, ctx);
+
+      case HiveParser.KW_PRECEDING:
+        return visitPreceding(node, ctx);
+
+      case HiveParser.KW_FOLLOWING:
+        return visitFollowing(node, ctx);
+
+      case HiveParser.KW_CURRENT:
+        return visitCurrentRow(node, ctx);
+
       default:
         // return visitChildren(node, ctx);
         throw new UnhandledASTTokenException(node);
@@ -287,6 +312,39 @@ public abstract class AbstractASTVisitor<R, C> {
 
   protected List<R> visitChildren(List<Node> nodes, C ctx) {
     return nodes.stream().map(n -> visit((ASTNode) n, ctx)).collect(Collectors.toList());
+  }
+
+  protected R visitTheOnlyChildByType(ASTNode node, C ctx, int nodeType) {
+    R result = visitOptionalChildByType(node, ctx, nodeType);
+    if (result == null) {
+      throw new UnexpectedASTChildCountException(node, 1, 0, nodeType);
+    }
+    return result;
+  }
+
+  protected R visitOptionalChildByType(ASTNode node, C ctx, int nodeType) {
+    List<R> results = visitChildrenByType(node, ctx, nodeType);
+    if (results == null || results.isEmpty()) {
+      return null;
+    }
+    if (results.size() > 1) {
+      throw new UnexpectedASTChildCountException(node, 1, results.size(), nodeType);
+    }
+    return results.get(0);
+  }
+
+  protected List<R> visitChildrenByType(ASTNode node, C ctx, int nodeType) {
+    Preconditions.checkNotNull(node, ctx);
+    Preconditions.checkNotNull(ctx);
+    if (node.getChildren() == null) {
+      return null;
+    }
+    return visitChildrenByType(node.getChildren(), ctx, nodeType);
+  }
+
+  protected List<R> visitChildrenByType(List<Node> nodes, C ctx, int nodeType) {
+    return nodes.stream().filter(node -> ((ASTNode) node).getType() == nodeType).map(n -> visit((ASTNode) n, ctx))
+        .collect(Collectors.toList());
   }
 
   protected R visitTabAlias(ASTNode node, C ctx) {
@@ -537,4 +595,35 @@ public abstract class AbstractASTVisitor<R, C> {
     return visitChildren(node, ctx).get(0);
   }
 
+  protected R visitWindowSpec(ASTNode node, C ctx) {
+    return visitChildren(node, ctx).get(0);
+  }
+
+  protected R visitPartitioningSpec(ASTNode node, C ctx) {
+    return visitChildren(node, ctx).get(0);
+  }
+
+  protected R visitDistributeBy(ASTNode node, C ctx) {
+    return visitChildren(node, ctx).get(0);
+  }
+
+  protected R visitWindowRange(ASTNode node, C ctx) {
+    return visitChildren(node, ctx).get(0);
+  }
+
+  protected R visitWindowValues(ASTNode node, C ctx) {
+    return visitChildren(node, ctx).get(0);
+  }
+
+  protected R visitPreceding(ASTNode node, C ctx) {
+    return visitChildren(node, ctx).get(0);
+  }
+
+  protected R visitFollowing(ASTNode node, C ctx) {
+    return visitChildren(node, ctx).get(0);
+  }
+
+  protected R visitCurrentRow(ASTNode node, C ctx) {
+    return visitChildren(node, ctx).get(0);
+  }
 }

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/AbstractASTVisitor.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/AbstractASTVisitor.java
@@ -314,14 +314,6 @@ public abstract class AbstractASTVisitor<R, C> {
     return nodes.stream().map(n -> visit((ASTNode) n, ctx)).collect(Collectors.toList());
   }
 
-  protected R visitTheOnlyChildByType(ASTNode node, C ctx, int nodeType) {
-    R result = visitOptionalChildByType(node, ctx, nodeType);
-    if (result == null) {
-      throw new UnexpectedASTChildCountException(node, nodeType, 1, 0);
-    }
-    return result;
-  }
-
   protected R visitOptionalChildByType(ASTNode node, C ctx, int nodeType) {
     List<R> results = visitChildrenByType(node, ctx, nodeType);
     if (results == null || results.isEmpty()) {

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/AbstractASTVisitor.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/AbstractASTVisitor.java
@@ -317,7 +317,7 @@ public abstract class AbstractASTVisitor<R, C> {
   protected R visitTheOnlyChildByType(ASTNode node, C ctx, int nodeType) {
     R result = visitOptionalChildByType(node, ctx, nodeType);
     if (result == null) {
-      throw new UnexpectedASTChildCountException(node, 1, 0, nodeType);
+      throw new UnexpectedASTChildCountException(node, nodeType, 1, 0);
     }
     return result;
   }
@@ -328,7 +328,7 @@ public abstract class AbstractASTVisitor<R, C> {
       return null;
     }
     if (results.size() > 1) {
-      throw new UnexpectedASTChildCountException(node, 1, results.size(), nodeType);
+      throw new UnexpectedASTChildCountException(node, nodeType, 1, results.size());
     }
     return results.get(0);
   }

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -580,8 +580,13 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
     // Special treatment for Window Function
     SqlNode lastSqlOperand = sqlOperands.get(sqlOperands.size() - 1);
     if (lastSqlOperand instanceof SqlWindow) {
-      // In Hive, "func() OVER (PARTITIONED BY ...)" will have the window spec as the last operand of the function "func".
-      // In Calcite, it's a SqlBasicCall("OVER", ["func", SqlWindow])
+      // For a SQL example of "func() OVER (PARTITIONED BY ...)":
+      // In Hive, TOK_WINDOWSPEC (the window spec) is the last operand of the function "func":
+      //    TOK_FUNCTION will have 1+N+1 children, where the first is the function name, the last is TOK_WINDOWSPEC
+      //    and everything in between are the operands of the function
+      // In Calcite, SqlWindow (the window spec) is a sibling of the function "func":
+      //    SqlBasicCall("OVER") will have 2 children: "func" and SqlWindow
+      /** See {@link #visitWindowSpec(ASTNode, ParseContext)} for SQL, AST Tree and SqlNode Tree examples */
       SqlNode func =
           hiveFunction.createCall(sqlOperands.get(0), sqlOperands.subList(1, sqlOperands.size() - 1), quantifier);
       SqlNode window = (SqlWindow) lastSqlOperand;

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -975,7 +975,7 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
   @Override
   protected SqlNode visitPreceding(ASTNode node, ParseContext ctx) {
     SqlNode sqlNode = visitChildren(node, ctx).get(0);
-    if (sqlNode.getKind() == SqlKind.LITERAL && sqlNode.toString().equals("'UNBOUNDED'")) {
+    if (sqlNode.getKind() == SqlKind.LITERAL && sqlNode.toString().equalsIgnoreCase("'UNBOUNDED'")) {
       return SqlWindow.createUnboundedPreceding(ZERO);
     } else {
       return SqlWindow.createPreceding(sqlNode, ZERO);
@@ -985,7 +985,7 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
   @Override
   protected SqlNode visitFollowing(ASTNode node, ParseContext ctx) {
     SqlNode sqlNode = visitChildren(node, ctx).get(0);
-    if (sqlNode.getKind() == SqlKind.LITERAL && sqlNode.toString().equals("'UNBOUNDED'")) {
+    if (sqlNode.getKind() == SqlKind.LITERAL && sqlNode.toString().equalsIgnoreCase("'UNBOUNDED'")) {
       return SqlWindow.createUnboundedFollowing(ZERO);
     } else {
       return SqlWindow.createFollowing(sqlNode, ZERO);

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -927,8 +927,8 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
     SqlWindow windowValues = (SqlWindow) visitOptionalChildByType(node, ctx, HiveParser.TOK_WINDOWVALUES);
     SqlWindow window = windowRange != null ? windowRange : windowValues;
 
-    return new SqlWindow(ZERO, null, null, partitionSpec == null ? null : partitionSpec.getPartitionList(),
-        partitionSpec == null ? null : partitionSpec.getOrderList(),
+    return new SqlWindow(ZERO, null, null, partitionSpec == null ? SqlNodeList.EMPTY : partitionSpec.getPartitionList(),
+        partitionSpec == null ? SqlNodeList.EMPTY : partitionSpec.getOrderList(),
         SqlLiteral.createBoolean(windowRange != null, ZERO), window == null ? null : window.getLowerBound(),
         window == null ? null : window.getUpperBound(), null);
   }
@@ -937,8 +937,8 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
   protected SqlNode visitPartitioningSpec(ASTNode node, ParseContext ctx) {
     SqlNode partitionList = visitOptionalChildByType(node, ctx, HiveParser.TOK_DISTRIBUTEBY);
     SqlNode orderList = visitOptionalChildByType(node, ctx, HiveParser.TOK_ORDERBY);
-    return new SqlWindow(ZERO, null, null, (SqlNodeList) partitionList, (SqlNodeList) orderList, null, null, null,
-        null);
+    return new SqlWindow(ZERO, null, null, partitionList != null ? (SqlNodeList) partitionList : SqlNodeList.EMPTY,
+        orderList != null ? (SqlNodeList) orderList : SqlNodeList.EMPTY, null, null, null, null);
   }
 
   @Override

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -899,7 +899,7 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
     // See Apache Hive source code: https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java#L4339
     // "private RelNode genSelectForWindowing(QB qb, RelNode srcRel, HashSet<ColumnInfo> newColumns)"
 
-    // SQL:
+    // Example SQL:
     //   ROW_NUMBER() OVER (PARTITION BY x ORDER BY y ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING
     // Hive Antlr ASTNode Tree:
     //TOK_FUNCTION

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -169,7 +169,6 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
     ParseDriver pd = new CoralParseDriver();
     try {
       ASTNode root = pd.parse(sql);
-      System.out.println("AST DUMP: \n" + root.dump());
       return processAST(root, hiveView);
     } catch (ParseException e) {
       throw new RuntimeException(e);

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/UnexpectedASTChildCountException.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/UnexpectedASTChildCountException.java
@@ -8,12 +8,13 @@ package com.linkedin.coral.hive.hive2rel.parsetree;
 import com.linkedin.coral.hive.hive2rel.parsetree.parser.ASTNode;
 
 
-public class UnhandledASTTokenException extends RuntimeException {
+public class UnexpectedASTChildCountException extends RuntimeException {
 
   private final ASTNode node;
 
-  public UnhandledASTTokenException(ASTNode node) {
-    super(String.format("Unhandled Hive AST token %d %s, tree: %s", node.getType(), node.getText(), node.dump()));
+  public UnexpectedASTChildCountException(ASTNode node, int type, int expected, int actual) {
+    super(String.format("Expected %d but got %d children of type %d under Hive AST token %s, tree: %s", expected,
+        actual, type, node.getText(), node.dump()));
     this.node = node;
   }
 

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
@@ -108,11 +108,11 @@ public class HiveToRelConverterTest {
     // Test if the code can handle the use of window functions
     String sql = "SELECT ROW_NUMBER() OVER (PARTITION BY a ORDER BY b) AS rid FROM foo";
     RelNode rel = converter.convertSql(sql);
-    RelBuilder relBuilder = createRelBuilder();
-    // TODO: Make expected more specific and verifyRel with the whole tree
-    RelNode expected = relBuilder.scan(ImmutableList.of("hive", "default", "foo"))
-        .project(ImmutableList.of(relBuilder.field("b")), ImmutableList.of(), true).build();
-    verifyRel(rel, expected);
+    String relString = relToStr(rel);
+    String expected =
+        "LogicalProject(rid=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $1 ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)])\n"
+            + "  LogicalTableScan(table=[[hive, default, foo]])\n";
+    assertEquals(relString, expected);
   }
 
   @Test
@@ -120,49 +120,73 @@ public class HiveToRelConverterTest {
     // Test if the code can handle the use of window functions with rows
     String sql = "SELECT MIN(c) OVER (PARTITION BY a ORDER BY b ROWS UNBOUNDED PRECEDING) AS min_c FROM foo";
     RelNode rel = converter.convertSql(sql);
-    RelBuilder relBuilder = createRelBuilder();
-    // TODO: Make expected more specific and verifyRel with the whole tree
-    RelNode expected = relBuilder.scan(ImmutableList.of("hive", "default", "foo"))
-        .project(ImmutableList.of(relBuilder.field("b")), ImmutableList.of(), true).build();
-    verifyRel(rel, expected);
+    String relString = relToStr(rel);
+    String expected =
+        "LogicalProject(min_c=[MIN($2) OVER (PARTITION BY $0 ORDER BY $1 ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)])\n"
+            + "  LogicalTableScan(table=[[hive, default, foo]])\n";
+    assertEquals(relString, expected);
   }
 
   @Test
   public void testWindowWithRangeUnboundedPreceding() {
     // Test if the code can handle the use of window functions with range
-    String sql = "SELECT MIN(c) OVER (PARTITION BY a ORDER BY b RANGE UNBOUNDED PRECEDING) AS min_c FROM foo";
+    String sql = "SELECT VARIANCE(c) OVER (PARTITION BY a ORDER BY b RANGE UNBOUNDED PRECEDING) AS var_c FROM foo";
     RelNode rel = converter.convertSql(sql);
-    RelBuilder relBuilder = createRelBuilder();
-    // TODO: Make expected more specific and verifyRel with the whole tree
-    RelNode expected = relBuilder.scan(ImmutableList.of("hive", "default", "foo"))
-        .project(ImmutableList.of(relBuilder.field("b")), ImmutableList.of(), true).build();
-    verifyRel(rel, expected);
+    String relString = relToStr(rel);
+    String expected =
+        "LogicalProject(var_c=[/(-(CASE(>(COUNT(*($2, $2)) OVER (PARTITION BY $0 ORDER BY $1 RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), 0), CAST($SUM0(*($2, $2)) OVER (PARTITION BY $0 ORDER BY $1 RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)):DOUBLE, null:DOUBLE), /(*(CASE(>(COUNT($2) OVER (PARTITION BY $0 ORDER BY $1 RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), 0), CAST($SUM0($2) OVER (PARTITION BY $0 ORDER BY $1 RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)):DOUBLE, null:DOUBLE), CASE(>(COUNT($2) OVER (PARTITION BY $0 ORDER BY $1 RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), 0), CAST($SUM0($2) OVER (PARTITION BY $0 ORDER BY $1 RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)):DOUBLE, null:DOUBLE)), CAST(COUNT($2) OVER (PARTITION BY $0 ORDER BY $1 RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)):DOUBLE NOT NULL)), CASE(=(COUNT($2) OVER (PARTITION BY $0 ORDER BY $1 RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), 1), null:BIGINT, CAST(-(COUNT($2) OVER (PARTITION BY $0 ORDER BY $1 RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), 1)):BIGINT))])\n"
+            + "  LogicalTableScan(table=[[hive, default, foo]])\n";
+    assertEquals(relString, expected);
   }
 
   @Test
   public void testWindowWithRowsPrecedingAndFollowing() {
     // Test if the code can handle the use of window functions with "rows between" and "current row"
     String sql =
-        "SELECT MIN(c) OVER (PARTITION BY a ORDER BY b ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS min_c FROM foo";
+        "SELECT FIRST_VALUE(c) OVER (PARTITION BY a ORDER BY b ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS first_value_c FROM foo";
     RelNode rel = converter.convertSql(sql);
-    RelBuilder relBuilder = createRelBuilder();
-    // TODO: Make expected more specific and verifyRel with the whole tree
-    RelNode expected = relBuilder.scan(ImmutableList.of("hive", "default", "foo"))
-        .project(ImmutableList.of(relBuilder.field("b")), ImmutableList.of(), true).build();
-    verifyRel(rel, expected);
+    String relString = relToStr(rel);
+    String expected =
+        "LogicalProject(first_value_c=[FIRST_VALUE($2) OVER (PARTITION BY $0 ORDER BY $1 ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)])\n"
+            + "  LogicalTableScan(table=[[hive, default, foo]])\n";
+    assertEquals(relString, expected);
   }
 
   @Test
   public void testWindowWithRowsPrecedingAndFollowingCurrentRow() {
     // Test if the code can handle the use of window functions with "rows between" and "current row"
     String sql =
-        "SELECT MIN(c) OVER (PARTITION BY a ORDER BY b ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS min_c FROM foo";
+        "SELECT LAST_VALUE(c) OVER (PARTITION BY a ORDER BY b ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) FROM foo";
     RelNode rel = converter.convertSql(sql);
-    RelBuilder relBuilder = createRelBuilder();
-    // TODO: Make expected more specific and verifyRel with the whole tree
-    RelNode expected = relBuilder.scan(ImmutableList.of("hive", "default", "foo"))
-        .project(ImmutableList.of(relBuilder.field("b")), ImmutableList.of(), true).build();
-    verifyRel(rel, expected);
+    String relString = relToStr(rel);
+    String expected =
+        "LogicalProject(EXPR$0=[LAST_VALUE($2) OVER (PARTITION BY $0 ORDER BY $1 ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING)])\n"
+            + "  LogicalTableScan(table=[[hive, default, foo]])\n";
+    assertEquals(relString, expected);
+  }
+
+  @Test
+  public void testWindowWithNoPartition() {
+    // Test if the code can handle the use of window functions with no "partition by"
+    String sql = "SELECT RANK() OVER (ORDER BY b) AS rank FROM foo";
+    RelNode rel = converter.convertSql(sql);
+    String relString = relToStr(rel);
+    String expected =
+        "LogicalProject(rank=[RANK() OVER (ORDER BY $1 RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)])\n"
+            + "  LogicalTableScan(table=[[hive, default, foo]])\n";
+    assertEquals(relString, expected);
+  }
+
+  @Test
+  public void testWindowWithNoPartitionNoOrder() {
+    // Test if the code can handle the use of window functions with no "partition by" or "order by"
+    String sql = "SELECT a, MAX(c) OVER () AS max_c FROM foo";
+    RelNode rel = converter.convertSql(sql);
+    String relString = relToStr(rel);
+    String expected =
+        "LogicalProject(a=[$0], max_c=[MAX($2) OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)])\n"
+            + "  LogicalTableScan(table=[[hive, default, foo]])\n";
+    assertEquals(relString, expected);
   }
 
   @Test

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
@@ -104,6 +104,68 @@ public class HiveToRelConverterTest {
   }
 
   @Test
+  public void testWindowSpec() {
+    // Test if the code can handle the use of window functions
+    String sql = "SELECT ROW_NUMBER() OVER (PARTITION BY a ORDER BY b) AS rid FROM foo";
+    RelNode rel = converter.convertSql(sql);
+    RelBuilder relBuilder = createRelBuilder();
+    // TODO: Make expected more specific and verifyRel with the whole tree
+    RelNode expected = relBuilder.scan(ImmutableList.of("hive", "default", "foo"))
+        .project(ImmutableList.of(relBuilder.field("b")), ImmutableList.of(), true).build();
+    verifyRel(rel, expected);
+  }
+
+  @Test
+  public void testWindowWithRowsUnboundedPreceding() {
+    // Test if the code can handle the use of window functions with rows
+    String sql = "SELECT MIN(c) OVER (PARTITION BY a ORDER BY b ROWS UNBOUNDED PRECEDING) AS min_c FROM foo";
+    RelNode rel = converter.convertSql(sql);
+    RelBuilder relBuilder = createRelBuilder();
+    // TODO: Make expected more specific and verifyRel with the whole tree
+    RelNode expected = relBuilder.scan(ImmutableList.of("hive", "default", "foo"))
+        .project(ImmutableList.of(relBuilder.field("b")), ImmutableList.of(), true).build();
+    verifyRel(rel, expected);
+  }
+
+  @Test
+  public void testWindowWithRangeUnboundedPreceding() {
+    // Test if the code can handle the use of window functions with range
+    String sql = "SELECT MIN(c) OVER (PARTITION BY a ORDER BY b RANGE UNBOUNDED PRECEDING) AS min_c FROM foo";
+    RelNode rel = converter.convertSql(sql);
+    RelBuilder relBuilder = createRelBuilder();
+    // TODO: Make expected more specific and verifyRel with the whole tree
+    RelNode expected = relBuilder.scan(ImmutableList.of("hive", "default", "foo"))
+        .project(ImmutableList.of(relBuilder.field("b")), ImmutableList.of(), true).build();
+    verifyRel(rel, expected);
+  }
+
+  @Test
+  public void testWindowWithRowsPrecedingAndFollowing() {
+    // Test if the code can handle the use of window functions with "rows between" and "current row"
+    String sql =
+        "SELECT MIN(c) OVER (PARTITION BY a ORDER BY b ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS min_c FROM foo";
+    RelNode rel = converter.convertSql(sql);
+    RelBuilder relBuilder = createRelBuilder();
+    // TODO: Make expected more specific and verifyRel with the whole tree
+    RelNode expected = relBuilder.scan(ImmutableList.of("hive", "default", "foo"))
+        .project(ImmutableList.of(relBuilder.field("b")), ImmutableList.of(), true).build();
+    verifyRel(rel, expected);
+  }
+
+  @Test
+  public void testWindowWithRowsPrecedingAndFollowingCurrentRow() {
+    // Test if the code can handle the use of window functions with "rows between" and "current row"
+    String sql =
+        "SELECT MIN(c) OVER (PARTITION BY a ORDER BY b ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) AS min_c FROM foo";
+    RelNode rel = converter.convertSql(sql);
+    RelBuilder relBuilder = createRelBuilder();
+    // TODO: Make expected more specific and verifyRel with the whole tree
+    RelNode expected = relBuilder.scan(ImmutableList.of("hive", "default", "foo"))
+        .project(ImmutableList.of(relBuilder.field("b")), ImmutableList.of(), true).build();
+    verifyRel(rel, expected);
+  }
+
+  @Test
   public void testSelectNull() {
     final String sql = "SELECT NULL as f";
     RelNode rel = toRel(sql);

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
@@ -107,12 +107,18 @@ public class ParseTreeBuilderTest {
         "(SELECT a,b from foo AS f where NOT EXISTS (select x from bar))",
 
         //NiladicParentheses
-        "SELECT current_timestamp", "SELECT current_date"
+        "SELECT current_timestamp", "SELECT current_date",
 
-    // window
-    // Not yet implemented
-    // "SELECT a, rank() over (partition by b order by c asc) from foo group by a",
-    );
+        // window
+        "SELECT a, rank() over (partition by b order by c asc) from foo group by a",
+        "SELECT ROW_NUMBER() OVER (PARTITION BY a ORDER BY b) AS rid FROM foo",
+        "SELECT DENSE_RANK() OVER (PARTITION BY a ORDER BY b DESC) AS rid FROM foo",
+        "SELECT CUME_DIST() OVER (PARTITION BY a ORDER BY b DESC) FROM foo",
+        "SELECT AVG(c) OVER (PARTITION BY a ORDER BY b ROWS UNBOUNDED PRECEDING) AS min_c FROM foo",
+        "SELECT FIRST_VALUE(c) OVER (PARTITION BY a ORDER BY b RANGE UNBOUNDED PRECEDING) AS min_c FROM foo",
+        "SELECT LAST_VALUE(c) OVER (PARTITION BY a ORDER BY b ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS min_c FROM foo",
+        "SELECT STDDEV(c) OVER (PARTITION BY a ORDER BY b RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING) AS min_c FROM foo",
+        "SELECT VARIANCE(c) OVER (PARTITION BY a ORDER BY b ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS min_c FROM foo");
     // We wrap the SQL to be tested here rather than wrap each SQL statement in the its own array in the constant
     return convertSql.stream().map(x -> new Object[] { x }).iterator();
   }

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
@@ -110,8 +110,8 @@ public class ParseTreeBuilderTest {
         "SELECT current_timestamp", "SELECT current_date",
 
         // window
-        "SELECT a, rank() over (partition by b order by c asc) from foo group by a",
-        "SELECT ROW_NUMBER() OVER (PARTITION BY a ORDER BY b) AS rid FROM foo",
+        "SELECT a, RANK() OVER (PARTITION BY b ORDER BY c asc) FROM foo GROUP BY a",
+        "SELECT ROW_NUMBER() OVER (ORDER BY b) AS rid FROM foo", "SELECT a, MAX(b) OVER () AS max_b FROM foo",
         "SELECT DENSE_RANK() OVER (PARTITION BY a ORDER BY b DESC) AS rid FROM foo",
         "SELECT CUME_DIST() OVER (PARTITION BY a ORDER BY b DESC) FROM foo",
         "SELECT AVG(c) OVER (PARTITION BY a ORDER BY b ROWS UNBOUNDED PRECEDING) AS min_c FROM foo",


### PR DESCRIPTION
New test cases in `ParseTreeBuilderTest.java` ensures that translations from Hive ASTNode Tree to Calcite SqlNode Tree are correctly done.

The test cases in `HiveToRelConverterTest.java` ensure that Calcite SqlNode Tree to Calcite RelNode Tree are successfully done.  The Calcite RelNode Tree validation requires some additional work to ensure the correctness (which is called out as TODO in the test cases).
