### PR TITLE
Coral-Hive: Treat `CHAR` with length > 255 as `VARCHAR` in `TypeConverter.convertPrimtiveType`

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/TypeConverter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/TypeConverter.java
@@ -17,6 +17,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.hadoop.hive.common.type.HiveChar;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.typeinfo.BaseCharTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
@@ -225,7 +226,11 @@ public class TypeConverter {
           return TypeInfoFactory.getVarcharTypeInfo(rType.getPrecision());
         }
       case CHAR:
-        return TypeInfoFactory.getCharTypeInfo(rType.getPrecision());
+        if (rType.getPrecision() > HiveChar.MAX_CHAR_LENGTH) {
+          return TypeInfoFactory.getVarcharTypeInfo(rType.getPrecision());
+        } else {
+          return TypeInfoFactory.getCharTypeInfo(rType.getPrecision());
+        }
       case OTHER:
       default:
         return TypeInfoFactory.voidTypeInfo;


### PR DESCRIPTION
 Function with a string parameter will be converted to SqlStringLiteral Node as an operand. The SqlStringLiteral Node is a char type node. And, The validation stage will rely on the node type to validate the value via hive serde. However, char type in HIVE is limited to 255. We need to CHAR convertPrimativeType to either char or varchar based on the length of the string. 