### PR TITLE
Support string splicing with double vertical lines

### DIFF
--- a/coral-hive/src/main/antlr/imports/IdentifiersParser.g
+++ b/coral-hive/src/main/antlr/imports/IdentifiersParser.g
@@ -396,6 +396,21 @@ precedencePlusExpression
     precedenceStarExpression (precedencePlusOperator^ precedenceStarExpression)*
     ;
 
+precedenceConcatenateOperator
+    :
+    CONCATENATE
+    ;
+
+precedenceConcatenateExpression
+    :
+    (precedencePlusExpression -> precedencePlusExpression)
+        (
+        precedenceConcatenateOperator plus=precedencePlusExpression
+        -> ^(TOK_FUNCTION {adaptor.create(Identifier, "concat")} {$precedenceConcatenateExpression.tree} $plus)
+        )*
+    -> {$precedenceConcatenateExpression.tree}
+    ;
+
 
 precedenceAmpersandOperator
     :
@@ -404,7 +419,7 @@ precedenceAmpersandOperator
 
 precedenceAmpersandExpression
     :
-    precedencePlusExpression (precedenceAmpersandOperator^ precedencePlusExpression)*
+    precedenceConcatenateExpression (precedenceAmpersandOperator^ precedenceConcatenateExpression)*
     ;
 
 

--- a/coral-hive/src/main/antlr/roots/com/linkedin/coral/hive/hive2rel/parsetree/parser/HiveLexer.g
+++ b/coral-hive/src/main/antlr/roots/com/linkedin/coral/hive/hive2rel/parsetree/parser/HiveLexer.g
@@ -348,6 +348,7 @@ DIV : 'DIV';
 AMPERSAND : '&';
 TILDE : '~';
 BITWISEOR : '|';
+CONCATENATE : '||';
 BITWISEXOR : '^';
 QUESTION : '?';
 DOLLAR : '$';

--- a/coral-hive/src/main/antlr/roots/com/linkedin/coral/hive/hive2rel/parsetree/parser/HiveParser.g
+++ b/coral-hive/src/main/antlr/roots/com/linkedin/coral/hive/hive2rel/parsetree/parser/HiveParser.g
@@ -535,6 +535,7 @@ import org.slf4j.LoggerFactory;
     xlateMap.put("AMPERSAND", "&");
     xlateMap.put("TILDE", "~");
     xlateMap.put("BITWISEOR", "|");
+    xlateMap.put("CONCATENATE", "||");
     xlateMap.put("BITWISEXOR", "^");
     xlateMap.put("CharSetLiteral", "\\'");
   }

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
@@ -582,6 +582,14 @@ public class HiveToRelConverterTest {
     assertEquals(generated3, expected);
   }
 
+  @Test
+  public void testConcat() {
+    final String expected = "LogicalProject(EXPR$0=[concat('a', 'b')])\n" + "  LogicalValues(tuples=[[{ 0 }]])\n";
+    final String sql = "SELECT 'a' || 'b'";
+    String generated = relToString(sql);
+    assertEquals(generated, expected);
+  }
+
   private String relToString(String sql) {
     return RelOptUtil.toString(converter.convertSql(sql));
   }

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -464,4 +464,16 @@ public class CoralSparkTest {
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
+  @Test
+  public void testConcat() {
+    RelNode relNode = TestUtils.toRelNode("SELECT 'a' || 'b'");
+
+    String targetSql = "SELECT concat('a', 'b')\nFROM (VALUES  (0)) t (ZERO)";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+    RelNode relNode2 = TestUtils.toRelNode("SELECT 'a' || 'b' || 'c'");
+
+    String targetSql2 = "SELECT concat(concat('a', 'b'), 'c')\nFROM (VALUES  (0)) t (ZERO)";
+    assertEquals(CoralSpark.create(relNode2).getSparkSql(), targetSql2);
+  }
+
 }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -256,67 +256,6 @@ public class HiveToTrinoConverterTest {
   }
 
   @Test
-  public void testLegacyUnnestArrayOfStruct() {
-    RelNode relNode = hiveToRelConverter.convertView("test", "view_with_explode_struct_array");
-    String targetSql = "SELECT \"$cor0\".\"a\" AS \"a\", \"t0\".\"c\" AS \"c\"\n"
-        + "FROM \"test\".\"table_with_struct_array\" AS \"$cor0\"\n"
-        + "CROSS JOIN UNNEST(\"$cor0\".\"b\") AS \"t0\" (\"c\")";
-
-    RelToTrinoConverter relToTrinoConverter =
-        new RelToTrinoConverter(ImmutableMap.of(SUPPORT_LEGACY_UNNEST_ARRAY_OF_STRUCT, true));
-    String expandedSql = relToTrinoConverter.convert(relNode);
-    assertEquals(expandedSql, targetSql);
-  }
-
-  @Test
-  public void testLegacyOuterUnnestArrayOfStruct() {
-    RelNode relNode = hiveToRelConverter.convertView("test", "view_with_outer_explode_struct_array");
-    String targetSql = "SELECT \"$cor0\".\"a\" AS \"a\", \"t0\".\"c\" AS \"c\"\n"
-        + "FROM \"test\".\"table_with_struct_array\" AS \"$cor0\"\n"
-        + "CROSS JOIN UNNEST(\"if\"(\"$cor0\".\"b\" IS NOT NULL AND CARDINALITY(\"$cor0\".\"b\") > 0, \"$cor0\".\"b\", ARRAY[NULL])) AS \"t0\" (\"c\")";
-
-    RelToTrinoConverter relToTrinoConverter =
-        new RelToTrinoConverter(ImmutableMap.of(SUPPORT_LEGACY_UNNEST_ARRAY_OF_STRUCT, true));
-    String expandedSql = relToTrinoConverter.convert(relNode);
-    assertEquals(expandedSql, targetSql);
-  }
-
-  @Test
-  public void testAvoidTransformToDate() {
-    RelNode relNode = hiveToRelConverter
-        .convertSql("SELECT to_date(substr('2021-08-20', 1, 10)), to_date('2021-08-20')" + "FROM test.tableA");
-    String targetSql =
-        "SELECT \"to_date\"(\"SUBSTR\"('2021-08-20', 1, 10)), \"to_date\"('2021-08-20')\n" + "FROM \"test\".\"tablea\"";
-
-    RelToTrinoConverter relToTrinoConverter =
-        new RelToTrinoConverter(ImmutableMap.of(AVOID_TRANSFORM_TO_DATE_UDF, true));
-    String expandedSql = relToTrinoConverter.convert(relNode);
-    assertEquals(expandedSql, targetSql);
-  }
-
-  @Test
-  public void testFromUnixTimeOneParameter() {
-    RelNode relNode = hiveToRelConverter.convertSql("SELECT from_unixtime(10000)");
-    String targetSql = "SELECT \"format_datetime\"(\"from_unixtime\"(10000), 'yyyy-MM-dd HH:mm:ss')\n"
-        + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
-
-    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
-    String expandedSql = relToTrinoConverter.convert(relNode);
-    assertEquals(expandedSql, targetSql);
-  }
-
-  @Test
-  public void testFromUnixTimeTwoParameters() {
-    RelNode relNode = hiveToRelConverter.convertSql("SELECT from_unixtime(10000, 'yyyy-MM-dd')");
-    String targetSql = "SELECT \"format_datetime\"(\"from_unixtime\"(10000), 'yyyy-MM-dd')\n"
-        + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
-
-    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
-    String expandedSql = relToTrinoConverter.convert(relNode);
-    assertEquals(expandedSql, targetSql);
-  }
-  
-  @Test
   public void testConcat() {
     RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
 

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -256,6 +256,67 @@ public class HiveToTrinoConverterTest {
   }
 
   @Test
+  public void testLegacyUnnestArrayOfStruct() {
+    RelNode relNode = hiveToRelConverter.convertView("test", "view_with_explode_struct_array");
+    String targetSql = "SELECT \"$cor0\".\"a\" AS \"a\", \"t0\".\"c\" AS \"c\"\n"
+        + "FROM \"test\".\"table_with_struct_array\" AS \"$cor0\"\n"
+        + "CROSS JOIN UNNEST(\"$cor0\".\"b\") AS \"t0\" (\"c\")";
+
+    RelToTrinoConverter relToTrinoConverter =
+        new RelToTrinoConverter(ImmutableMap.of(SUPPORT_LEGACY_UNNEST_ARRAY_OF_STRUCT, true));
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
+
+  @Test
+  public void testLegacyOuterUnnestArrayOfStruct() {
+    RelNode relNode = hiveToRelConverter.convertView("test", "view_with_outer_explode_struct_array");
+    String targetSql = "SELECT \"$cor0\".\"a\" AS \"a\", \"t0\".\"c\" AS \"c\"\n"
+        + "FROM \"test\".\"table_with_struct_array\" AS \"$cor0\"\n"
+        + "CROSS JOIN UNNEST(\"if\"(\"$cor0\".\"b\" IS NOT NULL AND CARDINALITY(\"$cor0\".\"b\") > 0, \"$cor0\".\"b\", ARRAY[NULL])) AS \"t0\" (\"c\")";
+
+    RelToTrinoConverter relToTrinoConverter =
+        new RelToTrinoConverter(ImmutableMap.of(SUPPORT_LEGACY_UNNEST_ARRAY_OF_STRUCT, true));
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
+
+  @Test
+  public void testAvoidTransformToDate() {
+    RelNode relNode = hiveToRelConverter
+        .convertSql("SELECT to_date(substr('2021-08-20', 1, 10)), to_date('2021-08-20')" + "FROM test.tableA");
+    String targetSql =
+        "SELECT \"to_date\"(\"SUBSTR\"('2021-08-20', 1, 10)), \"to_date\"('2021-08-20')\n" + "FROM \"test\".\"tablea\"";
+
+    RelToTrinoConverter relToTrinoConverter =
+        new RelToTrinoConverter(ImmutableMap.of(AVOID_TRANSFORM_TO_DATE_UDF, true));
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
+
+  @Test
+  public void testFromUnixTimeOneParameter() {
+    RelNode relNode = hiveToRelConverter.convertSql("SELECT from_unixtime(10000)");
+    String targetSql = "SELECT \"format_datetime\"(\"from_unixtime\"(10000), 'yyyy-MM-dd HH:mm:ss')\n"
+        + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
+
+  @Test
+  public void testFromUnixTimeTwoParameters() {
+    RelNode relNode = hiveToRelConverter.convertSql("SELECT from_unixtime(10000, 'yyyy-MM-dd')");
+    String targetSql = "SELECT \"format_datetime\"(\"from_unixtime\"(10000), 'yyyy-MM-dd')\n"
+        + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
+
+  @Test
   public void testConcat() {
     RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
 

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -252,4 +252,19 @@ public class HiveToTrinoConverterTest {
     assertEquals(expandedSql, targetSql);
   }
 
+  @Test
+  public void testConcat() {
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+
+    RelNode relNode = hiveToRelConverter.convertSql("SELECT 'a' || 'b'");
+    String targetSql = "SELECT \"concat\"('a', 'b')\nFROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+
+    RelNode relNode2 = hiveToRelConverter.convertSql("SELECT 'a' || 'b' || 'c'");
+    String targetSql2 = "SELECT \"concat\"(\"concat\"('a', 'b'), 'c')\nFROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+    String expandedSql2 = relToTrinoConverter.convert(relNode2);
+    assertEquals(expandedSql2, targetSql2);
+  }
+
 }


### PR DESCRIPTION
SQL like select 'a' || 'b', which is use double vertical lines concat string,this syntax coral  is not currently supported. The PR is to support this syntax.