### PR TITLE
Avoid including full exception stacktrace in warning

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveTable.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveTable.java
@@ -165,7 +165,7 @@ public class HiveTable implements ScannableTable {
       } catch (Exception e) {
         // if there is an exception like failing to get the deserializer or failing to get columns using deserializer,
         // we use sd.getCols() to avoid throwing exception
-        LOG.warn("Failed to get columns using deserializer", e);
+        LOG.warn("Failed to get columns using deserializer: {}", e.getMessage());
         return sd.getCols();
       }
     }

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/TransportableUDFMap.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/TransportableUDFMap.java
@@ -166,7 +166,7 @@ class TransportableUDFMap {
         return ScalaVersion.SCALA_2_12;
       throw new IllegalStateException(String.format("Unsupported Spark Version %s", sparkVersion));
     } catch (IllegalStateException | NoClassDefFoundError ex) {
-      LOG.warn("Couldn't determine Spark version, falling back to scala_2.11", ex);
+      LOG.warn("Couldn't determine Spark version, falling back to scala_2.11: {}", ex.getMessage());
       return ScalaVersion.SCALA_2_11;
     }
   }


### PR DESCRIPTION
Including the full exception stacktrace in warning is kind of noisy and unnecessary.