### PR TITLE
Coral-Schema: Add support for decimal type

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
@@ -21,6 +21,8 @@ import org.apache.calcite.sql.type.BasicSqlType;
 import org.apache.calcite.sql.type.MapSqlType;
 import org.apache.calcite.sql.type.MultisetSqlType;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.hadoop.hive.serde2.avro.AvroSerDe;
+import org.codehaus.jackson.node.JsonNodeFactory;
 
 import com.linkedin.coral.com.google.common.base.Preconditions;
 
@@ -106,6 +108,13 @@ class RelDataTypeToAvroType {
         Schema schema = Schema.create(Schema.Type.LONG);
         schema.addProp("logicalType", "timestamp");
         return schema;
+      case DECIMAL:
+        JsonNodeFactory factory = JsonNodeFactory.instance;
+        Schema decimalSchema = Schema.create(Schema.Type.BYTES);
+        decimalSchema.addProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE, AvroSerDe.DECIMAL_TYPE_NAME);
+        decimalSchema.addProp(AvroSerDe.AVRO_PROP_PRECISION, factory.numberNode(relDataType.getPrecision()));
+        decimalSchema.addProp(AvroSerDe.AVRO_PROP_SCALE, factory.numberNode(relDataType.getScale()));
+        return decimalSchema;
       default:
         throw new UnsupportedOperationException(relDataType.getSqlTypeName() + " is not supported.");
     }

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
@@ -117,7 +117,7 @@ public class TestUtils {
         + "array_col_3: array<struct<struct_col_6:struct<int_field_5:int>>>>)");
 
     executeQuery("DROP TABLE IF EXISTS basedecimal");
-    executeQuery("CREATE TABLE IF NOT EXISTS basedecimal(decimal_col decimal(2,2))");
+    executeQuery("CREATE TABLE IF NOT EXISTS basedecimal(decimal_col decimal(2,1))");
   }
 
   private static void initializeUdfs() {

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
@@ -115,6 +115,9 @@ public class TestUtils {
         + "map_col_1 map<string, struct<map_col_2:map<string, struct<int_field_3:int>>>>, "
         + "struct_col_4 struct<map_col_3: map<string, struct<struct_col_5:struct<int_field_4:int>>>, "
         + "array_col_3: array<struct<struct_col_6:struct<int_field_5:int>>>>)");
+
+    executeQuery("DROP TABLE IF EXISTS basedecimal");
+    executeQuery("CREATE TABLE IF NOT EXISTS basedecimal(decimal_col decimal(2,2))");
   }
 
   private static void initializeUdfs() {

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -871,5 +871,16 @@ public class ViewToAvroSchemaConverterTests {
     Assert.assertEquals(actualSchema.toString(true),
         TestUtils.loadSchema("docTestResources/testMultipleLateralViewDifferentArrayType-expected-with-doc.avsc"));
   }
+
+  @Test
+  public void testDecimalType() {
+    String viewSql = "CREATE VIEW v AS SELECT * FROM basedecimal";
+    TestUtils.executeCreateViewQuery("default", "v", viewSql);
+
+    ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);
+    Schema actualSchema = viewToAvroSchemaConverter.toAvroSchema("default", "v");
+
+    Assert.assertEquals(actualSchema.toString(true), TestUtils.loadSchema("testDecimalType-expected.avsc"));
+  }
   // TODO: add more unit tests
 }

--- a/coral-schema/src/test/resources/testDecimalType-expected.avsc
+++ b/coral-schema/src/test/resources/testDecimalType-expected.avsc
@@ -8,7 +8,7 @@
       "type" : "bytes",
       "logicalType" : "decimal",
       "precision" : 2,
-      "scale" : 2
+      "scale" : 1
     } ],
     "default" : null
   } ]

--- a/coral-schema/src/test/resources/testDecimalType-expected.avsc
+++ b/coral-schema/src/test/resources/testDecimalType-expected.avsc
@@ -1,0 +1,15 @@
+{
+  "type" : "record",
+  "name" : "v",
+  "namespace" : "default.v",
+  "fields" : [ {
+    "name" : "decimal_col",
+    "type" : [ "null", {
+      "type" : "bytes",
+      "logicalType" : "decimal",
+      "precision" : 2,
+      "scale" : 2
+    } ],
+    "default" : null
+  } ]
+}


### PR DESCRIPTION
At present, there is no support for decimal type in `RelDataTypeToAvroType`.

Tests:
1. unit test
2. tested on the affected production views, which could be translated well with this patch
3. integration test, no regression after verification