### PR TITLE
Coral-Trino: Remove extra artificial wrapping `ROW` for `LATERAL VIEW EXPLODE` over ARRAY of STRUCTS

### DIFF
--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -111,13 +111,13 @@ public class HiveToTrinoConverterTest {
             + "FROM \"test\".\"table_with_string_array\" AS \"$cor0\"\n"
             + "CROSS JOIN UNNEST(\"if\"(\"$cor0\".\"b\" IS NOT NULL AND CARDINALITY(\"$cor0\".\"b\") > 0, \"$cor0\".\"b\", ARRAY[NULL])) AS \"t0\" (\"c\")" },
 
-        { "test", "view_with_explode_struct_array", "SELECT \"$cor0\".\"a\" AS \"a\", \"t0\".\"c\" AS \"c\"\n"
+        { "test", "view_with_explode_struct_array", "SELECT \"$cor0\".\"a\" AS \"a\", \"t0\".\"c\".\"sa\" AS \"sa\"\n"
             + "FROM \"test\".\"table_with_struct_array\" AS \"$cor0\"\n"
-            + "CROSS JOIN UNNEST(TRANSFORM(\"$cor0\".\"b\", x -> ROW(x))) AS \"t0\" (\"c\")" },
+            + "CROSS JOIN UNNEST(\"$cor0\".\"b\") AS \"t0\" (\"c\")" },
 
         { "test", "view_with_outer_explode_struct_array", "SELECT \"$cor0\".\"a\" AS \"a\", \"t0\".\"c\" AS \"c\"\n"
             + "FROM \"test\".\"table_with_struct_array\" AS \"$cor0\"\n"
-            + "CROSS JOIN UNNEST(TRANSFORM(\"if\"(\"$cor0\".\"b\" IS NOT NULL AND CARDINALITY(\"$cor0\".\"b\") > 0, \"$cor0\".\"b\", ARRAY[NULL]), x -> ROW(x))) AS \"t0\" (\"c\")" },
+            + "CROSS JOIN UNNEST(\"if\"(\"$cor0\".\"b\" IS NOT NULL AND CARDINALITY(\"$cor0\".\"b\") > 0, \"$cor0\".\"b\", ARRAY[NULL])) AS \"t0\" (\"c\")" },
 
         { "test", "view_with_explode_map", "SELECT \"$cor0\".\"a\" AS \"a\", \"t0\".\"c\" AS \"c\", \"t0\".\"d\" AS \"d\"\n"
             + "FROM \"test\".\"table_with_map\" AS \"$cor0\"\n"

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
@@ -272,7 +272,7 @@ public class TestUtils {
 
     run(driver, "CREATE TABLE test.table_with_struct_array(a int, b array<struct<sa: int, sb: string>>)");
     run(driver,
-        "CREATE VIEW test.view_with_explode_struct_array AS SELECT a, c FROM test.table_with_struct_array LATERAL VIEW EXPLODE(b) t AS c");
+        "CREATE VIEW test.view_with_explode_struct_array AS SELECT a, c.sa FROM test.table_with_struct_array LATERAL VIEW EXPLODE(b) t AS c");
     run(driver,
         "CREATE VIEW test.view_with_outer_explode_struct_array AS SELECT a, c FROM test.table_with_struct_array LATERAL VIEW OUTER EXPLODE(b) t AS c");
 


### PR DESCRIPTION
#93 added an extra artificial wrapping `ROW` for `LATERAL VIEW EXPLODE` over ARRAY of STRUCTS, which will cause the issue while querying the translated Trino SQL.

i.e.
```
CREATE TABLE test.table_with_struct_array(a int, b array<struct<sa: int, sb: string>>)
CREATE VIEW test.view_with_explode_struct_array AS SELECT a, c.sa FROM test.table_with_struct_array LATERAL VIEW EXPLODE(b) t AS c
```
The translated Trino SQL of view `test.view_with_explode_struct_array` with this PR would be:
```
SELECT "$cor0"."a" AS "a", "t0"."c"."sa" AS "sa"
FROM "test"."table_with_struct_array" AS "$cor0"
CROSS JOIN UNNEST(TRANSFORM("$cor0"."b", x -> ROW(x))) AS "t0" ("c")
```
Since we used `TRANSFORM("$cor0"."b", x -> ROW(x))`, the schema of `t0.c` would be `row(row(sa integer, sb varchar))`, therefore, trino couldn't find `sa` from `t0.c` and will throw the exception `Column 't0.c.sa' cannot be resolved`.

Before patch #93, without `TRANSFORM("$cor0"."b", x -> ROW(x))`, the schema of `t0.c` was `row(sa integer, sb varchar)` and `t0.c.sa` could be resolved and the translated trino SQL could run well.

This PR is to remove the change made by #93 

Tests:
1. Modified unit test, the translated Trino SQL could not be resolved before this PR.
2. Tested on the affected production views
3. Integration test, no regression