### PR TITLE
coral-hive: handle t.* correctly

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -6,6 +6,7 @@
 package com.linkedin.coral.hive.hive2rel.parsetree;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -36,6 +37,7 @@ import org.apache.calcite.sql.SqlWindow;
 import org.apache.calcite.sql.SqlWith;
 import org.apache.calcite.sql.SqlWithItem;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.hadoop.hive.metastore.api.Table;
 
@@ -451,7 +453,22 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
 
   @Override
   protected SqlNode visitAllColRef(ASTNode node, ParseContext ctx) {
-    return SqlIdentifier.star(ZERO);
+    List<SqlNode> children = visitChildren(node, ctx);
+    // This is to allow t.* and t.col.*
+    // In Hive ASTNode Tree, "t.*" has the following shape
+    // TOK_ALLCOLREF
+    // - TOK_TABLE_OR_COL
+    //   - "t"
+    List<String> names = new ArrayList<>();
+    if (children != null) {
+      for (SqlNode child : children) {
+        names.addAll(((SqlIdentifier) child).names);
+      }
+    }
+    names.add("*");
+    List<SqlParserPos> sqlParserPos = Collections.nCopies(names.size(), ZERO);
+    SqlNode star = SqlIdentifier.star(names, ZERO, sqlParserPos);
+    return star;
   }
 
   @Override

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -454,7 +454,7 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
   @Override
   protected SqlNode visitAllColRef(ASTNode node, ParseContext ctx) {
     List<SqlNode> children = visitChildren(node, ctx);
-    // This is to allow t.* and t.col.*
+    // This is to allow t.*
     // In Hive ASTNode Tree, "t.*" has the following shape
     // TOK_ALLCOLREF
     // - TOK_TABLE_OR_COL

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
@@ -88,6 +88,7 @@ public class ParseTreeBuilderTest {
         "SELECT * from foo left outer join bar on foo.a = bar.b",
         "SELECT * from foo right outer join bar on foo.a = bar.b",
         "SELECT * from foo full outer join bar on foo.a = bar.b",
+        "SELECT foo.*, bar.b from foo join bar on foo.a = bar.b",
 
         // subqeury
         "SELECT * from foo where a in (select a from bar)",

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -47,10 +47,9 @@ public class HiveToTrinoConverterTest {
   public Object[][] viewTestCasesProvider() {
     return new Object[][] {
 
-        { "test", "t_dot_star_view", "SELECT \"tablea\".\"a\" AS \"a\", \"tablea\".\"b\" AS \"b\", \"tablea0\".\"b\" AS \"tbb\"\n" +
-            "FROM \"test\".\"tablea\"\n" +
-            "INNER JOIN \"test\".\"tablea\" AS \"tablea0\" ON \"tablea\".\"a\" = \"tablea0\".\"a\""
-        },
+        { "test", "t_dot_star_view", "SELECT \"tablea\".\"a\" AS \"a\", \"tablea\".\"b\" AS \"b\", \"tablea0\".\"b\" AS \"tbb\"\n"
+            + "FROM \"test\".\"tablea\"\n"
+            + "INNER JOIN \"test\".\"tablea\" AS \"tablea0\" ON \"tablea\".\"a\" = \"tablea0\".\"a\"" },
 
         { "test", "fuzzy_union_view", "SELECT \"a\", \"b\"\nFROM ("
             + "SELECT \"a\", \"b\"\nFROM \"test\".\"tablea\"\nUNION ALL\n"

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -47,6 +47,11 @@ public class HiveToTrinoConverterTest {
   public Object[][] viewTestCasesProvider() {
     return new Object[][] {
 
+        { "test", "t_dot_star_view", "SELECT \"tablea\".\"a\" AS \"a\", \"tablea\".\"b\" AS \"b\", \"tablea0\".\"b\" AS \"tbb\"\n" +
+            "FROM \"test\".\"tablea\"\n" +
+            "INNER JOIN \"test\".\"tablea\" AS \"tablea0\" ON \"tablea\".\"a\" = \"tablea0\".\"a\""
+        },
+
         { "test", "fuzzy_union_view", "SELECT \"a\", \"b\"\nFROM ("
             + "SELECT \"a\", \"b\"\nFROM \"test\".\"tablea\"\nUNION ALL\n"
             + "SELECT \"a\", \"b\"\nFROM \"test\".\"tablea\") AS \"t1\"" },

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
@@ -312,6 +312,11 @@ public class TestUtils {
             + "from_utc_timestamp(a_date, 'America/Los_Angeles')" + "FROM test.table_from_utc_timestamp");
 
     run(driver, "CREATE VIEW IF NOT EXISTS test.pmod_view AS \n" + "SELECT pmod(-9, 4) FROM test.tableA");
+
+    run(driver, "CREATE VIEW IF NOT EXISTS test.t_dot_star_view AS \n"
+        + "SELECT ta.*, tb.b as tbb FROM test.tableA as ta JOIN test.tableA as tb ON ta.a = tb.a");
+
+
   }
 
   public static RelNode convertView(String db, String view) {

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
@@ -316,7 +316,6 @@ public class TestUtils {
     run(driver, "CREATE VIEW IF NOT EXISTS test.t_dot_star_view AS \n"
         + "SELECT ta.*, tb.b as tbb FROM test.tableA as ta JOIN test.tableA as tb ON ta.a = tb.a");
 
-
   }
 
   public static RelNode convertView(String db, String view) {


### PR DESCRIPTION
The existing code treats `t.*` as `*`, which is apparently incorrect.
