### PR TITLE
coral incorrectly get rid of CAST in converting double constants to integer

### DIFF
--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -342,6 +342,14 @@ public class CoralSparkTest {
   }
 
   @Test
+  public void testCastByTypeName() {
+    RelNode relNode = TestUtils.toRelNode("SELECT DOUBLE(1), INT(1.5), STRING(2.3), TIMESTAMP(1631142817), BOOLEAN('')  FROM default.complex");
+    String targetSql = "SELECT 1, 1.5, CAST(2.3 AS STRING), CAST(1631142817 AS TIMESTAMP), CAST('' AS BOOLEAN)\n" +
+        "FROM default.complex";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+  }
+
+  @Test
   public void testInterval() {
     RelNode relNode = TestUtils.toRelNode("SELECT CAST('2021-08-31' AS DATE) + INTERVAL '7' DAY FROM default.complex");
     String targetSql = "SELECT (CAST('2021-08-31' AS DATE) + INTERVAL '7' DAY)\n" + "FROM default.complex";


### PR DESCRIPTION
This test case shows a bug.  One possible solution is to modify the code in `HiveConvertletTable.java`'s `convertCast` to always call `return cx.getRexBuilder().makeAbstractCast(castType, leftRex);`:

CC @antumbde Any thoughts?  Since you added the `if` condition in the code

```
  public RexNode convertCast(SqlRexContext cx, SqlCastFunction cast, SqlCall call) {
    final SqlNode left = call.operand(0);
    if (SqlUtil.isNullLiteral(left, false)) {
      RexNode leftRex = cx.convertLiteral((SqlLiteral) left);
      SqlDataTypeSpec dataType = call.operand(1);
      RelDataType castType = dataType.deriveType(cx.getValidator(), true);
      // can not call RexBuilder.makeCast() since that optimizes to remove the cast
      // we don't want to remove the cast
      return cx.getRexBuilder().makeAbstractCast(castType, leftRex);
    }
    // this is odd but we want to re-use as much code from calcite as possible
    return StandardConvertletTable.INSTANCE.get(call).convertCall(cx, call);
  }
```
