### PR TITLE
Support translation of GREATEST and LEAST functions for Trino

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -183,8 +183,8 @@ public class StaticHiveFunctionRegistry implements HiveFunctionRegistry {
     createAddUserDefinedFunction("shiftleft", ARG0_NULLABLE, EXACT_NUMERIC_EXACT_NUMERIC);
     createAddUserDefinedFunction("shiftright", ARG0_NULLABLE, EXACT_NUMERIC_EXACT_NUMERIC);
     createAddUserDefinedFunction("shiftrightunsigned", ARG0_NULLABLE, EXACT_NUMERIC_EXACT_NUMERIC);
-    createAddUserDefinedFunction("greatest", ARG0_NULLABLE, ANY);
-    createAddUserDefinedFunction("least", ARG0_NULLABLE, ANY);
+    createAddUserDefinedFunction("greatest", ARG0_NULLABLE, SAME_VARIADIC);
+    createAddUserDefinedFunction("least", ARG0_NULLABLE, SAME_VARIADIC);
     createAddUserDefinedFunction("width_bucket", INTEGER_NULLABLE,
         family(SqlTypeFamily.NUMERIC, SqlTypeFamily.NUMERIC, SqlTypeFamily.NUMERIC, SqlTypeFamily.INTEGER));
 

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -174,7 +174,13 @@ public class HiveToTrinoConverterTest {
 
         { "test", "view_with_timestamp_and_interval", "SELECT (CAST('2021-08-30' AS TIMESTAMP) + INTERVAL -'3 01:02:03' DAY TO SECOND)\nFROM \"test\".\"tablea\"" },
 
-        { "test", "view_with_timestamp_and_interval_2", "SELECT (CAST('2021-08-30' AS TIMESTAMP) + INTERVAL -'1-6' YEAR TO MONTH)\nFROM \"test\".\"tablea\"" }, };
+        { "test", "view_with_timestamp_and_interval_2", "SELECT (CAST('2021-08-30' AS TIMESTAMP) + INTERVAL -'1-6' YEAR TO MONTH)\nFROM \"test\".\"tablea\"" },
+
+        { "test", "greatest_view", "SELECT \"greatest\"(\"a\", \"b\") AS \"g_int\", \"greatest\"(\"c\", \"d\") AS \"g_string\"\n"
+            + "FROM \"test\".\"table_ints_strings\"" },
+
+        { "test", "least_view", "SELECT \"least\"(\"a\", \"b\") AS \"g_int\", \"least\"(\"c\", \"d\") AS \"g_string\"\n"
+            + "FROM \"test\".\"table_ints_strings\"" }, };
   }
 
   @Test

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
@@ -336,6 +336,14 @@ public class TestUtils {
     run(driver, "CREATE VIEW IF NOT EXISTS test.t_dot_star_view AS \n"
         + "SELECT ta.*, tb.b as tbb FROM test.tableA as ta JOIN test.tableA as tb ON ta.a = tb.a");
 
+    run(driver, "CREATE TABLE IF NOT EXISTS test.table_ints_strings( a int, b int, c string, d string)");
+
+    run(driver, "CREATE VIEW IF NOT EXISTS test.greatest_view AS \n"
+        + "SELECT greatest(t.a, t.b) as g_int, greatest(t.c, t.d) as g_string FROM test.table_ints_strings t");
+
+    run(driver, "CREATE VIEW IF NOT EXISTS test.least_view AS \n"
+        + "SELECT least(t.a, t.b) as g_int, least(t.c, t.d) as g_string FROM test.table_ints_strings t");
+
   }
 
   public static RelNode convertView(String db, String view) {


### PR DESCRIPTION
Hive views fail to translate in Trino with errors like the one below for any data type and number of parameters.

`Failed to translate Hive view 'test.greatest_test_v': At line 0, column 0: No match found for function signature greatest(<NUMERIC>, <NUMERIC>)`

This can be resolved by changing the hive function definition as follows.

before:
`createAddUserDefinedFunction("greatest", ARG0_NULLABLE, ANY);`
`createAddUserDefinedFunction("least", ARG0_NULLABLE, ANY);`

after:
`createAddUserDefinedFunction("greatest", ARG0_NULLABLE, SAME_VARIADIC);`
`createAddUserDefinedFunction("least", ARG0_NULLABLE, SAME_VARIADIC);`
