### PR TITLE
Improved calcite hive lateral view explode compatibility

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveRelBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveRelBuilder.java
@@ -1,6 +1,15 @@
+/**
+ * Copyright 2021 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
 package com.linkedin.coral.hive.hive2rel;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.google.common.base.Preconditions;
+
 import org.apache.calcite.plan.Context;
 import org.apache.calcite.plan.Contexts;
 import org.apache.calcite.plan.RelOptCluster;
@@ -14,10 +23,8 @@ import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.Pair;
-import com.linkedin.coral.hive.hive2rel.rel.HiveUncollect;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.linkedin.coral.hive.hive2rel.rel.HiveUncollect;
 
 import static org.apache.calcite.rel.core.RelFactories.DEFAULT_AGGREGATE_FACTORY;
 import static org.apache.calcite.rel.core.RelFactories.DEFAULT_EXCHANGE_FACTORY;
@@ -34,94 +41,80 @@ import static org.apache.calcite.rel.core.RelFactories.DEFAULT_SPOOL_FACTORY;
 import static org.apache.calcite.rel.core.RelFactories.DEFAULT_TABLE_SCAN_FACTORY;
 import static org.apache.calcite.rel.core.RelFactories.DEFAULT_VALUES_FACTORY;
 
+
 public class HiveRelBuilder extends RelBuilder {
 
-    private HiveRelBuilder(Context context, RelOptCluster cluster, RelOptSchema relOptSchema) {
-        super(context, cluster, relOptSchema);
+  private HiveRelBuilder(Context context, RelOptCluster cluster, RelOptSchema relOptSchema) {
+    super(context, cluster, relOptSchema);
+  }
+
+  /**
+   * Creates a RelBuilder.
+   */
+  public static RelBuilder create(FrameworkConfig config) {
+    return Frameworks.withPrepare(config, (cluster, relOptSchema, rootSchema,
+        statement) -> new HiveRelBuilder(config.getContext(), cluster, relOptSchema));
+  }
+
+  /** Creates a {@link RelBuilderFactory}, a partially-created RelBuilder.
+   * Just add a {@link RelOptCluster} and a {@link RelOptSchema} */
+  public static RelBuilderFactory proto(final Context context) {
+    return (cluster, schema) -> new HiveRelBuilder(context, cluster, schema);
+  }
+
+  public static final RelBuilderFactory LOGICAL_BUILDER =
+      HiveRelBuilder.proto(Contexts.of(DEFAULT_PROJECT_FACTORY, DEFAULT_FILTER_FACTORY, DEFAULT_JOIN_FACTORY,
+          DEFAULT_SORT_FACTORY, DEFAULT_EXCHANGE_FACTORY, DEFAULT_SORT_EXCHANGE_FACTORY, DEFAULT_AGGREGATE_FACTORY,
+          DEFAULT_MATCH_FACTORY, DEFAULT_SET_OP_FACTORY, DEFAULT_VALUES_FACTORY, DEFAULT_TABLE_SCAN_FACTORY,
+          DEFAULT_SNAPSHOT_FACTORY, DEFAULT_SPOOL_FACTORY, DEFAULT_REPEAT_UNION_FACTORY));
+
+  /** Ensures that the field names match those given.
+   *
+   * <p>If all fields have the same name, adds nothing;
+   * if any fields do not have the same name, adds a {@link Project}.
+   *
+   * <p>Note that the names can be short-lived. Other {@code RelBuilder}
+   * operations make no guarantees about the field names of the rows they
+   * produce.
+   *
+   * @param fieldNames List of desired field names; may contain null values or
+   * have fewer fields than the current row type
+   */
+  @Override
+  public RelBuilder rename(List<String> fieldNames) {
+    final List<String> oldFieldNames = peek().getRowType().getFieldNames();
+    Preconditions.checkArgument(fieldNames.size() <= oldFieldNames.size(), "More names than fields");
+    final List<String> newFieldNames = new ArrayList<>(oldFieldNames);
+    for (int i = 0; i < fieldNames.size(); i++) {
+      final String s = fieldNames.get(i);
+      if (s != null) {
+        newFieldNames.set(i, s);
+      }
+    }
+    if (oldFieldNames.equals(newFieldNames)) {
+      return this;
+    }
+    if (peek() instanceof Values) {
+      // Special treatment for VALUES. Re-build it rather than add a project.
+      final Values v = (Values) build();
+      final RelDataTypeFactory.Builder b = getTypeFactory().builder();
+      for (Pair<String, RelDataTypeField> p : Pair.zip(newFieldNames, v.getRowType().getFieldList())) {
+        b.add(p.left, p.right.getType());
+      }
+      return values(v.tuples, b.build());
+    }
+    if (peek() instanceof HiveUncollect) {
+      // Special treatment for HiveUncollect. Re-build it rather than add a project.
+      final HiveUncollect v = (HiveUncollect) build();
+      final RelDataTypeFactory.Builder b = getTypeFactory().builder();
+      for (Pair<String, RelDataTypeField> p : Pair.zip(newFieldNames, v.getRowType().getFieldList())) {
+        b.add(p.left, p.right.getType());
+      }
+      push(v.copy(b.build()));
+      return this;
     }
 
-    /**
-     * Creates a RelBuilder.
-     */
-    public static RelBuilder create(FrameworkConfig config) {
-        return Frameworks.withPrepare(config,
-                (cluster, relOptSchema, rootSchema, statement) ->
-                        new HiveRelBuilder(config.getContext(), cluster, relOptSchema));
-    }
-
-    /** Creates a {@link RelBuilderFactory}, a partially-created RelBuilder.
-     * Just add a {@link RelOptCluster} and a {@link RelOptSchema} */
-    public static RelBuilderFactory proto(final Context context) {
-        return (cluster, schema) -> new HiveRelBuilder(context, cluster, schema);
-    }
-
-    public static final RelBuilderFactory LOGICAL_BUILDER =
-            HiveRelBuilder.proto(
-                    Contexts.of(DEFAULT_PROJECT_FACTORY,
-                            DEFAULT_FILTER_FACTORY,
-                            DEFAULT_JOIN_FACTORY,
-                            DEFAULT_SORT_FACTORY,
-                            DEFAULT_EXCHANGE_FACTORY,
-                            DEFAULT_SORT_EXCHANGE_FACTORY,
-                            DEFAULT_AGGREGATE_FACTORY,
-                            DEFAULT_MATCH_FACTORY,
-                            DEFAULT_SET_OP_FACTORY,
-                            DEFAULT_VALUES_FACTORY,
-                            DEFAULT_TABLE_SCAN_FACTORY,
-                            DEFAULT_SNAPSHOT_FACTORY,
-                            DEFAULT_SPOOL_FACTORY,
-                            DEFAULT_REPEAT_UNION_FACTORY));
-
-    /** Ensures that the field names match those given.
-     *
-     * <p>If all fields have the same name, adds nothing;
-     * if any fields do not have the same name, adds a {@link Project}.
-     *
-     * <p>Note that the names can be short-lived. Other {@code RelBuilder}
-     * operations make no guarantees about the field names of the rows they
-     * produce.
-     *
-     * @param fieldNames List of desired field names; may contain null values or
-     * have fewer fields than the current row type
-     */
-    @Override
-    public RelBuilder rename(List<String> fieldNames) {
-        final List<String> oldFieldNames = peek().getRowType().getFieldNames();
-        Preconditions.checkArgument(fieldNames.size() <= oldFieldNames.size(),
-                "More names than fields");
-        final List<String> newFieldNames = new ArrayList<>(oldFieldNames);
-        for (int i = 0; i < fieldNames.size(); i++) {
-            final String s = fieldNames.get(i);
-            if (s != null) {
-                newFieldNames.set(i, s);
-            }
-        }
-        if (oldFieldNames.equals(newFieldNames)) {
-            return this;
-        }
-        if (peek() instanceof Values) {
-            // Special treatment for VALUES. Re-build it rather than add a project.
-            final Values v = (Values) build();
-            final RelDataTypeFactory.Builder b = getTypeFactory().builder();
-            for (Pair<String, RelDataTypeField> p
-                    : Pair.zip(newFieldNames, v.getRowType().getFieldList())) {
-                b.add(p.left, p.right.getType());
-            }
-            return values(v.tuples, b.build());
-        }
-        if (peek() instanceof HiveUncollect) {
-            // Special treatment for HiveUncollect. Re-build it rather than add a project.
-            final HiveUncollect v = (HiveUncollect) build();
-            final RelDataTypeFactory.Builder b = getTypeFactory().builder();
-            for (Pair<String, RelDataTypeField> p
-                    : Pair.zip(newFieldNames, v.getRowType().getFieldList())) {
-                b.add(p.left, p.right.getType());
-            }
-            push(v.copy(b.build()));
-            return this;
-        }
-
-        return project(fields(), newFieldNames, true);
-    }
+    return project(fields(), newFieldNames, true);
+  }
 
 }

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveRelBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveRelBuilder.java
@@ -79,7 +79,7 @@ public class HiveRelBuilder extends RelBuilder {
           DEFAULT_SNAPSHOT_FACTORY, DEFAULT_SPOOL_FACTORY, DEFAULT_REPEAT_UNION_FACTORY));
 
   /** Almost the same as the parent method except the handling of HiveUncollect.
-   *  See also {@link org.apache.calcite.tools.RelBuilder#rename(List<String>)}
+   *  See also {@link org.apache.calcite.tools.RelBuilder#rename} for details.
    *
    * @param fieldNames List of desired field names; may contain null values or
    * have fewer fields than the current row type

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveRelBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveRelBuilder.java
@@ -67,11 +67,17 @@ public class HiveRelBuilder extends RelBuilder {
   }
 
   /** Creates a {@link RelBuilderFactory}, a partially-created RelBuilder.
-   * Just add a {@link RelOptCluster} and a {@link RelOptSchema} */
+   * Just add a {@link RelOptCluster} and a {@link RelOptSchema}
+   *
+   * Note that this function creates a HiveRelBuilder instead of a RelBuilder as in its parent.
+   * */
   public static RelBuilderFactory proto(final Context context) {
     return (cluster, schema) -> new HiveRelBuilder(context, cluster, schema);
   }
 
+  /**
+   * Note that this static variable is created with HiveRelBuilder.proto instead of RelBuilder.proto as in its parent.
+   */
   public static final RelBuilderFactory LOGICAL_BUILDER =
       HiveRelBuilder.proto(Contexts.of(DEFAULT_PROJECT_FACTORY, DEFAULT_FILTER_FACTORY, DEFAULT_JOIN_FACTORY,
           DEFAULT_SORT_FACTORY, DEFAULT_EXCHANGE_FACTORY, DEFAULT_SORT_EXCHANGE_FACTORY, DEFAULT_AGGREGATE_FACTORY,

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveRelBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveRelBuilder.java
@@ -1,0 +1,127 @@
+package com.linkedin.coral.hive.hive2rel;
+
+import com.google.common.base.Preconditions;
+import org.apache.calcite.plan.Context;
+import org.apache.calcite.plan.Contexts;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptSchema;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.Values;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.tools.FrameworkConfig;
+import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.calcite.util.Pair;
+import com.linkedin.coral.hive.hive2rel.rel.HiveUncollect;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.calcite.rel.core.RelFactories.DEFAULT_AGGREGATE_FACTORY;
+import static org.apache.calcite.rel.core.RelFactories.DEFAULT_EXCHANGE_FACTORY;
+import static org.apache.calcite.rel.core.RelFactories.DEFAULT_FILTER_FACTORY;
+import static org.apache.calcite.rel.core.RelFactories.DEFAULT_JOIN_FACTORY;
+import static org.apache.calcite.rel.core.RelFactories.DEFAULT_MATCH_FACTORY;
+import static org.apache.calcite.rel.core.RelFactories.DEFAULT_PROJECT_FACTORY;
+import static org.apache.calcite.rel.core.RelFactories.DEFAULT_REPEAT_UNION_FACTORY;
+import static org.apache.calcite.rel.core.RelFactories.DEFAULT_SET_OP_FACTORY;
+import static org.apache.calcite.rel.core.RelFactories.DEFAULT_SNAPSHOT_FACTORY;
+import static org.apache.calcite.rel.core.RelFactories.DEFAULT_SORT_EXCHANGE_FACTORY;
+import static org.apache.calcite.rel.core.RelFactories.DEFAULT_SORT_FACTORY;
+import static org.apache.calcite.rel.core.RelFactories.DEFAULT_SPOOL_FACTORY;
+import static org.apache.calcite.rel.core.RelFactories.DEFAULT_TABLE_SCAN_FACTORY;
+import static org.apache.calcite.rel.core.RelFactories.DEFAULT_VALUES_FACTORY;
+
+public class HiveRelBuilder extends RelBuilder {
+
+    private HiveRelBuilder(Context context, RelOptCluster cluster, RelOptSchema relOptSchema) {
+        super(context, cluster, relOptSchema);
+    }
+
+    /**
+     * Creates a RelBuilder.
+     */
+    public static RelBuilder create(FrameworkConfig config) {
+        return Frameworks.withPrepare(config,
+                (cluster, relOptSchema, rootSchema, statement) ->
+                        new HiveRelBuilder(config.getContext(), cluster, relOptSchema));
+    }
+
+    /** Creates a {@link RelBuilderFactory}, a partially-created RelBuilder.
+     * Just add a {@link RelOptCluster} and a {@link RelOptSchema} */
+    public static RelBuilderFactory proto(final Context context) {
+        return (cluster, schema) -> new HiveRelBuilder(context, cluster, schema);
+    }
+
+    public static final RelBuilderFactory LOGICAL_BUILDER =
+            HiveRelBuilder.proto(
+                    Contexts.of(DEFAULT_PROJECT_FACTORY,
+                            DEFAULT_FILTER_FACTORY,
+                            DEFAULT_JOIN_FACTORY,
+                            DEFAULT_SORT_FACTORY,
+                            DEFAULT_EXCHANGE_FACTORY,
+                            DEFAULT_SORT_EXCHANGE_FACTORY,
+                            DEFAULT_AGGREGATE_FACTORY,
+                            DEFAULT_MATCH_FACTORY,
+                            DEFAULT_SET_OP_FACTORY,
+                            DEFAULT_VALUES_FACTORY,
+                            DEFAULT_TABLE_SCAN_FACTORY,
+                            DEFAULT_SNAPSHOT_FACTORY,
+                            DEFAULT_SPOOL_FACTORY,
+                            DEFAULT_REPEAT_UNION_FACTORY));
+
+    /** Ensures that the field names match those given.
+     *
+     * <p>If all fields have the same name, adds nothing;
+     * if any fields do not have the same name, adds a {@link Project}.
+     *
+     * <p>Note that the names can be short-lived. Other {@code RelBuilder}
+     * operations make no guarantees about the field names of the rows they
+     * produce.
+     *
+     * @param fieldNames List of desired field names; may contain null values or
+     * have fewer fields than the current row type
+     */
+    @Override
+    public RelBuilder rename(List<String> fieldNames) {
+        final List<String> oldFieldNames = peek().getRowType().getFieldNames();
+        Preconditions.checkArgument(fieldNames.size() <= oldFieldNames.size(),
+                "More names than fields");
+        final List<String> newFieldNames = new ArrayList<>(oldFieldNames);
+        for (int i = 0; i < fieldNames.size(); i++) {
+            final String s = fieldNames.get(i);
+            if (s != null) {
+                newFieldNames.set(i, s);
+            }
+        }
+        if (oldFieldNames.equals(newFieldNames)) {
+            return this;
+        }
+        if (peek() instanceof Values) {
+            // Special treatment for VALUES. Re-build it rather than add a project.
+            final Values v = (Values) build();
+            final RelDataTypeFactory.Builder b = getTypeFactory().builder();
+            for (Pair<String, RelDataTypeField> p
+                    : Pair.zip(newFieldNames, v.getRowType().getFieldList())) {
+                b.add(p.left, p.right.getType());
+            }
+            return values(v.tuples, b.build());
+        }
+        if (peek() instanceof HiveUncollect) {
+            // Special treatment for HiveUncollect. Re-build it rather than add a project.
+            final HiveUncollect v = (HiveUncollect) build();
+            final RelDataTypeFactory.Builder b = getTypeFactory().builder();
+            for (Pair<String, RelDataTypeField> p
+                    : Pair.zip(newFieldNames, v.getRowType().getFieldList())) {
+                b.add(p.left, p.right.getType());
+            }
+            push(v.copy(b.build()));
+            return this;
+        }
+
+        return project(fields(), newFieldNames, true);
+    }
+
+}

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveRelBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveRelBuilder.java
@@ -78,7 +78,8 @@ public class HiveRelBuilder extends RelBuilder {
           DEFAULT_MATCH_FACTORY, DEFAULT_SET_OP_FACTORY, DEFAULT_VALUES_FACTORY, DEFAULT_TABLE_SCAN_FACTORY,
           DEFAULT_SNAPSHOT_FACTORY, DEFAULT_SPOOL_FACTORY, DEFAULT_REPEAT_UNION_FACTORY));
 
-  /** Almost the same as {@link RelBuilder#rename(List<String>)} except the handling of HiveUncollect.
+  /** Almost the same as the parent method except the handling of HiveUncollect.
+   *  See also {@link org.apache.calcite.tools.RelBuilder#rename(List<String>)}
    *
    * @param fieldNames List of desired field names; may contain null values or
    * have fewer fields than the current row type

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveSqlToRelConverter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveSqlToRelConverter.java
@@ -90,7 +90,6 @@ class HiveSqlToRelConverter extends SqlToRelConverter {
 
   private void convertUnnestFrom(Blackboard bb, SqlNode from) {
     final SqlCall call;
-    final SqlNode[] operands;
     call = (SqlCall) from;
     final List<SqlNode> nodes = call.getOperandList();
     final SqlUnnestOperator operator = (SqlUnnestOperator) call.getOperator();

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveSqlToRelConverter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveSqlToRelConverter.java
@@ -8,7 +8,6 @@ package com.linkedin.coral.hive.hive2rel;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.linkedin.coral.hive.hive2rel.functions.HiveExplodeOperator;
 import org.apache.calcite.linq4j.Ord;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
@@ -35,6 +34,7 @@ import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql2rel.SqlRexConvertletTable;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 
+import com.linkedin.coral.hive.hive2rel.functions.HiveExplodeOperator;
 import com.linkedin.coral.hive.hive2rel.rel.HiveUncollect;
 
 
@@ -102,9 +102,8 @@ class HiveSqlToRelConverter extends SqlToRelConverter {
       exprs.add(bb.convertExpression(node.e));
       // In Hive, "LATERAL VIEW EXPLODE(arr) t" is equivalent to "LATERAL VIEW EXPLODE(arr) t AS col".
       // Use the default column name "col" if not specified.
-      fieldNames.add(node.e.getKind() == SqlKind.AS
-              ? validator.deriveAlias(node.e, node.i)
-              : HiveExplodeOperator.ARRAY_ELEMENT_COLUMN_NAME);
+      fieldNames.add(node.e.getKind() == SqlKind.AS ? validator.deriveAlias(node.e, node.i)
+          : HiveExplodeOperator.ARRAY_ELEMENT_COLUMN_NAME);
     }
     final RelNode input = RelOptUtil.createProject((null != bb.root) ? bb.root : LogicalValues.createOneRow(cluster),
         exprs, fieldNames, true);

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveSqlToRelConverter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveSqlToRelConverter.java
@@ -8,6 +8,7 @@ package com.linkedin.coral.hive.hive2rel;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.linkedin.coral.hive.hive2rel.functions.HiveExplodeOperator;
 import org.apache.calcite.linq4j.Ord;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
@@ -27,6 +28,7 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlExplainFormat;
 import org.apache.calcite.sql.SqlExplainLevel;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlUnnestOperator;
 import org.apache.calcite.sql.validate.SqlValidator;
@@ -98,7 +100,11 @@ class HiveSqlToRelConverter extends SqlToRelConverter {
     final List<String> fieldNames = new ArrayList<>();
     for (Ord<SqlNode> node : Ord.zip(nodes)) {
       exprs.add(bb.convertExpression(node.e));
-      fieldNames.add(validator.deriveAlias(node.e, node.i));
+      // In Hive, "LATERAL VIEW EXPLODE(arr) t" is equivalent to "LATERAL VIEW EXPLODE(arr) t AS col".
+      // Use the default column name "col" if not specified.
+      fieldNames.add(node.e.getKind() == SqlKind.AS
+              ? validator.deriveAlias(node.e, node.i)
+              : HiveExplodeOperator.ARRAY_ELEMENT_COLUMN_NAME);
     }
     final RelNode input = RelOptUtil.createProject((null != bb.root) ? bb.root : LogicalValues.createOneRow(cluster),
         exprs, fieldNames, true);

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/RelContextProvider.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/RelContextProvider.java
@@ -245,8 +245,7 @@ public class RelContextProvider {
    */
   SqlToRelConverter getSqlToRelConverter() {
     return new HiveSqlToRelConverter(getViewExpander(), getHiveSqlValidator(), getCalciteCatalogReader(),
-        getRelOptCluster(), convertletTable, SqlToRelConverter.configBuilder().withRelBuilderFactory(
-            HiveRelBuilder.LOGICAL_BUILDER
-    ).build());
+        getRelOptCluster(), convertletTable,
+        SqlToRelConverter.configBuilder().withRelBuilderFactory(HiveRelBuilder.LOGICAL_BUILDER).build());
   }
 }

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveExplodeOperator.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveExplodeOperator.java
@@ -28,6 +28,8 @@ public class HiveExplodeOperator extends SqlUnnestOperator {
 
   public static final HiveExplodeOperator EXPLODE = new HiveExplodeOperator();
 
+  public static final String ARRAY_ELEMENT_COLUMN_NAME = "col";
+
   public HiveExplodeOperator() {
     // keep same same as base class 'UNNEST' operator
     // Hive has a separate 'posexplode' function for ordinality
@@ -50,7 +52,9 @@ public class HiveExplodeOperator extends SqlUnnestOperator {
     RelDataType operandType = opBinding.getOperandType(0);
     final RelDataTypeFactory.Builder builder = opBinding.getTypeFactory().builder();
     if (operandType instanceof ArraySqlType) {
-      builder.add(SqlUtil.deriveAliasFromOrdinal(0), operandType.getComponentType());
+      // builder.add(SqlUtil.deriveAliasFromOrdinal(0), operandType.getComponentType());
+      // array type
+      builder.add(ARRAY_ELEMENT_COLUMN_NAME, operandType.getComponentType());
     } else {
       // map type
       builder.add(MAP_KEY_COLUMN_NAME, operandType.getKeyType());

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveExplodeOperator.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveExplodeOperator.java
@@ -11,7 +11,6 @@ import org.apache.calcite.sql.SqlCallBinding;
 import org.apache.calcite.sql.SqlOperandCountRange;
 import org.apache.calcite.sql.SqlOperatorBinding;
 import org.apache.calcite.sql.SqlUnnestOperator;
-import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.type.ArraySqlType;
 import org.apache.calcite.sql.type.MapSqlType;
 import org.apache.calcite.sql.type.SqlOperandCountRanges;

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveExplodeOperator.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveExplodeOperator.java
@@ -51,7 +51,6 @@ public class HiveExplodeOperator extends SqlUnnestOperator {
     RelDataType operandType = opBinding.getOperandType(0);
     final RelDataTypeFactory.Builder builder = opBinding.getTypeFactory().builder();
     if (operandType instanceof ArraySqlType) {
-      // builder.add(SqlUtil.deriveAliasFromOrdinal(0), operandType.getComponentType());
       // array type
       builder.add(ARRAY_ELEMENT_COLUMN_NAME, operandType.getComponentType());
     } else {

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -275,13 +275,15 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
     //   The logic above will be implemented as part of Calcite SqlNode validation
     //   Note that "operandCount == 2 && isOuter" is not supported yet due to the lack of type information needed
     //   to derive the correct IF function parameters.
-    checkState((operandCount == 2 && !isOuter) || operandCount == 3 || operandCount == 4,
+    checkState(operandCount == 2 || operandCount == 3 || operandCount == 4,
         format("Unsupported LATERAL VIEW EXPLODE operand number: %d", operandCount));
     // TODO The code below assumes LATERAL VIEW is used with UNNEST EXPLODE only. It should be made more generic.
     SqlCall unnestCall = tableFunctionCall;
     SqlNode unnestOperand = unnestCall.operand(0);
 
     if (isOuter) {
+      checkState(operandCount > 2, format(
+          "LATERAL VIEW OUTER EXPLODE without column aliases is not supported. Add 'AS col' or 'AS key, value' to fix it"));
       // transforms unnest(b) to unnest( if(b is null or cardinality(b) = 0, ARRAY(null)/MAP(null, null), b))
       SqlNode operandIsNull = SqlStdOperatorTable.IS_NOT_NULL.createCall(ZERO, unnestOperand);
       SqlNode emptyArray = SqlStdOperatorTable.GREATER_THAN.createCall(ZERO,

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -298,18 +298,12 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
       unnestOperand = hiveIfFunction.createCall(SqlLiteral.createCharString("if", ZERO),
           ImmutableList.of(ifCondition, unnestOperand, arrayOrMapOfNull), null);
     }
-    // if (operandCount == 3) { // unnest explode array
-    //  unnestCall = HiveExplodeOperator.EXPLODE.createCall(ZERO,
-    //      SqlStdOperatorTable.AS.createCall(ZERO, unnestOperand, aliasOperands.get(2)));
-    // This AS call is useless
-    //  unnestCall = SqlStdOperatorTable.AS.createCall(ZERO, unnestCall, aliasOperands.get(1), aliasOperands.get(2));
-    //} else { // unnest explode map
     unnestCall = HiveExplodeOperator.EXPLODE.createCall(ZERO, unnestOperand);
 
-    List<SqlNode> operands = new ArrayList<>();
-    operands.add(unnestCall);
-    operands.addAll(aliasOperands.subList(1, aliasOperands.size()));
-    SqlNode as = SqlStdOperatorTable.AS.createCall(ZERO, operands);
+    List<SqlNode> asOperands = new ArrayList<>();
+    asOperands.add(unnestCall);
+    asOperands.addAll(aliasOperands.subList(1, aliasOperands.size()));
+    SqlNode as = SqlStdOperatorTable.AS.createCall(ZERO, asOperands);
 
     SqlNode lateralCall = SqlStdOperatorTable.LATERAL.createCall(ZERO, as);
     return new SqlJoin(ZERO, sqlNodes.get(1), SqlLiteral.createBoolean(false, ZERO), JoinType.COMMA.symbol(ZERO),

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -15,7 +15,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.linkedin.coral.hive.hive2rel.rel.HiveUncollect;
 import org.apache.calcite.sql.JoinConditionType;
 import org.apache.calcite.sql.JoinType;
 import org.apache.calcite.sql.SqlAsOperator;

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -301,19 +301,19 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
     // if (operandCount == 3) { // unnest explode array
     //  unnestCall = HiveExplodeOperator.EXPLODE.createCall(ZERO,
     //      SqlStdOperatorTable.AS.createCall(ZERO, unnestOperand, aliasOperands.get(2)));
-      // This AS call is useless
+    // This AS call is useless
     //  unnestCall = SqlStdOperatorTable.AS.createCall(ZERO, unnestCall, aliasOperands.get(1), aliasOperands.get(2));
     //} else { // unnest explode map
-      unnestCall = HiveExplodeOperator.EXPLODE.createCall(ZERO, unnestOperand);
+    unnestCall = HiveExplodeOperator.EXPLODE.createCall(ZERO, unnestOperand);
 
-      List<SqlNode> operands = new ArrayList<>();
-      operands.add(unnestCall);
-      operands.addAll(aliasOperands.subList(1, aliasOperands.size()));
-      SqlNode as = SqlStdOperatorTable.AS.createCall(ZERO, operands);
+    List<SqlNode> operands = new ArrayList<>();
+    operands.add(unnestCall);
+    operands.addAll(aliasOperands.subList(1, aliasOperands.size()));
+    SqlNode as = SqlStdOperatorTable.AS.createCall(ZERO, operands);
 
     SqlNode lateralCall = SqlStdOperatorTable.LATERAL.createCall(ZERO, as);
     return new SqlJoin(ZERO, sqlNodes.get(1), SqlLiteral.createBoolean(false, ZERO), JoinType.COMMA.symbol(ZERO),
-            lateralCall, JoinConditionType.NONE.symbol(ZERO), null);
+        lateralCall, JoinConditionType.NONE.symbol(ZERO), null);
   }
 
   private SqlNode visitLateralViewJsonTuple(List<SqlNode> sqlNodes, List<SqlNode> aliasOperands, SqlCall sqlCall) {

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/rel/HiveUncollect.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/rel/HiveUncollect.java
@@ -44,13 +44,20 @@ public class HiveUncollect extends Uncollect {
   public RelNode copy(RelTraitSet traitSet, RelNode input) {
     assert traitSet.containsIfApplicable(Convention.NONE);
     HiveUncollect result = new HiveUncollect(getCluster(), traitSet, input, withOrdinality);
+    // copy the rowType as well
     result.rowType = this.rowType;
     return result;
   }
 
+  /**
+   * Create a copy of this HiveUncollect object with the specified rowType.
+   * @param rowType rowType of the newly created HiveUncollect object
+   * @return a new HiveUncollect object
+   */
   public RelNode copy(RelDataType rowType) {
     assert traitSet.containsIfApplicable(Convention.NONE);
     HiveUncollect result = new HiveUncollect(getCluster(), traitSet, input, withOrdinality);
+    // set the rowType of the new HiveUncollect object
     result.rowType = rowType;
     return result;
   }
@@ -70,9 +77,7 @@ public class HiveUncollect extends Uncollect {
         builder.add(SqlUnnestOperator.MAP_VALUE_COLUMN_NAME, field.getType().getValueType());
       } else {
         RelDataType ret = field.getType().getComponentType();
-        System.out.println("fields[0]=" + field.getName());
         builder.add(field.getName(), ret);
-        // builder.add(fields.size() == 1 ? HiveExplodeOperator.ARRAY_ELEMENT_COLUMN_NAME : field.getName(), ret);
       }
     }
     if (withOrdinality) {

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/rel/HiveUncollect.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/rel/HiveUncollect.java
@@ -7,7 +7,6 @@ package com.linkedin.coral.hive.hive2rel.rel;
 
 import java.util.List;
 
-import com.linkedin.coral.hive.hive2rel.functions.HiveExplodeOperator;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
@@ -198,8 +198,7 @@ public class HiveToRelConverterTest {
     String expected = "LogicalProject(col=[$1])\n"
         + "  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])\n"
         + "    LogicalProject(a=[ARRAY('a1', 'a2')])\n" + "      LogicalValues(tuples=[[{ 0 }]])\n"
-        + "    LogicalProject(col=[$0])\n" + "      HiveUncollect\n" + "        LogicalProject(col=[$cor0.a])\n"
-        + "          LogicalValues(tuples=[[{ 0 }]])\n";
+        + "    HiveUncollect\n" + "      LogicalProject(col=[$cor0.a])\n" + "        LogicalValues(tuples=[[{ 0 }]])\n";
     assertEquals(relString, expected);
   }
 
@@ -212,8 +211,7 @@ public class HiveToRelConverterTest {
     String expected = "LogicalProject(col=[$1])\n"
         + "  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])\n"
         + "    LogicalProject(a=[ARRAY('a1', 'a2')])\n" + "      LogicalValues(tuples=[[{ 0 }]])\n"
-        + "    LogicalProject(col=[$0])\n" + "      HiveUncollect\n" + "        LogicalProject(a=[$cor0.a])\n"
-        + "          LogicalValues(tuples=[[{ 0 }]])\n";
+        + "    HiveUncollect\n" + "      LogicalProject(col=[$cor0.a])\n" + "        LogicalValues(tuples=[[{ 0 }]])\n";
     assertEquals(relString, expected);
   }
 
@@ -227,8 +225,7 @@ public class HiveToRelConverterTest {
     String expected = "LogicalProject(key=[$1], value=[$2])\n"
         + "  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])\n"
         + "    LogicalProject(m=[MAP('key1', 'value1')])\n" + "      LogicalValues(tuples=[[{ 0 }]])\n"
-        + "    LogicalProject(KEY=[$0], VALUE=[$1])\n" + "      HiveUncollect\n"
-        + "        LogicalProject(m=[$cor0.m])\n" + "          LogicalValues(tuples=[[{ 0 }]])\n";
+        + "    HiveUncollect\n" + "      LogicalProject(col=[$cor0.m])\n" + "        LogicalValues(tuples=[[{ 0 }]])\n";
     assertEquals(relString, expected);
   }
 
@@ -241,8 +238,7 @@ public class HiveToRelConverterTest {
     String expected = "LogicalProject(key=[$1], value=[$2])\n"
         + "  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])\n"
         + "    LogicalProject(m=[MAP('key1', 'value1')])\n" + "      LogicalValues(tuples=[[{ 0 }]])\n"
-        + "    LogicalProject(KEY=[$0], VALUE=[$1])\n" + "      HiveUncollect\n"
-        + "        LogicalProject(m=[$cor0.m])\n" + "          LogicalValues(tuples=[[{ 0 }]])\n";
+        + "    HiveUncollect\n" + "      LogicalProject(col=[$cor0.m])\n" + "        LogicalValues(tuples=[[{ 0 }]])\n";
     assertEquals(relString, expected);
   }
 

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
@@ -52,7 +52,7 @@ public class HiveToRelConverterTest {
 
   public void testBasicWithSQL(String sql) {
     RelNode rel = converter.convertSql(sql);
-    RelBuilder relBuilder = createRelBuilder();
+    RelBuilder relBuilder = createRelBuilderHiveRelBuilder();
     RelNode expected = relBuilder.scan(ImmutableList.of("hive", "default", "foo"))
         .project(ImmutableList.of(relBuilder.field("a"), relBuilder.field("b"), relBuilder.field("c")),
             ImmutableList.of(), true)

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
@@ -52,7 +52,7 @@ public class HiveToRelConverterTest {
 
   public void testBasicWithSQL(String sql) {
     RelNode rel = converter.convertSql(sql);
-    RelBuilder relBuilder = createRelBuilderHiveRelBuilder();
+    RelBuilder relBuilder = createRelBuilder();
     RelNode expected = relBuilder.scan(ImmutableList.of("hive", "default", "foo"))
         .project(ImmutableList.of(relBuilder.field("a"), relBuilder.field("b"), relBuilder.field("c")),
             ImmutableList.of(), true)

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
@@ -191,7 +191,7 @@ public class HiveToRelConverterTest {
 
   @Test
   public void testLateralViewArray() {
-    // Test if the code can handle the use of window functions
+    // Test if the code can handle lateral view explode with an array
     String sql = "SELECT col FROM (SELECT ARRAY('a1', 'a2') as a) tmp LATERAL VIEW EXPLODE(a) a_alias AS col";
     RelNode rel = converter.convertSql(sql);
     String relString = relToStr(rel);
@@ -204,7 +204,7 @@ public class HiveToRelConverterTest {
 
   @Test
   public void testLateralViewArrayWithoutColumns() {
-    // Test if the code can handle the use of window functions
+    // Test if the code can handle lateral view explode with an array without column aliases
     String sql = "SELECT a_alias.col FROM (SELECT ARRAY('a1', 'a2') as a) tmp LATERAL VIEW EXPLODE(a) a_alias";
     RelNode rel = converter.convertSql(sql);
     String relString = relToStr(rel);
@@ -217,7 +217,7 @@ public class HiveToRelConverterTest {
 
   @Test
   public void testLateralViewMap() {
-    // Test if the code can handle the use of window functions
+    // Test if the code can handle lateral view explode with a map
     String sql =
         "SELECT key, value FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias AS key, value";
     RelNode rel = converter.convertSql(sql);
@@ -231,7 +231,7 @@ public class HiveToRelConverterTest {
 
   @Test
   public void testLateralViewMapWithoutColumns() {
-    // Test if the code can handle the use of window functions
+    // Test if the code can handle lateral view explode with a map without column aliases
     String sql = "SELECT key, value FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias";
     RelNode rel = converter.convertSql(sql);
     String relString = relToStr(rel);

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
@@ -190,6 +190,63 @@ public class HiveToRelConverterTest {
   }
 
   @Test
+  public void testLateralViewArray() {
+    // Test if the code can handle the use of window functions
+    String sql = "SELECT col FROM (SELECT ARRAY('a1', 'a2') as a) tmp LATERAL VIEW EXPLODE(a) a_alias AS col";
+    RelNode rel = converter.convertSql(sql);
+    String relString = relToStr(rel);
+    String expected = "LogicalProject(col=[$1])\n"
+        + "  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])\n"
+        + "    LogicalProject(a=[ARRAY('a1', 'a2')])\n" + "      LogicalValues(tuples=[[{ 0 }]])\n"
+        + "    LogicalProject(col=[$0])\n" + "      HiveUncollect\n" + "        LogicalProject(col=[$cor0.a])\n"
+        + "          LogicalValues(tuples=[[{ 0 }]])\n";
+    assertEquals(relString, expected);
+  }
+
+  @Test
+  public void testLateralViewArrayWithoutColumns() {
+    // Test if the code can handle the use of window functions
+    String sql = "SELECT a_alias.col FROM (SELECT ARRAY('a1', 'a2') as a) tmp LATERAL VIEW EXPLODE(a) a_alias";
+    RelNode rel = converter.convertSql(sql);
+    String relString = relToStr(rel);
+    String expected = "LogicalProject(col=[$1])\n"
+        + "  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])\n"
+        + "    LogicalProject(a=[ARRAY('a1', 'a2')])\n" + "      LogicalValues(tuples=[[{ 0 }]])\n"
+        + "    LogicalProject(col=[$0])\n" + "      HiveUncollect\n" + "        LogicalProject(a=[$cor0.a])\n"
+        + "          LogicalValues(tuples=[[{ 0 }]])\n";
+    assertEquals(relString, expected);
+  }
+
+  @Test
+  public void testLateralViewMap() {
+    // Test if the code can handle the use of window functions
+    String sql =
+        "SELECT key, value FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias AS key, value";
+    RelNode rel = converter.convertSql(sql);
+    String relString = relToStr(rel);
+    String expected = "LogicalProject(key=[$1], value=[$2])\n"
+        + "  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])\n"
+        + "    LogicalProject(m=[MAP('key1', 'value1')])\n" + "      LogicalValues(tuples=[[{ 0 }]])\n"
+        + "    LogicalProject(KEY=[$0], VALUE=[$1])\n" + "      HiveUncollect\n"
+        + "        LogicalProject(m=[$cor0.m])\n" + "          LogicalValues(tuples=[[{ 0 }]])\n";
+    assertEquals(relString, expected);
+  }
+
+  @Test
+  public void testLateralViewMapWithoutColumns() {
+    // Test if the code can handle the use of window functions
+    String sql = "SELECT key, value FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias";
+    RelNode rel = converter.convertSql(sql);
+    String relString = relToStr(rel);
+    String expected = "LogicalProject(key=[$1], value=[$2])\n"
+        + "  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])\n"
+        + "    LogicalProject(m=[MAP('key1', 'value1')])\n" + "      LogicalValues(tuples=[[{ 0 }]])\n"
+        + "    LogicalProject(KEY=[$0], VALUE=[$1])\n" + "      HiveUncollect\n"
+        + "        LogicalProject(m=[$cor0.m])\n" + "          LogicalValues(tuples=[[{ 0 }]])\n";
+    assertEquals(relString, expected);
+  }
+
+  @Test
   public void testSelectNull() {
     final String sql = "SELECT NULL as f";
     RelNode rel = toRel(sql);

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/LateralViewTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/LateralViewTest.java
@@ -38,9 +38,8 @@ public class LateralViewTest {
     RelNode relNode = toRel(sql);
     String expected = "LogicalProject(a=[$0], ccol=[$6])\n"
         + "  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])\n"
-        + "    LogicalTableScan(table=[[hive, default, complex]])\n" + "    LogicalProject(ccol=[$0])\n"
-        + "      HiveUncollect\n" + "        LogicalProject(ccol=[$cor0.c])\n"
-        + "          LogicalValues(tuples=[[{ 0 }]])\n";
+        + "    LogicalTableScan(table=[[hive, default, complex]])\n" + "    HiveUncollect\n"
+        + "      LogicalProject(col=[$cor0.c])\n" + "        LogicalValues(tuples=[[{ 0 }]])\n";
     assertEquals(toRelStr(sql), expected);
   }
 
@@ -50,10 +49,9 @@ public class LateralViewTest {
     RelNode relNode = toRel(sql);
     String expected = "LogicalProject(a=[$0], ccol=[$6])\n"
         + "  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])\n"
-        + "    LogicalTableScan(table=[[hive, default, complex]])\n" + "    LogicalProject(ccol=[$0])\n"
-        + "      HiveUncollect\n"
-        + "        LogicalProject(ccol=[if(AND(IS NOT NULL($cor0.c), >(CARDINALITY($cor0.c), 0)), $cor0.c, ARRAY(null:NULL))])\n"
-        + "          LogicalValues(tuples=[[{ 0 }]])\n";
+        + "    LogicalTableScan(table=[[hive, default, complex]])\n" + "    HiveUncollect\n"
+        + "      LogicalProject(col=[if(AND(IS NOT NULL($cor0.c), >(CARDINALITY($cor0.c), 0)), $cor0.c, ARRAY(null:NULL))])\n"
+        + "        LogicalValues(tuples=[[{ 0 }]])\n";
 
     assertEquals(toRelStr(sql), expected);
   }
@@ -63,9 +61,8 @@ public class LateralViewTest {
     final String sql = "SELECT a, mkey, mvalue from complex lateral view explode(complex.m) t as mkey, mvalue";
     String expected = "LogicalProject(a=[$0], mkey=[$6], mvalue=[$7])\n"
         + "  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{4}])\n"
-        + "    LogicalTableScan(table=[[hive, default, complex]])\n" + "    LogicalProject(KEY=[$0], VALUE=[$1])\n"
-        + "      HiveUncollect\n" + "        LogicalProject(m=[$cor0.m])\n"
-        + "          LogicalValues(tuples=[[{ 0 }]])\n";
+        + "    LogicalTableScan(table=[[hive, default, complex]])\n" + "    HiveUncollect\n"
+        + "      LogicalProject(col=[$cor0.m])\n" + "        LogicalValues(tuples=[[{ 0 }]])\n";
     assertEquals(toRelStr(sql), expected);
   }
 
@@ -74,10 +71,9 @@ public class LateralViewTest {
     final String sql = "SELECT a, mkey, mvalue from complex lateral view outer explode(complex.m) t as mkey, mvalue";
     String expected = "LogicalProject(a=[$0], mkey=[$6], mvalue=[$7])\n"
         + "  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{4}])\n"
-        + "    LogicalTableScan(table=[[hive, default, complex]])\n" + "    LogicalProject(KEY=[$0], VALUE=[$1])\n"
-        + "      HiveUncollect\n"
-        + "        LogicalProject(EXPR$0=[if(AND(IS NOT NULL($cor0.m), >(CARDINALITY($cor0.m), 0)), $cor0.m, MAP(null:NULL, null:NULL))])\n"
-        + "          LogicalValues(tuples=[[{ 0 }]])\n";
+        + "    LogicalTableScan(table=[[hive, default, complex]])\n" + "    HiveUncollect\n"
+        + "      LogicalProject(col=[if(AND(IS NOT NULL($cor0.m), >(CARDINALITY($cor0.m), 0)), $cor0.m, MAP(null:NULL, null:NULL))])\n"
+        + "        LogicalValues(tuples=[[{ 0 }]])\n";
 
     assertEquals(toRelStr(sql), expected);
   }
@@ -89,12 +85,10 @@ public class LateralViewTest {
     String expected = "LogicalProject(a=[$0], ccol=[$6], anotherCCol=[$7])\n"
         + "  LogicalCorrelate(correlation=[$cor3], joinType=[inner], requiredColumns=[{2}])\n"
         + "    LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])\n"
-        + "      LogicalTableScan(table=[[hive, default, complex]])\n" + "      LogicalProject(ccol=[$0])\n"
-        + "        HiveUncollect\n"
-        + "          LogicalProject(ccol=[if(AND(IS NOT NULL($cor0.c), >(CARDINALITY($cor0.c), 0)), $cor0.c, ARRAY(null:NULL))])\n"
-        + "            LogicalValues(tuples=[[{ 0 }]])\n" + "    LogicalProject(anotherCCol=[$0])\n"
-        + "      HiveUncollect\n" + "        LogicalProject(anotherCCol=[$cor3.c])\n"
-        + "          LogicalValues(tuples=[[{ 0 }]])\n";
+        + "      LogicalTableScan(table=[[hive, default, complex]])\n" + "      HiveUncollect\n"
+        + "        LogicalProject(col=[if(AND(IS NOT NULL($cor0.c), >(CARDINALITY($cor0.c), 0)), $cor0.c, ARRAY(null:NULL))])\n"
+        + "          LogicalValues(tuples=[[{ 0 }]])\n" + "    HiveUncollect\n"
+        + "      LogicalProject(col=[$cor3.c])\n" + "        LogicalValues(tuples=[[{ 0 }]])\n";
     assertEquals(toRelStr(sql), expected);
   }
 
@@ -103,10 +97,9 @@ public class LateralViewTest {
     final String sql = "SELECT a, sarr, flat_s FROM complex\n" + "lateral view outer explode(complex.sarr) t as flat_s";
     String expected = "LogicalProject(a=[$0], sarr=[$5], flat_s=[$6])\n"
         + "  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{5}])\n"
-        + "    LogicalTableScan(table=[[hive, default, complex]])\n" + "    LogicalProject(flat_s=[$0])\n"
-        + "      HiveUncollect\n"
-        + "        LogicalProject(flat_s=[if(AND(IS NOT NULL($cor0.sarr), >(CARDINALITY($cor0.sarr), 0)), $cor0.sarr, ARRAY(null:NULL))])\n"
-        + "          LogicalValues(tuples=[[{ 0 }]])\n";
+        + "    LogicalTableScan(table=[[hive, default, complex]])\n" + "    HiveUncollect\n"
+        + "      LogicalProject(col=[if(AND(IS NOT NULL($cor0.sarr), >(CARDINALITY($cor0.sarr), 0)), $cor0.sarr, ARRAY(null:NULL))])\n"
+        + "        LogicalValues(tuples=[[{ 0 }]])\n";
     assertEquals(toRelStr(sql), expected);
   }
 
@@ -116,10 +109,9 @@ public class LateralViewTest {
         + " explode(if(size(complex.c) > 5, array(10.5), complex.c)) t as ccol";
     final String expected = "LogicalProject(a=[$0], ccol=[$6])\n"
         + "  LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])\n"
-        + "    LogicalTableScan(table=[[hive, default, complex]])\n" + "    LogicalProject(ccol=[$0])\n"
-        + "      HiveUncollect\n"
-        + "        LogicalProject(ccol=[if(>(CARDINALITY($cor0.c), 5), ARRAY(10.5:DECIMAL(3, 1)), $cor0.c)])\n"
-        + "          LogicalValues(tuples=[[{ 0 }]])\n";
+        + "    LogicalTableScan(table=[[hive, default, complex]])\n" + "    HiveUncollect\n"
+        + "      LogicalProject(col=[if(>(CARDINALITY($cor0.c), 5), ARRAY(10.5:DECIMAL(3, 1)), $cor0.c)])\n"
+        + "        LogicalValues(tuples=[[{ 0 }]])\n";
     assertEquals(toRelStr(sql), expected);
   }
 

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/ToRelConverter.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/ToRelConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2020 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -65,7 +65,7 @@ class ToRelConverter {
   }
 
   static RelBuilder createRelBuilder() {
-    return RelBuilder.create(relContextProvider.getConfig());
+    return HiveRelBuilder.create(relContextProvider.getConfig());
   }
 
   static void verifyRel(RelNode input, RelNode expected) {

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
@@ -130,11 +130,11 @@ public class ParseTreeBuilderTest {
         // test lateral view explode with a map
         ImmutableList.of(
             "SELECT key, value FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias AS key, value",
-            "SELECT `key`, `value` FROM (SELECT MAP['key1', 'value1'] AS `m`) AS `tmp`, LATERAL (SELECT * from UNNEST(`m`)) AS `m_alias` (`key`, `value`)"),
+            "SELECT `key`, `value` FROM (SELECT MAP['key1', 'value1'] AS `m`) AS `tmp`, LATERAL UNNEST(`m`) AS `m_alias` (`key`, `value`)"),
         // hive automatically creates column aliases `key` and `value` when the type is a map
         ImmutableList.of(
             "SELECT key, value FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias",
-            "SELECT `key`, `value` FROM (SELECT MAP['key1', 'value1'] AS `m`) AS `tmp`, LATERAL (SELECT * from UNNEST(`m`)) AS `m_alias` (`key`, `value`)"),
+            "SELECT `key`, `value` FROM (SELECT MAP['key1', 'value1'] AS `m`) AS `tmp`, LATERAL UNNEST(`m`) AS `m_alias`"),
         // hive doesn't support casting as varbinary
         ImmutableList.of("SELECT cast(a as binary) from foo", "SELECT cast(`a` as binary) from `foo`"),
         ImmutableList.of("SELECT cast(a as string) from foo", "SELECT cast(`a` as varchar) from `foo`"),

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
@@ -133,8 +133,7 @@ public class ParseTreeBuilderTest {
             "SELECT col FROM (SELECT ARRAY('v1', 'v2') as arr) tmp LATERAL VIEW EXPLODE(arr) arr_alias AS col",
             "SELECT `col` FROM (SELECT ARRAY['v1', 'v2'] AS `arr`) AS `tmp`, LATERAL UNNEST(`arr`) AS `arr_alias` (`col`)"),
         // hive automatically creates column aliases `col` when the type is an array
-        ImmutableList.of(
-            "SELECT col FROM (SELECT ARRAY('v1', 'v2') as arr) tmp LATERAL VIEW EXPLODE(arr) arr_alias",
+        ImmutableList.of("SELECT col FROM (SELECT ARRAY('v1', 'v2') as arr) tmp LATERAL VIEW EXPLODE(arr) arr_alias",
             "SELECT `col` FROM (SELECT ARRAY['v1', 'v2'] AS `arr`) AS `tmp`, LATERAL UNNEST(`arr`) AS `arr_alias`"),
         // test lateral view explode with a map
         ImmutableList.of(
@@ -187,7 +186,7 @@ public class ParseTreeBuilderTest {
    * OUTER EXPLODE without column aliases are not supported yet.
    * See details in {@link ParseTreeBuilder#visitLateralViewExplode(List, List, SqlCall, boolean)}
    */
-  @Test(expectedExceptions = {java.lang.IllegalStateException.class})
+  @Test(expectedExceptions = { java.lang.IllegalStateException.class })
   public void testUnsupportedOuterExplodeWithoutColumns() {
     String input = "SELECT col FROM (SELECT ARRAY('v1', 'v2') as arr) tmp LATERAL VIEW OUTER EXPLODE(arr) arr_alias";
     String expected = "";

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
@@ -125,10 +125,30 @@ public class ParseTreeBuilderTest {
   }
 
   @DataProvider(name = "validateSql")
-  public Object[][] getValidateSql() {
-    return new Object[][] {
+  public Iterator<Object[]> getValidateSql() {
+    List<List<String>> convertAndValidateSql = ImmutableList.of(
+        // test lateral view explode with a map
+        ImmutableList.of(
+            "SELECT key, value FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias AS key, value",
+            "SELECT `key`, `value` FROM (SELECT MAP['key1', 'value1'] AS `m`) AS `tmp`, LATERAL (SELECT * from UNNEST(`m`)) AS `m_alias` (`key`, `value`)"),
+        // hive automatically creates column aliases `key` and `value` when the type is a map
+        ImmutableList.of(
+            "SELECT key, value FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias",
+            "SELECT `key`, `value` FROM (SELECT MAP['key1', 'value1'] AS `m`) AS `tmp`, LATERAL (SELECT * from UNNEST(`m`)) AS `m_alias` (`key`, `value`)"),
         // hive doesn't support casting as varbinary
-        { "SELECT cast(a as binary) from foo", "SELECT cast(`a` as binary) from `foo`" }, { "SELECT cast(a as string) from foo", "SELECT cast(`a` as varchar) from `foo`" }, { "SELECT a, c from foo union all select x, y from bar", "SELECT * FROM (SELECT `a`, `c` from `foo` union all SELECT `x`, `y` from `bar`) as `_u1`" }, { "SELECT case (a + 10) when 20 then 5 when 30 then 10 else 1 END from foo", "SELECT CASE WHEN `a` + 10 = 20 THEN 5 WHEN `a` + 10 = 30 THEN 10 ELSE 1 END from `foo`" }, { "SELECT CASE WHEN a THEN 10 WHEN b THEN 20 ELSE 30 END from foo", "SELECT CASE WHEN `a` THEN 10 WHEN `b` THEN 20 ELSE 30 END from `foo`" }, { "SELECT named_struct('abc', 123, 'def', 234.23) FROM foo", "SELECT `named_struct`('abc', 123, 'def', 234.23) FROM `foo`" }, { "SELECT 0L from foo", "SELECT 0 from `foo`" } };
+        ImmutableList.of("SELECT cast(a as binary) from foo", "SELECT cast(`a` as binary) from `foo`"),
+        ImmutableList.of("SELECT cast(a as string) from foo", "SELECT cast(`a` as varchar) from `foo`"),
+        ImmutableList.of("SELECT a, c from foo union all select x, y from bar",
+            "SELECT * FROM (SELECT `a`, `c` from `foo` union all SELECT `x`, `y` from `bar`) as `_u1`"),
+        ImmutableList.of("SELECT case (a + 10) when 20 then 5 when 30 then 10 else 1 END from foo",
+            "SELECT CASE WHEN `a` + 10 = 20 THEN 5 WHEN `a` + 10 = 30 THEN 10 ELSE 1 END from `foo`"),
+        ImmutableList.of("SELECT CASE WHEN a THEN 10 WHEN b THEN 20 ELSE 30 END from foo",
+            "SELECT CASE WHEN `a` THEN 10 WHEN `b` THEN 20 ELSE 30 END from `foo`"),
+        ImmutableList.of("SELECT named_struct('abc', 123, 'def', 234.23) FROM foo",
+            "SELECT `named_struct`('abc', 123, 'def', 234.23) FROM `foo`"),
+        ImmutableList.of("SELECT 0L from foo", "SELECT 0 from `foo`"));
+
+    return convertAndValidateSql.stream().map(x -> new Object[] { x.get(0), x.get(1) }).iterator();
   }
 
   @Test(dataProvider = "convertSQL")

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -423,8 +423,8 @@ public class ViewToAvroSchemaConverterTests {
 
   @Test
   public void testLateralViewMap() {
-    String viewSql = "CREATE VIEW v AS " + "SELECT bl.Id AS Id_View_Col, t.Col1, t.Col2 " + "FROM baselateralview bl "
-        + "LATERAL VIEW explode(bl.Map_Col_String) t as Col1, Col2";
+    String viewSql = "CREATE VIEW v AS " + "SELECT bl.Id AS Id_View_Col, t.col1, t.col2 " + "FROM baselateralview bl "
+        + "LATERAL VIEW explode(bl.Map_Col_String) t as col1, col2";
 
     TestUtils.executeCreateViewQuery("default", "v", viewSql);
 

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/CoralSpark.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/CoralSpark.java
@@ -15,6 +15,7 @@ import org.apache.calcite.rel.RelNode;
 import com.linkedin.coral.spark.containers.SparkRelInfo;
 import com.linkedin.coral.spark.containers.SparkUDFInfo;
 import com.linkedin.coral.spark.dialect.SparkSqlDialect;
+import org.apache.calcite.rel.rel2sql.SqlImplementor;
 
 
 /**
@@ -84,7 +85,8 @@ public class CoralSpark {
    */
   private static String constructSparkSQL(RelNode sparkRelNode) {
     SparkRelToSparkSqlConverter rel2sql = new SparkRelToSparkSqlConverter();
-    return rel2sql.visitChild(0, sparkRelNode).asStatement().accept(new SparkSqlRewriter())
+    SqlImplementor.Result r = rel2sql.visitChild(0, sparkRelNode);
+    return r.asStatement().accept(new SparkSqlRewriter())
         .toSqlString(SparkSqlDialect.INSTANCE).getSql();
   }
 

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/CoralSpark.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/CoralSpark.java
@@ -11,11 +11,11 @@ import java.util.stream.Collectors;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.rel2sql.SqlImplementor;
 
 import com.linkedin.coral.spark.containers.SparkRelInfo;
 import com.linkedin.coral.spark.containers.SparkUDFInfo;
 import com.linkedin.coral.spark.dialect.SparkSqlDialect;
-import org.apache.calcite.rel.rel2sql.SqlImplementor;
 
 
 /**
@@ -86,8 +86,7 @@ public class CoralSpark {
   private static String constructSparkSQL(RelNode sparkRelNode) {
     SparkRelToSparkSqlConverter rel2sql = new SparkRelToSparkSqlConverter();
     SqlImplementor.Result r = rel2sql.visitChild(0, sparkRelNode);
-    return r.asStatement().accept(new SparkSqlRewriter())
-        .toSqlString(SparkSqlDialect.INSTANCE).getSql();
+    return r.asStatement().accept(new SparkSqlRewriter()).toSqlString(SparkSqlDialect.INSTANCE).getSql();
   }
 
   /**

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/CoralSpark.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/CoralSpark.java
@@ -85,6 +85,7 @@ public class CoralSpark {
    */
   private static String constructSparkSQL(RelNode sparkRelNode) {
     SparkRelToSparkSqlConverter rel2sql = new SparkRelToSparkSqlConverter();
+    // Create a temporary object r to make debugging easier
     SqlImplementor.Result r = rel2sql.visitChild(0, sparkRelNode);
     return r.asStatement().accept(new SparkSqlRewriter()).toSqlString(SparkSqlDialect.INSTANCE).getSql();
   }

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/SparkRelToSparkSqlConverter.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/SparkRelToSparkSqlConverter.java
@@ -8,7 +8,6 @@ package com.linkedin.coral.spark;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Correlate;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.TableScan;
@@ -103,11 +102,10 @@ public class SparkRelToSparkSqlConverter extends RelToSqlConverter {
     final Result rightResult = visitChild(1, e.getRight());
 
     // Unwrap the top-level SqlASOperator from the rightResult since we will create a SqlLateralViewAsOperator instead.
-    final SqlNode rightNode = rightResult.node.getKind() == SqlKind.AS ? ((SqlBasicCall)rightResult.node).getOperandList().get(0)
-            : rightResult.node;
+    final SqlNode rightNode = rightResult.node.getKind() == SqlKind.AS
+        ? ((SqlBasicCall) rightResult.node).getOperandList().get(0) : rightResult.node;
     final List<SqlNode> asOperands =
         createAsFullOperands(e.getRight().getRowType(), rightNode, rightResult.neededAlias);
-
 
     // Same as AS operator but instead of "AS TableRef(ColRef1, ColRef2)" produces "TableRef AS ColRef1, ColRef2"
     SqlNode rightLateral = SqlLateralViewAsOperator.instance.createCall(POS, asOperands);

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/SparkRelToSparkSqlConverter.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/SparkRelToSparkSqlConverter.java
@@ -158,8 +158,6 @@ public class SparkRelToSparkSqlConverter extends RelToSqlConverter {
     final SqlNode asNode = SqlStdOperatorTable.AS.createCall(POS, asOperands);
 
     return result(asNode, ImmutableList.of(Clause.FROM), e, null);
-
-    // return result(unnestNode, ImmutableList.of(Clause.FROM), e, null);
   }
 
   /**

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/SparkRelToSparkSqlConverter.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/SparkRelToSparkSqlConverter.java
@@ -217,7 +217,7 @@ public class SparkRelToSparkSqlConverter extends RelToSqlConverter {
             if (arrayOrMapNode instanceof SqlBasicCall) {
               SqlBasicCall arrayOrMapCall = (SqlBasicCall) arrayOrMapNode;
               if (arrayOrMapCall.getOperator() instanceof SqlMultisetValueConstructor
-                      && arrayOrMapCall.getOperandList().get(0) instanceof SqlLiteral) {
+                  && arrayOrMapCall.getOperandList().get(0) instanceof SqlLiteral) {
                 SqlLiteral sqlLiteral = (SqlLiteral) arrayOrMapCall.getOperandList().get(0);
                 return sqlLiteral.getTypeName().toString().equals("NULL");
               }

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/functions/SqlLateralViewAsOperator.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/functions/SqlLateralViewAsOperator.java
@@ -5,10 +5,10 @@
  */
 package com.linkedin.coral.spark.functions;
 
+import org.apache.calcite.sql.SqlAsOperator;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.type.InferTypes;
 import org.apache.calcite.sql.type.OperandTypes;
@@ -16,7 +16,19 @@ import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.util.Util;
 
 
-public class SqlLateralViewAsOperator extends SqlSpecialOperator {
+/**
+ * SqlLateralViewAsOperator inherits from SqlAsOperator.
+ *
+ * The only difference between the two is that the `unparse` method in SqlLateralViewAsOperator
+ * produces
+ *     "... table_alias AS column_alias1, column_alias2"
+ * instead of
+ *     "... AS table_alias(column_alias1, column_alias2)"
+ *
+ * The inheritance is necessary for the code to pass the assert condition in
+ * {@link org.apache.calcite.rel.rel2sql.SqlImplementor#wrapSelect(SqlNode)}
+ */
+public class SqlLateralViewAsOperator extends SqlAsOperator {
   public static SqlLateralViewAsOperator instance = new SqlLateralViewAsOperator();
 
   public SqlLateralViewAsOperator() {

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -293,9 +293,6 @@ public class CoralSparkTest {
     assertEquals(convertToSparkSql, targetSql);
   }
 
-  /**
-   * Following Queries are supported now
-   */
   @Test
   public void testLateralViewStar() {
     RelNode relNode = TestUtils

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -190,9 +190,9 @@ public class CoralSparkTest {
   @Test
   public void testLateralView() {
     RelNode relNode = TestUtils.toRelNode(
-            String.join("\n", "", "SELECT a, t.ccol", "FROM complex", "LATERAL VIEW explode(complex.c) t as ccol"));
+        String.join("\n", "", "SELECT a, t.ccol", "FROM complex", "LATERAL VIEW explode(complex.c) t as ccol"));
     String targetSql = String.join("\n", "SELECT complex.a, t1.ccol",
-            "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t1 AS ccol");
+        "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t1 AS ccol");
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -379,63 +379,52 @@ public class CoralSparkTest {
 
   @Test
   public void testLateralViewArray() {
-    RelNode relNode = TestUtils.toRelNode(
-            "SELECT col FROM (SELECT ARRAY('a1', 'a2') as a) tmp LATERAL VIEW EXPLODE(a) a_alias AS col"
-    );
+    RelNode relNode = TestUtils
+        .toRelNode("SELECT col FROM (SELECT ARRAY('a1', 'a2') as a) tmp LATERAL VIEW EXPLODE(a) a_alias AS col");
 
-    String targetSql = "SELECT t20.col\n" +
-            "FROM (SELECT ARRAY ('a1', 'a2') a\n" +
-            "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.a) t20 AS col";
+    String targetSql = "SELECT t20.col\n" + "FROM (SELECT ARRAY ('a1', 'a2') a\n"
+        + "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.a) t20 AS col";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testLateralViewArrayWithoutColumns() {
-    RelNode relNode = TestUtils.toRelNode(
-            "SELECT col FROM (SELECT ARRAY('a1', 'a2') as a) tmp LATERAL VIEW EXPLODE(a) a_alias"
-    );
+    RelNode relNode =
+        TestUtils.toRelNode("SELECT col FROM (SELECT ARRAY('a1', 'a2') as a) tmp LATERAL VIEW EXPLODE(a) a_alias");
 
-    String targetSql = "SELECT t20.col\n" +
-            "FROM (SELECT ARRAY ('a1', 'a2') a\n" +
-            "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.a) t20 AS col";
+    String targetSql = "SELECT t20.col\n" + "FROM (SELECT ARRAY ('a1', 'a2') a\n"
+        + "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.a) t20 AS col";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testLateralViewMap2() {
     RelNode relNode = TestUtils.toRelNode(
-            "SELECT key, value FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias AS key, value"
-    );
+        "SELECT key, value FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias AS key, value");
 
-    String targetSql = "SELECT t20.KEY key, t20.VALUE value\n" +
-            "FROM (SELECT MAP ('key1', 'value1') m\n" +
-            "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.m) t20 AS KEY, VALUE";
+    String targetSql = "SELECT t20.KEY key, t20.VALUE value\n" + "FROM (SELECT MAP ('key1', 'value1') m\n"
+        + "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.m) t20 AS KEY, VALUE";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testLateralViewMapRenameColumns() {
     RelNode relNode = TestUtils.toRelNode(
-            "SELECT k1, v1 FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias AS k1, v1"
-    );
+        "SELECT k1, v1 FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias AS k1, v1");
 
-    String targetSql = "SELECT t20.KEY k1, t20.VALUE v1\n" +
-            "FROM (SELECT MAP ('key1', 'value1') m\n" +
-            "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.m) t20 AS KEY, VALUE";
+    String targetSql = "SELECT t20.KEY k1, t20.VALUE v1\n" + "FROM (SELECT MAP ('key1', 'value1') m\n"
+        + "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.m) t20 AS KEY, VALUE";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testLateralViewMapWithoutColumns() {
-    RelNode relNode = TestUtils.toRelNode(
-            "SELECT key, value FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias"
-    );
+    RelNode relNode = TestUtils
+        .toRelNode("SELECT key, value FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias");
 
-    String targetSql = "SELECT t20.KEY key, t20.VALUE value\n" +
-            "FROM (SELECT MAP ('key1', 'value1') m\n" +
-            "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.m) t20 AS KEY, VALUE";
+    String targetSql = "SELECT t20.KEY key, t20.VALUE value\n" + "FROM (SELECT MAP ('key1', 'value1') m\n"
+        + "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.m) t20 AS KEY, VALUE";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
-
 
 }

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -389,7 +389,7 @@ public class CoralSparkTest {
     RelNode relNode =
         TestUtils.toRelNode("SELECT arr.alias FROM foo tmp LATERAL VIEW EXPLODE(ARRAY('a', 'b')) arr as alias");
 
-    String targetSql = "SELECT t0.alias\n" + "FROM default.foo,\n" + "EXPLODE(ARRAY ('a', 'b')) t0 AS alias";
+    String targetSql = "SELECT t0.alias\n" + "FROM default.foo LATERAL VIEW EXPLODE(ARRAY ('a', 'b')) t0 AS alias";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -191,8 +191,8 @@ public class CoralSparkTest {
   public void testLateralView() {
     RelNode relNode = TestUtils.toRelNode(
         String.join("\n", "", "SELECT a, t.ccol", "FROM complex", "LATERAL VIEW explode(complex.c) t as ccol"));
-    String targetSql = String.join("\n", "SELECT complex.a, t1.ccol",
-        "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t1 AS ccol");
+    String targetSql =
+        "SELECT complex.a, t00.ccol\n" + "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t00 AS ccol";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -204,8 +204,8 @@ public class CoralSparkTest {
     System.out.println(relNodePlan);
     String convertToSparkSql = CoralSpark.create(relNode).getSparkSql();
 
-    String targetSql = String.join("\n", "SELECT complex.a, t1.ccol", "FROM default.complex " + "LATERAL VIEW OUTER "
-        + "EXPLODE(" + "if(complex.c IS NOT NULL AND size(complex.c) > 0, complex.c, ARRAY (NULL))" + ") t1 AS ccol");
+    String targetSql = "SELECT complex.a, t00.ccol\n"
+        + "FROM default.complex LATERAL VIEW OUTER EXPLODE(if(complex.c IS NOT NULL AND size(complex.c) > 0, complex.c, ARRAY (NULL))) t00 AS ccol";
     assertEquals(convertToSparkSql, targetSql);
   }
 
@@ -213,8 +213,8 @@ public class CoralSparkTest {
   public void testMultipleLateralView() {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT a, t.ccol, t2.ccol2", "FROM complex ",
         "LATERAL VIEW explode(complex.c) t AS ccol ", "LATERAL VIEW explode(complex.c) t2 AS ccol2 "));
-    String targetSql = String.join("\n", "SELECT complex.a, t1.ccol, t4.ccol2", "FROM default.complex "
-        + "LATERAL VIEW EXPLODE(complex.c) t1 AS ccol " + "LATERAL VIEW EXPLODE(complex.c) t4 AS ccol2");
+    String targetSql = "SELECT complex.a, t00.ccol, t20.ccol2\n"
+        + "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t00 AS ccol LATERAL VIEW EXPLODE(complex.c) t20 AS ccol2";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -222,8 +222,8 @@ public class CoralSparkTest {
   public void testLateralViewMap() {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT a, t.ccol1, t.ccol2", "FROM complex",
         "LATERAL VIEW explode(complex.m) t as ccol1, ccol2"));
-    String targetSql = String.join("\n", "SELECT complex.a, t1.KEY ccol1, t1.VALUE ccol2",
-        "FROM default.complex LATERAL VIEW EXPLODE(complex.m) t1 AS KEY, VALUE");
+    String targetSql = "SELECT complex.a, t00.ccol1, t00.ccol2\n"
+        + "FROM default.complex LATERAL VIEW EXPLODE(complex.m) t00 AS ccol1, ccol2";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -231,8 +231,8 @@ public class CoralSparkTest {
   public void testLateralViewMapOuter() {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT a, t.ccol1, t.ccol2", "FROM complex",
         "LATERAL VIEW OUTER explode(complex.m) t as ccol1, ccol2"));
-    String targetSql = String.join("\n", "SELECT complex.a, t1.KEY ccol1, t1.VALUE ccol2",
-        "FROM default.complex LATERAL VIEW OUTER EXPLODE(if(complex.m IS NOT NULL AND size(complex.m) > 0, complex.m, MAP (NULL, NULL))) t1 AS KEY, VALUE");
+    String targetSql = String.join("\n", "SELECT complex.a, t00.ccol1, t00.ccol2",
+        "FROM default.complex LATERAL VIEW OUTER EXPLODE(if(complex.m IS NOT NULL AND size(complex.m) > 0, complex.m, MAP (NULL, NULL))) t00 AS ccol1, ccol2");
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -294,22 +294,23 @@ public class CoralSparkTest {
   }
 
   /**
-   * Following Queries are not supported
+   * Following Queries are supported now
    */
-
-  @Test(expectedExceptions = IllegalStateException.class)
-  public void testLateralViewStarNotSupported() {
+  @Test
+  public void testLateralViewStar() {
     RelNode relNode = TestUtils
         .toRelNode(String.join("\n", "", "SELECT a, t.*", "FROM complex", "LATERAL VIEW explode(complex.c) t"));
-    CoralSpark.create(relNode);
+    String targetSql =
+        "SELECT complex.a, t00.col\n" + "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t00 AS col";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testLateralViewGroupBy() {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT adid, count(1)", "FROM complex",
         "LATERAL VIEW explode(c) t as adid", "GROUP BY adid"));
-    String targetSql = String.join("\n", "SELECT t1.adid, COUNT(*)",
-        "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t1 AS adid", "GROUP BY t1.adid");
+    String targetSql = "SELECT t00.adid, COUNT(*)\n"
+        + "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t00 AS adid\n" + "GROUP BY t00.adid";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -402,8 +403,8 @@ public class CoralSparkTest {
     RelNode relNode = TestUtils.toRelNode(
         "SELECT key, value FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias AS key, value");
 
-    String targetSql = "SELECT t20.KEY key, t20.VALUE value\n" + "FROM (SELECT MAP ('key1', 'value1') m\n"
-        + "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.m) t20 AS KEY, VALUE";
+    String targetSql = "SELECT t20.key, t20.value\n" + "FROM (SELECT MAP ('key1', 'value1') m\n"
+        + "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.m) t20 AS key, value";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -412,8 +413,8 @@ public class CoralSparkTest {
     RelNode relNode = TestUtils.toRelNode(
         "SELECT k1, v1 FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias AS k1, v1");
 
-    String targetSql = "SELECT t20.KEY k1, t20.VALUE v1\n" + "FROM (SELECT MAP ('key1', 'value1') m\n"
-        + "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.m) t20 AS KEY, VALUE";
+    String targetSql = "SELECT t20.k1, t20.v1\n" + "FROM (SELECT MAP ('key1', 'value1') m\n"
+        + "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.m) t20 AS k1, v1";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -192,7 +192,7 @@ public class CoralSparkTest {
     RelNode relNode = TestUtils.toRelNode(
         String.join("\n", "", "SELECT a, t.ccol", "FROM complex", "LATERAL VIEW explode(complex.c) t as ccol"));
     String targetSql =
-        "SELECT complex.a, t00.ccol\n" + "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t00 AS ccol";
+        "SELECT complex.a, t0.ccol\n" + "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t0 AS ccol";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -204,8 +204,8 @@ public class CoralSparkTest {
     System.out.println(relNodePlan);
     String convertToSparkSql = CoralSpark.create(relNode).getSparkSql();
 
-    String targetSql = "SELECT complex.a, t00.ccol\n"
-        + "FROM default.complex LATERAL VIEW OUTER EXPLODE(if(complex.c IS NOT NULL AND size(complex.c) > 0, complex.c, ARRAY (NULL))) t00 AS ccol";
+    String targetSql = "SELECT complex.a, t0.ccol\n"
+        + "FROM default.complex LATERAL VIEW OUTER EXPLODE(if(complex.c IS NOT NULL AND size(complex.c) > 0, complex.c, ARRAY (NULL))) t0 AS ccol";
     assertEquals(convertToSparkSql, targetSql);
   }
 
@@ -213,8 +213,8 @@ public class CoralSparkTest {
   public void testMultipleLateralView() {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT a, t.ccol, t2.ccol2", "FROM complex ",
         "LATERAL VIEW explode(complex.c) t AS ccol ", "LATERAL VIEW explode(complex.c) t2 AS ccol2 "));
-    String targetSql = "SELECT complex.a, t00.ccol, t20.ccol2\n"
-        + "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t00 AS ccol LATERAL VIEW EXPLODE(complex.c) t20 AS ccol2";
+    String targetSql = "SELECT complex.a, t0.ccol, t2.ccol2\n"
+        + "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t0 AS ccol LATERAL VIEW EXPLODE(complex.c) t2 AS ccol2";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -222,8 +222,8 @@ public class CoralSparkTest {
   public void testLateralViewMap() {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT a, t.ccol1, t.ccol2", "FROM complex",
         "LATERAL VIEW explode(complex.m) t as ccol1, ccol2"));
-    String targetSql = "SELECT complex.a, t00.ccol1, t00.ccol2\n"
-        + "FROM default.complex LATERAL VIEW EXPLODE(complex.m) t00 AS ccol1, ccol2";
+    String targetSql = "SELECT complex.a, t0.ccol1, t0.ccol2\n"
+        + "FROM default.complex LATERAL VIEW EXPLODE(complex.m) t0 AS ccol1, ccol2";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -231,8 +231,8 @@ public class CoralSparkTest {
   public void testLateralViewMapOuter() {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT a, t.ccol1, t.ccol2", "FROM complex",
         "LATERAL VIEW OUTER explode(complex.m) t as ccol1, ccol2"));
-    String targetSql = String.join("\n", "SELECT complex.a, t00.ccol1, t00.ccol2",
-        "FROM default.complex LATERAL VIEW OUTER EXPLODE(if(complex.m IS NOT NULL AND size(complex.m) > 0, complex.m, MAP (NULL, NULL))) t00 AS ccol1, ccol2");
+    String targetSql = String.join("\n", "SELECT complex.a, t0.ccol1, t0.ccol2",
+        "FROM default.complex LATERAL VIEW OUTER EXPLODE(if(complex.m IS NOT NULL AND size(complex.m) > 0, complex.m, MAP (NULL, NULL))) t0 AS ccol1, ccol2");
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -297,8 +297,7 @@ public class CoralSparkTest {
   public void testLateralViewStar() {
     RelNode relNode = TestUtils
         .toRelNode(String.join("\n", "", "SELECT a, t.*", "FROM complex", "LATERAL VIEW explode(complex.c) t"));
-    String targetSql =
-        "SELECT complex.a, t00.col\n" + "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t00 AS col";
+    String targetSql = "SELECT complex.a, t0.col\n" + "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t0 AS col";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -306,8 +305,8 @@ public class CoralSparkTest {
   public void testLateralViewGroupBy() {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT adid, count(1)", "FROM complex",
         "LATERAL VIEW explode(c) t as adid", "GROUP BY adid"));
-    String targetSql = "SELECT t00.adid, COUNT(*)\n"
-        + "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t00 AS adid\n" + "GROUP BY t00.adid";
+    String targetSql = "SELECT t0.adid, COUNT(*)\n"
+        + "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t0 AS adid\n" + "GROUP BY t0.adid";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -380,8 +379,17 @@ public class CoralSparkTest {
     RelNode relNode = TestUtils
         .toRelNode("SELECT col FROM (SELECT ARRAY('a1', 'a2') as a) tmp LATERAL VIEW EXPLODE(a) a_alias AS col");
 
-    String targetSql = "SELECT t20.col\n" + "FROM (SELECT ARRAY ('a1', 'a2') a\n"
-        + "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.a) t20 AS col";
+    String targetSql = "SELECT t2.col\n" + "FROM (SELECT ARRAY ('a1', 'a2') a\n"
+        + "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.a) t2 AS col";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+  }
+
+  @Test
+  public void testLateralViewArray2() {
+    RelNode relNode =
+        TestUtils.toRelNode("SELECT arr.alias FROM foo tmp LATERAL VIEW EXPLODE(ARRAY('a', 'b')) arr as alias");
+
+    String targetSql = "SELECT t0.alias\n" + "FROM default.foo,\n" + "EXPLODE(ARRAY ('a', 'b')) t0 AS alias";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -390,8 +398,8 @@ public class CoralSparkTest {
     RelNode relNode =
         TestUtils.toRelNode("SELECT col FROM (SELECT ARRAY('a1', 'a2') as a) tmp LATERAL VIEW EXPLODE(a) a_alias");
 
-    String targetSql = "SELECT t20.col\n" + "FROM (SELECT ARRAY ('a1', 'a2') a\n"
-        + "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.a) t20 AS col";
+    String targetSql = "SELECT t2.col\n" + "FROM (SELECT ARRAY ('a1', 'a2') a\n"
+        + "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.a) t2 AS col";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -400,8 +408,8 @@ public class CoralSparkTest {
     RelNode relNode = TestUtils.toRelNode(
         "SELECT key, value FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias AS key, value");
 
-    String targetSql = "SELECT t20.key, t20.value\n" + "FROM (SELECT MAP ('key1', 'value1') m\n"
-        + "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.m) t20 AS key, value";
+    String targetSql = "SELECT t2.key, t2.value\n" + "FROM (SELECT MAP ('key1', 'value1') m\n"
+        + "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.m) t2 AS key, value";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -410,8 +418,8 @@ public class CoralSparkTest {
     RelNode relNode = TestUtils.toRelNode(
         "SELECT k1, v1 FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias AS k1, v1");
 
-    String targetSql = "SELECT t20.k1, t20.v1\n" + "FROM (SELECT MAP ('key1', 'value1') m\n"
-        + "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.m) t20 AS k1, v1";
+    String targetSql = "SELECT t2.k1, t2.v1\n" + "FROM (SELECT MAP ('key1', 'value1') m\n"
+        + "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.m) t2 AS k1, v1";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -420,8 +428,8 @@ public class CoralSparkTest {
     RelNode relNode = TestUtils
         .toRelNode("SELECT key, value FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias");
 
-    String targetSql = "SELECT t20.KEY key, t20.VALUE value\n" + "FROM (SELECT MAP ('key1', 'value1') m\n"
-        + "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.m) t20 AS KEY, VALUE";
+    String targetSql = "SELECT t2.KEY key, t2.VALUE value\n" + "FROM (SELECT MAP ('key1', 'value1') m\n"
+        + "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.m) t2 AS KEY, VALUE";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -190,9 +190,9 @@ public class CoralSparkTest {
   @Test
   public void testLateralView() {
     RelNode relNode = TestUtils.toRelNode(
-        String.join("\n", "", "SELECT a, t.ccol", "FROM complex", "LATERAL VIEW explode(complex.c) t as ccol"));
+            String.join("\n", "", "SELECT a, t.ccol", "FROM complex", "LATERAL VIEW explode(complex.c) t as ccol"));
     String targetSql = String.join("\n", "SELECT complex.a, t1.ccol",
-        "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t1 AS ccol");
+            "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t1 AS ccol");
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -376,5 +376,66 @@ public class CoralSparkTest {
     }
     return listOfUriStrings;
   }
+
+  @Test
+  public void testLateralViewArray() {
+    RelNode relNode = TestUtils.toRelNode(
+            "SELECT col FROM (SELECT ARRAY('a1', 'a2') as a) tmp LATERAL VIEW EXPLODE(a) a_alias AS col"
+    );
+
+    String targetSql = "SELECT t20.col\n" +
+            "FROM (SELECT ARRAY ('a1', 'a2') a\n" +
+            "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.a) t20 AS col";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+  }
+
+  @Test
+  public void testLateralViewArrayWithoutColumns() {
+    RelNode relNode = TestUtils.toRelNode(
+            "SELECT col FROM (SELECT ARRAY('a1', 'a2') as a) tmp LATERAL VIEW EXPLODE(a) a_alias"
+    );
+
+    String targetSql = "SELECT t20.col\n" +
+            "FROM (SELECT ARRAY ('a1', 'a2') a\n" +
+            "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.a) t20 AS col";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+  }
+
+  @Test
+  public void testLateralViewMap2() {
+    RelNode relNode = TestUtils.toRelNode(
+            "SELECT key, value FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias AS key, value"
+    );
+
+    String targetSql = "SELECT t20.KEY key, t20.VALUE value\n" +
+            "FROM (SELECT MAP ('key1', 'value1') m\n" +
+            "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.m) t20 AS KEY, VALUE";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+  }
+
+  @Test
+  public void testLateralViewMapRenameColumns() {
+    RelNode relNode = TestUtils.toRelNode(
+            "SELECT k1, v1 FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias AS k1, v1"
+    );
+
+    String targetSql = "SELECT t20.KEY k1, t20.VALUE v1\n" +
+            "FROM (SELECT MAP ('key1', 'value1') m\n" +
+            "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.m) t20 AS KEY, VALUE";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+  }
+
+  @Test
+  public void testLateralViewMapWithoutColumns() {
+    RelNode relNode = TestUtils.toRelNode(
+            "SELECT key, value FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias"
+    );
+
+    String targetSql = "SELECT t20.KEY key, t20.VALUE value\n" +
+            "FROM (SELECT MAP ('key1', 'value1') m\n" +
+            "FROM (VALUES  (0)) t (ZERO)) t0 LATERAL VIEW EXPLODE(t0.m) t20 AS KEY, VALUE";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+  }
+
 
 }

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
@@ -223,6 +223,9 @@ public class RelToTrinoConverter extends RelToSqlConverter {
     final Result rightResult = visitChild(1, e.getRight());
     SqlNode rightLateral = rightResult.node;
     if (rightLateral.getKind() != SqlKind.AS) {
+      // LATERAL is only needed in Trino if it's not an AS node.
+      // For example, "FROM t0 CROSS JOIN UNNEST(yyy) AS t1(col1, col2)" is valid Trino SQL
+      // without the need of LATERAL keywords.
       rightLateral = SqlStdOperatorTable.LATERAL.createCall(POS, rightLateral);
       rightLateral =
           SqlStdOperatorTable.AS.createCall(POS, rightLateral, new SqlIdentifier(rightResult.neededAlias, POS));

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
@@ -222,8 +222,8 @@ public class RelToTrinoConverter extends RelToSqlConverter {
     parseCorrelTable(e, leftResult);
     final Result rightResult = visitChild(1, e.getRight());
     SqlNode rightLateral = rightResult.node;
-    rightLateral = SqlStdOperatorTable.LATERAL.createCall(POS, rightLateral);
     if (rightLateral.getKind() != SqlKind.AS) {
+      rightLateral = SqlStdOperatorTable.LATERAL.createCall(POS, rightLateral);
       rightLateral =
           SqlStdOperatorTable.AS.createCall(POS, rightLateral, new SqlIdentifier(rightResult.neededAlias, POS));
     }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -192,6 +192,21 @@ public class HiveToTrinoConverterTest {
     assertEquals(expandedSql, targetSql);
   }
 
+  /**
+   * Test the generation of COMMA JOIN in Presto from Lateral views that are uncorrelated.
+   */
+  @Test
+  public void testLateralViewArray2() {
+    RelNode relNode = hiveToRelConverter
+        .convertSql("SELECT arr.alias FROM test.tableA tmp LATERAL VIEW EXPLODE(ARRAY('a', 'b')) arr as alias");
+
+    String targetSql = "SELECT \"t0\".\"alias\" AS \"alias\"\n" + "FROM \"test\".\"tablea\",\n"
+        + "UNNEST(ARRAY['a', 'b']) AS \"t0\" (\"alias\")";
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
+
   @Test
   public void testLateralViewArrayWithoutColumns() {
     RelNode relNode = hiveToRelConverter

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -181,14 +181,11 @@ public class HiveToTrinoConverterTest {
 
   @Test
   public void testLateralViewArray() {
-    RelNode relNode = hiveToRelConverter.convertSql(
-            "SELECT col FROM (SELECT ARRAY('a1', 'a2') as a) tmp LATERAL VIEW EXPLODE(a) a_alias AS col"
-    );
-    String targetSql = "SELECT \"t3\".\"col\" AS \"col\"\n" +
-            "FROM (SELECT ARRAY['a1', 'a2'] AS \"a\"\n" +
-            "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")) AS \"$cor0\"\n" +
-            "CROSS JOIN LATERAL (SELECT \"col\"\n" +
-            "FROM UNNEST(\"$cor0\".\"a\") AS \"t2\" (\"col\")) AS \"t3\"";
+    RelNode relNode = hiveToRelConverter
+        .convertSql("SELECT col FROM (SELECT ARRAY('a1', 'a2') as a) tmp LATERAL VIEW EXPLODE(a) a_alias AS col");
+    String targetSql = "SELECT \"t3\".\"col\" AS \"col\"\n" + "FROM (SELECT ARRAY['a1', 'a2'] AS \"a\"\n"
+        + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")) AS \"$cor0\"\n" + "CROSS JOIN LATERAL (SELECT \"col\"\n"
+        + "FROM UNNEST(\"$cor0\".\"a\") AS \"t2\" (\"col\")) AS \"t3\"";
 
     RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
     String expandedSql = relToTrinoConverter.convert(relNode);
@@ -197,14 +194,11 @@ public class HiveToTrinoConverterTest {
 
   @Test
   public void testLateralViewArrayWithoutColumns() {
-    RelNode relNode = hiveToRelConverter.convertSql(
-            "SELECT col FROM (SELECT ARRAY('a1', 'a2') as a) tmp LATERAL VIEW EXPLODE(a) a_alias"
-    );
-    String targetSql = "SELECT \"t3\".\"col\" AS \"col\"\n" +
-            "FROM (SELECT ARRAY['a1', 'a2'] AS \"a\"\n" +
-            "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")) AS \"$cor0\"\n" +
-            "CROSS JOIN LATERAL (SELECT \"a\" AS \"col\"\n" +
-            "FROM UNNEST(\"$cor0\".\"a\") AS \"t2\" (\"a\")) AS \"t3\"";
+    RelNode relNode = hiveToRelConverter
+        .convertSql("SELECT col FROM (SELECT ARRAY('a1', 'a2') as a) tmp LATERAL VIEW EXPLODE(a) a_alias");
+    String targetSql = "SELECT \"t3\".\"col\" AS \"col\"\n" + "FROM (SELECT ARRAY['a1', 'a2'] AS \"a\"\n"
+        + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")) AS \"$cor0\"\n" + "CROSS JOIN LATERAL (SELECT \"a\" AS \"col\"\n"
+        + "FROM UNNEST(\"$cor0\".\"a\") AS \"t2\" (\"a\")) AS \"t3\"";
 
     RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
     String expandedSql = relToTrinoConverter.convert(relNode);
@@ -214,13 +208,11 @@ public class HiveToTrinoConverterTest {
   @Test
   public void testLateralViewMap() {
     RelNode relNode = hiveToRelConverter.convertSql(
-            "SELECT key, value FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias AS key, value"
-    );
-    String targetSql = "SELECT \"t3\".\"KEY\" AS \"key\", \"t3\".\"VALUE\" AS \"value\"\n" +
-            "FROM (SELECT MAP (ARRAY['key1'], ARRAY['value1']) AS \"m\"\n" +
-            "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")) AS \"$cor0\"\n" +
-            "CROSS JOIN LATERAL (SELECT \"KEY\", \"VALUE\"\n" +
-            "FROM UNNEST(\"$cor0\".\"m\") AS \"t2\" (\"KEY\", \"VALUE\")) AS \"t3\"";
+        "SELECT key, value FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias AS key, value");
+    String targetSql = "SELECT \"t3\".\"KEY\" AS \"key\", \"t3\".\"VALUE\" AS \"value\"\n"
+        + "FROM (SELECT MAP (ARRAY['key1'], ARRAY['value1']) AS \"m\"\n"
+        + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")) AS \"$cor0\"\n" + "CROSS JOIN LATERAL (SELECT \"KEY\", \"VALUE\"\n"
+        + "FROM UNNEST(\"$cor0\".\"m\") AS \"t2\" (\"KEY\", \"VALUE\")) AS \"t3\"";
 
     RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
     String expandedSql = relToTrinoConverter.convert(relNode);
@@ -229,14 +221,12 @@ public class HiveToTrinoConverterTest {
 
   @Test
   public void testLateralViewMapWithoutAlias() {
-    RelNode relNode = hiveToRelConverter.convertSql(
-            "SELECT key, value FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias"
-    );
-    String targetSql = "SELECT \"t3\".\"KEY\" AS \"key\", \"t3\".\"VALUE\" AS \"value\"\n" +
-            "FROM (SELECT MAP (ARRAY['key1'], ARRAY['value1']) AS \"m\"\n" +
-            "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")) AS \"$cor0\"\n" +
-            "CROSS JOIN LATERAL (SELECT \"KEY\", \"VALUE\"\n" +
-            "FROM UNNEST(\"$cor0\".\"m\") AS \"t2\" (\"KEY\", \"VALUE\")) AS \"t3\"";
+    RelNode relNode = hiveToRelConverter
+        .convertSql("SELECT key, value FROM (SELECT MAP('key1', 'value1') as m) tmp LATERAL VIEW EXPLODE(m) m_alias");
+    String targetSql = "SELECT \"t3\".\"KEY\" AS \"key\", \"t3\".\"VALUE\" AS \"value\"\n"
+        + "FROM (SELECT MAP (ARRAY['key1'], ARRAY['value1']) AS \"m\"\n"
+        + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")) AS \"$cor0\"\n" + "CROSS JOIN LATERAL (SELECT \"KEY\", \"VALUE\"\n"
+        + "FROM UNNEST(\"$cor0\".\"m\") AS \"t2\" (\"KEY\", \"VALUE\")) AS \"t3\"";
 
     RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
     String expandedSql = relToTrinoConverter.convert(relNode);

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverterTest.java
@@ -250,7 +250,7 @@ public class RelToTrinoConverterTest {
   public void testUnnestConstant() {
     final String sql = "" + "SELECT c1 + 2\n" + "FROM UNNEST(ARRAY[(1, 1),(2, 2), (3, 3)]) as t(c1, c2)";
 
-    final String expected = "" + "SELECT \"t00\".\"col_0\" + 2\n"
+    final String expected = "" + "SELECT \"t0\".\"col_0\" + 2\n"
         + "FROM UNNEST(ARRAY[ROW(1, 1), ROW(2, 2), ROW(3, 3)]) AS \"t0\" (\"col_0\", \"col_1\")";
     testConversion(sql, expected);
   }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
@@ -47,7 +47,6 @@ public class TestUtils {
   private static HiveMscAdapter hiveMetastoreClient;
   static HiveToRelConverter hiveToRelConverter;
 
-
   public static FrameworkConfig createFrameworkConfig(TestTable... tables) {
     SchemaPlus rootSchema = Frameworks.createRootSchema(true);
     Arrays.asList(tables).forEach(t -> rootSchema.add(t.getTableName(), t));

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
@@ -45,6 +45,8 @@ import static java.lang.String.format;
 
 public class TestUtils {
   private static HiveMscAdapter hiveMetastoreClient;
+  static HiveToRelConverter hiveToRelConverter;
+
 
   public static FrameworkConfig createFrameworkConfig(TestTable... tables) {
     SchemaPlus rootSchema = Frameworks.createRootSchema(true);
@@ -189,6 +191,7 @@ public class TestUtils {
     SessionState.start(conf);
     Driver driver = new Driver(conf);
     hiveMetastoreClient = new HiveMscAdapter(Hive.get(conf).getMSC());
+    hiveToRelConverter = HiveToRelConverter.create(hiveMetastoreClient);
 
     // Views and tables used in HiveToTrinoConverterTest
     run(driver, "CREATE DATABASE IF NOT EXISTS test");


### PR DESCRIPTION
This patch fixes two problems:
1. While `LATERAL VIEW EXPLODE(my_array) t AS col`, `LATERAL VIEW EXPLODE(my_map) t AS key, value` are supported, `LATERAL VIEW EXPLODE(my_array_or_map) t` was not supported until this patch;
2. coral-trino generates queries like `FROM t CROSS JOIN LATERAL (SELECT xxx FROM UNNEST(t.arr_col) AS t2(c2))` which is not supported by the version of Trino that I am using.  With this patch, it generates `FROM t CROSS JOIN UNNEST(t.arr_col) AS t2(c2)` which is well supported by Presto as noted [in trino official doc](https://trino.io/docs/current/sql/select.html#unnest)