### PR TITLE
Avoid duplicating visit(SqlCall) FuzzyUnionSqlRewriter

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionSqlRewriter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionSqlRewriter.java
@@ -111,9 +111,7 @@ class FuzzyUnionSqlRewriter extends SqlShuttle {
       final RelDataType expectedDataType = getUnionDataType(call);
       call = addFuzzyUnionToUnionCall(call, expectedDataType);
     }
-    ArgHandler<SqlNode> argHandler = new CallCopyingArgHandler(call, false);
-    call.getOperator().acceptCall(this, call, false, argHandler);
-    return argHandler.result();
+    return super.visit(call);
   }
 
   /**

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionTest.java
@@ -29,7 +29,11 @@ public class FuzzyUnionTest {
   private SqlNode getFuzzyUnionView(String databaseName, String viewName) throws TException {
     SqlNode node = viewToSqlNode(databaseName, viewName);
     Table view = relContextProvider.getHiveSchema().getSubSchema(databaseName).getTable(viewName);
-    node.accept(new FuzzyUnionSqlRewriter(viewName, getRelContextProvider()));
+
+    // sanity check, in party with com.linkedin.coral.hive.hive2rel.HiveToRelConverter.convertView
+    if (view != null) {
+      node.accept(new FuzzyUnionSqlRewriter(viewName, getRelContextProvider()));
+    }
     return node;
   }
 


### PR DESCRIPTION
The edited code block in `FuzzyUnionSqlRewriter.java` is exactly the same as `super.visit(call)` as I read through the code base. We should directly invoke the method in super class instead of copying them. 

Also make `getFuzzyUnionView` method in test class in parity with `com.linkedin.coral.hive.hive2rel.HiveToRelConverter#convertView` 

Since there's no actual change in the functionality, there's no additional tests done other than existing unit tests. 