### PR TITLE
Apply fuzzy union to unions in and fix generic project issue in Coral-Trino

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionSqlRewriter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionSqlRewriter.java
@@ -214,7 +214,8 @@ class FuzzyUnionSqlRewriter extends SqlShuttle {
     for (final SqlNode node : leafNodes) {
       RelDataType fromNodeDataType = relContextProvider.getHiveSqlValidator().getValidatedNodeTypeIfKnown(node);
       if (fromNodeDataType == null) {
-        relContextProvider.getHiveSqlValidator().validate(node);
+        relContextProvider.getHiveSqlValidator()
+            .validate(node.accept(new FuzzyUnionSqlRewriter(tableName, relContextProvider)));
         fromNodeDataType = relContextProvider.getHiveSqlValidator().getValidatedNodeType(node);
       }
       leafNodeDataTypes.add(fromNodeDataType);

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionTest.java
@@ -212,4 +212,20 @@ public class FuzzyUnionTest {
     String expandedSql = nodeToStr(node);
     assertEquals(expandedSql, expectedSql);
   }
+
+  @Test
+  public void testFuzzyUnionInFromClause() throws TException {
+    String database = "fuzzy_union";
+    String view = "union_view_in_from_clause";
+    SqlNode node = getFuzzyUnionView(database, view);
+
+    String expectedSql = "SELECT \"a\"\n" + "FROM (SELECT *\n" + "FROM \"hive\".\"fuzzy_union\".\"tableb\"\n"
+        + "UNION ALL\n" + "SELECT \"a\", \"generic_project\"(\"b\", 'b') AS \"b\"\n"
+        + "FROM \"hive\".\"fuzzy_union\".\"tablec\") AS \"t0\"\n" + "UNION ALL\n" + "SELECT \"a\"\n"
+        + "FROM \"hive\".\"fuzzy_union\".\"tableb\"";
+
+    getRelContextProvider().getHiveSqlValidator().validate(node);
+    String expandedSql = nodeToStr(node);
+    assertEquals(expandedSql, expectedSql);
+  }
 }

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/TestUtils.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/TestUtils.java
@@ -92,6 +92,8 @@ public class TestUtils {
       driver.run("CREATE TABLE IF NOT EXISTS fuzzy_union.tableC(a int, b struct<b1:string>)");
       driver.run(
           "CREATE VIEW IF NOT EXISTS fuzzy_union.union_view_single_branch_evolved AS SELECT * from fuzzy_union.tableB union all SELECT * from fuzzy_union.tableC");
+      driver.run(
+          "CREATE VIEW IF NOT EXISTS fuzzy_union.union_view_in_from_clause AS SELECT a FROM (SELECT * FROM fuzzy_union.tableB UNION ALL SELECT * FROM fuzzy_union.tableC) t1 UNION ALL SELECT a FROM fuzzy_union.tableB t2");
       driver.run("ALTER TABLE fuzzy_union.tableC CHANGE COLUMN b b struct<b1:string, b2:int>");
 
       driver.run("CREATE TABLE IF NOT EXISTS fuzzy_union.tableD(a int, b struct<b1:string>)");

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/functions/GenericProjectToTrinoConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/functions/GenericProjectToTrinoConverter.java
@@ -13,7 +13,6 @@ import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rel.type.RelRecordType;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
-import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.ArraySqlType;
@@ -180,10 +179,9 @@ public class GenericProjectToTrinoConverter {
     //           [RexLiteral: 'col1, (k, v) -> transform(v , x -> cast(row(x.a) as row(a int)))']
     // The resolved SQL string will look like:
     //   'transform_values(col1, (k, v) -> transform(v , x -> cast(row(x.a) as row(a int))))'
-    RexInputRef transformColumn = (RexInputRef) call.getOperands().get(0);
     RexLiteral columnNameLiteral = (RexLiteral) call.getOperands().get(1);
     String transformColumnFieldName = RexLiteral.stringValue(columnNameLiteral);
-    RelDataType fromDataType = transformColumn.getType();
+    RelDataType fromDataType = call.getOperands().get(0).getType();
     RelDataType toDataType = call.getOperator().inferReturnType(null);
     switch (toDataType.getSqlTypeName()) {
       case ROW:


### PR DESCRIPTION
Change in `FuzzyUnionSqlRewriter`: apply fuzzy union to unions in `FROM`, like:
```
SELECT * 
FROM (
SELECT xxx
UNION ALL
SELECT xxx
)
```
otherwise, the validation will fail.

Change in `GenericProjectToTrinoConverter`: the type of `call.getOperands().get(0)` might not be `RexInputRef`, we can get the type of it directly without casting it to `RexInputRef`.

Tests:
1. Unit test, which will fail without this patch
2. Tested on affected views, could be translated well with this patch
3. Integration test, no regression