### PR TITLE
Bump calcite version to 1.21.0.151

### DIFF
--- a/coral-hive/build.gradle
+++ b/coral-hive/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'antlr'
 
 dependencies {
   antlr deps.'antlr'
-  compile('com.linkedin.calcite:calcite-core:1.21.0.150') {
+  compile('com.linkedin.calcite:calcite-core:1.21.0.151') {
     artifact {
       name = 'calcite-core'
       extension = 'jar'


### PR DESCRIPTION
To include the fix https://github.com/linkedin/linkedin-calcite/pull/49.
No regression in integration test.