### PR TITLE
Add support for bracketed comments

### DIFF
--- a/coral-hive/src/main/antlr/roots/com/linkedin/coral/hive/hive2rel/parsetree/parser/HiveLexer.g
+++ b/coral-hive/src/main/antlr/roots/com/linkedin/coral/hive/hive2rel/parsetree/parser/HiveLexer.g
@@ -472,4 +472,6 @@ WS  :  (' '|'\r'|'\t'|'\n') {$channel=HIDDEN;}
 COMMENT
   : '--' (~('\n'|'\r'))*
     { $channel=HIDDEN; }
+  | '/*' (options { greedy=false; } : .)* '*/'
+    { $channel=HIDDEN; }
   ;

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
@@ -559,6 +559,29 @@ public class HiveToRelConverterTest {
     assertEquals(relToHql(rel), expectedSql);
   }
 
+  @Test
+  public void testComment() {
+    final String expected =
+        "LogicalProject(a=[$0], b=[$1], c=[$2])\n" + "  LogicalTableScan(table=[[hive, default, foo]])\n";
+
+    // single-line comments
+    final String sql1 = "--comment0 select\nselect * -- comment1\nfrom foo";
+    String generated1 = relToString(sql1);
+    assertEquals(generated1, expected);
+
+    // bracketed comments
+    final String sql2 =
+        "/* comment0 */\n/*comment1*//* comment 2*/ /**/ select /*comm\nent3*/* from default./*comment4*/foo /* comment5 */";
+    String generated2 = relToString(sql2);
+    assertEquals(generated2, expected);
+
+    // mixed-style comments
+    final String sql3 =
+        "-- comment 0\n/*comment1*/-- comment 2\nselect /*comm\nent3*/* from/**/default./*comment4*/foo /* comment5 */--";
+    String generated3 = relToString(sql3);
+    assertEquals(generated3, expected);
+  }
+
   private String relToString(String sql) {
     return RelOptUtil.toString(converter.convertSql(sql));
   }


### PR DESCRIPTION
Coral does not recognize the bracketed comment style in Hive. This PR is to add that support.
```
/* here is a multi-line
comment */
SELECT /* an inline comment */ col FROM t;
```