### PR TITLE
Coral-Trino: Add config for LinkedIn's internal use

### DIFF
--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/Calcite2TrinoUDFConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/Calcite2TrinoUDFConverter.java
@@ -193,7 +193,7 @@ public class Calcite2TrinoUDFConverter {
           return modifiedCall.get();
         }
       }
-      
+
       if (operatorName.equalsIgnoreCase("from_unixtime")) {
         Optional<RexNode> modifiedCall = visitFromUnixtime(call);
         if (modifiedCall.isPresent()) {

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/Calcite2TrinoUDFConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/Calcite2TrinoUDFConverter.java
@@ -8,6 +8,7 @@ package com.linkedin.coral.trino.rel2trino;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.calcite.rel.RelNode;
@@ -45,6 +46,7 @@ import com.linkedin.coral.com.google.common.collect.Multimap;
 import com.linkedin.coral.hive.hive2rel.functions.GenericProjectFunction;
 import com.linkedin.coral.trino.rel2trino.functions.GenericProjectToTrinoConverter;
 
+import static com.linkedin.coral.trino.rel2trino.CoralTrinoConfigKeys.*;
 import static com.linkedin.coral.trino.rel2trino.UDFMapUtils.createUDF;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.MULTIPLY;
 import static org.apache.calcite.sql.type.ReturnTypes.explicit;
@@ -61,7 +63,7 @@ public class Calcite2TrinoUDFConverter {
    * @param calciteNode Original Calcite plan
    * @return Trino-compatible Calcite plan
    */
-  public static RelNode convertRel(RelNode calciteNode) {
+  public static RelNode convertRel(RelNode calciteNode, Map<String, Boolean> configs) {
     RelShuttle converter = new RelShuttleImpl() {
       @Override
       public RelNode visit(LogicalProject project) {
@@ -139,7 +141,7 @@ public class Calcite2TrinoUDFConverter {
       }
 
       private TrinoRexConverter getTrinoRexConverter(RelNode node) {
-        return new TrinoRexConverter(node.getCluster().getRexBuilder(), node.getCluster().getTypeFactory());
+        return new TrinoRexConverter(node.getCluster().getRexBuilder(), node.getCluster().getTypeFactory(), configs);
       }
     };
     return calciteNode.accept(converter);
@@ -151,6 +153,7 @@ public class Calcite2TrinoUDFConverter {
   public static class TrinoRexConverter extends RexShuttle {
     private final RexBuilder rexBuilder;
     private final RelDataTypeFactory typeFactory;
+    private Map<String, Boolean> configs;
 
     // SUPPORTED_TYPE_CAST_MAP is a static mapping that maps a SqlTypeFamily key to its set of
     // type-castable SqlTypeFamilies.
@@ -160,9 +163,10 @@ public class Calcite2TrinoUDFConverter {
           .putAll(SqlTypeFamily.CHARACTER, SqlTypeFamily.NUMERIC, SqlTypeFamily.BOOLEAN).build();
     }
 
-    public TrinoRexConverter(RexBuilder rexBuilder, RelDataTypeFactory typeFactory) {
+    public TrinoRexConverter(RexBuilder rexBuilder, RelDataTypeFactory typeFactory, Map<String, Boolean> configs) {
       this.rexBuilder = rexBuilder;
       this.typeFactory = typeFactory;
+      this.configs = configs;
     }
 
     @Override
@@ -180,16 +184,17 @@ public class Calcite2TrinoUDFConverter {
         return this.convertMapValueConstructor(rexBuilder, call);
       }
 
-      if (call.getOperator().getName().equals("from_utc_timestamp")) {
+      final String operatorName = call.getOperator().getName();
+
+      if (operatorName.equals("from_utc_timestamp")) {
         Optional<RexNode> modifiedCall = visitFromUtcTimestampCall(call);
         if (modifiedCall.isPresent()) {
           return modifiedCall.get();
         }
       }
 
-      final UDFTransformer transformer =
-          CalciteTrinoUDFMap.getUDFTransformer(call.getOperator().getName(), call.operands.size());
-      if (transformer != null) {
+      final UDFTransformer transformer = CalciteTrinoUDFMap.getUDFTransformer(operatorName, call.operands.size());
+      if (transformer != null && shouldTransformOperator(operatorName)) {
         return super.visitCall((RexCall) transformer.transformCall(rexBuilder, call.getOperands()));
       }
       RexCall modifiedCall = adjustInconsistentTypesToEqualityOperator(call);
@@ -293,6 +298,10 @@ public class Calcite2TrinoUDFConverter {
       }
       results.add(rexBuilder.makeCall(SqlStdOperatorTable.ARRAY_VALUE_CONSTRUCTOR, values));
       return rexBuilder.makeCall(call.getOperator(), results);
+    }
+
+    private boolean shouldTransformOperator(String operatorName) {
+      return !("to_date".equalsIgnoreCase(operatorName) && configs.getOrDefault(AVOID_TRANSFORM_TO_DATE_UDF, false));
     }
   }
 }

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CoralTrinoConfigKeys.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CoralTrinoConfigKeys.java
@@ -9,6 +9,21 @@ package com.linkedin.coral.trino.rel2trino;
  * Contains configuration keys for {@link RelToTrinoConverter#configs}
  */
 public class CoralTrinoConfigKeys {
+  /**
+   * SQL standard (which Trino follows) defines that when we do CROSS JOIN UNNEST over ARRAY(ROW(...)), both ARRAY and ROW are unnested.
+   * This is not what Hive's LATERAL VIEW EXPLODE does, which only unnests ARRAY.
+   * Therefore, https://github.com/linkedin/coral/pull/93 adds extra ROW wrapping (translating ARRAY(ROW(...)) to ARRAY(ROW(ROW(...)))) on purpose.
+   * However, LinkedIn's internal Trino is still extending the support for Hive’s legacy behavior of unnest, which only unnests ARRAY.
+   * Therefore, we add this config for LinkedIn's internal use, if the value is set to true, we don't add extra ROW wrapping.
+   */
   public static final String SUPPORT_LEGACY_UNNEST_ARRAY_OF_STRUCT = "SUPPORT_LEGACY_UNNEST_ARRAY_OF_STRUCT";
+
+  /**
+   * https://github.com/linkedin/coral/pull/132 converts `to_date(xxx)` (returns string type pre Hive 2.1.0, returns date type on or after Hive 2.1.0)
+   * to `date(cast(xxx as timestamp))` (returns date type).
+   * Since LinkedIn is using Hive 1.x, our users expect `to_date(xxx)` function to return `string` type instead of `date` type.
+   * And we have registered `to_date` UDF in Trino which returns `string` type to meet the users’ needs.
+   * Therefore, we add this config for LinkedIn's internal use, if the value is set to true, we don't convert `to_date(xxx)` to `date(cast(xxx as timestamp))`.
+   */
   public static final String AVOID_TRANSFORM_TO_DATE_UDF = "AVOID_TRANSFORM_TO_DATE_UDF";
 }

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CoralTrinoConfigKeys.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CoralTrinoConfigKeys.java
@@ -1,0 +1,14 @@
+/**
+ * Copyright 2021 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.trino.rel2trino;
+
+/**
+ * Contains configuration keys for {@link RelToTrinoConverter#configs}
+ */
+public class CoralTrinoConfigKeys {
+  public static final String SUPPORT_LEGACY_UNNEST_ARRAY_OF_STRUCT = "SUPPORT_LEGACY_UNNEST_ARRAY_OF_STRUCT";
+  public static final String AVOID_TRANSFORM_TO_DATE_UDF = "AVOID_TRANSFORM_TO_DATE_UDF";
+}

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverter.java
@@ -29,6 +29,7 @@ public class HiveToTrinoConverter {
 
   public static HiveToTrinoConverter create(HiveMetastoreClient mscClient, Map<String, Boolean> configs) {
     checkNotNull(mscClient);
+    checkNotNull(configs);
     HiveToRelConverter hiveToRelConverter = HiveToRelConverter.create(mscClient);
     RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter(configs);
     return new HiveToTrinoConverter(hiveToRelConverter, relToTrinoConverter);

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverter.java
@@ -5,6 +5,8 @@
  */
 package com.linkedin.coral.trino.rel2trino;
 
+import java.util.Map;
+
 import org.apache.calcite.rel.RelNode;
 
 import com.linkedin.coral.hive.hive2rel.HiveMetastoreClient;
@@ -22,6 +24,13 @@ public class HiveToTrinoConverter {
     checkNotNull(mscClient);
     HiveToRelConverter hiveToRelConverter = HiveToRelConverter.create(mscClient);
     RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+    return new HiveToTrinoConverter(hiveToRelConverter, relToTrinoConverter);
+  }
+
+  public static HiveToTrinoConverter create(HiveMetastoreClient mscClient, Map<String, Boolean> configs) {
+    checkNotNull(mscClient);
+    HiveToRelConverter hiveToRelConverter = HiveToRelConverter.create(mscClient);
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter(configs);
     return new HiveToTrinoConverter(hiveToRelConverter, relToTrinoConverter);
   }
 

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
@@ -7,6 +7,7 @@ package com.linkedin.coral.trino.rel2trino;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -20,6 +21,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rel.type.RelDataTypeFieldImpl;
 import org.apache.calcite.rel.type.RelRecordType;
+import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.*;
@@ -34,9 +36,22 @@ import com.linkedin.coral.hive.hive2rel.rel.HiveUncollect;
 import com.linkedin.coral.trino.rel2trino.functions.TrinoArrayTransformFunction;
 
 import static com.linkedin.coral.trino.rel2trino.Calcite2TrinoUDFConverter.convertRel;
+import static com.linkedin.coral.trino.rel2trino.CoralTrinoConfigKeys.*;
 
 
 public class RelToTrinoConverter extends RelToSqlConverter {
+
+  /**
+   * We introduce this configuration for LinkedIn's internal use since our Trino is extending the following legacy/internal supports:
+   * (1) Unnest array of struct, refer to https://github.com/linkedin/coral/pull/93#issuecomment-912698600 for more information.
+   *     If the value of key {@link CoralTrinoConfigKeys#SUPPORT_LEGACY_UNNEST_ARRAY_OF_STRUCT} is set to true, we don't add extra ROW
+   *     wrapping in {@link RelToTrinoConverter#visit(Uncollect)}
+   * (2) Some internally registered UDFs which should not be converted, like `to_date`.
+   *     If the value of key {@link CoralTrinoConfigKeys#AVOID_TRANSFORM_TO_DATE_UDF} is set to true, we don't transform `to_date` UDF
+   *     in {@link com.linkedin.coral.trino.rel2trino.Calcite2TrinoUDFConverter.TrinoRexConverter#visitCall(RexCall)}
+   * For uses outside LinkedIn, just ignore this configuration.
+   */
+  private Map<String, Boolean> configs = new HashMap<>();
 
   /**
    * Creates a RelToTrinoConverter.
@@ -45,13 +60,18 @@ public class RelToTrinoConverter extends RelToSqlConverter {
     super(TrinoSqlDialect.INSTANCE);
   }
 
+  public RelToTrinoConverter(Map<String, Boolean> configs) {
+    super(TrinoSqlDialect.INSTANCE);
+    this.configs = configs;
+  }
+
   /**
    * Convert relational algebra to Trino's SQL
    * @param relNode calcite relational algebra representation of SQL
    * @return SQL string
    */
   public String convert(RelNode relNode) {
-    RelNode rel = convertRel(relNode);
+    RelNode rel = convertRel(relNode, configs);
     return convertToSqlNode(rel).accept(new TrinoSqlRewriter()).toSqlString(TrinoSqlDialect.INSTANCE).toString();
   }
 
@@ -124,7 +144,8 @@ public class RelToTrinoConverter extends RelToSqlConverter {
     // Build <unnestColumns>
     final List<SqlNode> unnestOperands = new ArrayList<>();
     for (RexNode unnestCol : ((Project) e.getInput()).getChildExps()) {
-      if (e instanceof HiveUncollect && unnestCol.getType().getSqlTypeName().equals(SqlTypeName.ARRAY)
+      if (!configs.getOrDefault(SUPPORT_LEGACY_UNNEST_ARRAY_OF_STRUCT, false) && e instanceof HiveUncollect
+          && unnestCol.getType().getSqlTypeName().equals(SqlTypeName.ARRAY)
           && unnestCol.getType().getComponentType().getSqlTypeName().equals(SqlTypeName.ROW)) {
 
         // wrapper Record type with single column.

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
@@ -35,6 +35,7 @@ import com.linkedin.coral.com.google.common.collect.ImmutableList;
 import com.linkedin.coral.hive.hive2rel.rel.HiveUncollect;
 import com.linkedin.coral.trino.rel2trino.functions.TrinoArrayTransformFunction;
 
+import static com.google.common.base.Preconditions.*;
 import static com.linkedin.coral.trino.rel2trino.Calcite2TrinoUDFConverter.convertRel;
 import static com.linkedin.coral.trino.rel2trino.CoralTrinoConfigKeys.*;
 
@@ -62,6 +63,7 @@ public class RelToTrinoConverter extends RelToSqlConverter {
 
   public RelToTrinoConverter(Map<String, Boolean> configs) {
     super(TrinoSqlDialect.INSTANCE);
+    checkNotNull(configs);
     this.configs = configs;
   }
 

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -8,6 +8,8 @@ package com.linkedin.coral.trino.rel2trino;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import com.google.common.collect.ImmutableMap;
+
 import org.apache.calcite.rel.RelNode;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeTest;
@@ -16,6 +18,7 @@ import org.testng.annotations.Test;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static com.linkedin.coral.trino.rel2trino.CoralTrinoConfigKeys.*;
 import static com.linkedin.coral.trino.rel2trino.TestUtils.hiveToRelConverter;
 import static org.testng.Assert.assertEquals;
 
@@ -252,4 +255,42 @@ public class HiveToTrinoConverterTest {
     assertEquals(expandedSql, targetSql);
   }
 
+  @Test
+  public void testLegacyUnnestArrayOfStruct() {
+    RelNode relNode = hiveToRelConverter.convertView("test", "view_with_explode_struct_array");
+    String targetSql = "SELECT \"$cor0\".\"a\" AS \"a\", \"t0\".\"c\" AS \"c\"\n"
+        + "FROM \"test\".\"table_with_struct_array\" AS \"$cor0\"\n"
+        + "CROSS JOIN UNNEST(\"$cor0\".\"b\") AS \"t0\" (\"c\")";
+
+    RelToTrinoConverter relToTrinoConverter =
+        new RelToTrinoConverter(ImmutableMap.of(SUPPORT_LEGACY_UNNEST_ARRAY_OF_STRUCT, true));
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
+
+  @Test
+  public void testLegacyOuterUnnestArrayOfStruct() {
+    RelNode relNode = hiveToRelConverter.convertView("test", "view_with_outer_explode_struct_array");
+    String targetSql = "SELECT \"$cor0\".\"a\" AS \"a\", \"t0\".\"c\" AS \"c\"\n"
+        + "FROM \"test\".\"table_with_struct_array\" AS \"$cor0\"\n"
+        + "CROSS JOIN UNNEST(\"if\"(\"$cor0\".\"b\" IS NOT NULL AND CARDINALITY(\"$cor0\".\"b\") > 0, \"$cor0\".\"b\", ARRAY[NULL])) AS \"t0\" (\"c\")";
+
+    RelToTrinoConverter relToTrinoConverter =
+        new RelToTrinoConverter(ImmutableMap.of(SUPPORT_LEGACY_UNNEST_ARRAY_OF_STRUCT, true));
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
+
+  @Test
+  public void testAvoidTransformToDate() {
+    RelNode relNode = hiveToRelConverter
+        .convertSql("SELECT to_date(substr('2021-08-20', 1, 10)), to_date('2021-08-20')" + "FROM test.tableA");
+    String targetSql =
+        "SELECT \"to_date\"(\"SUBSTR\"('2021-08-20', 1, 10)), \"to_date\"('2021-08-20')\n" + "FROM \"test\".\"tablea\"";
+
+    RelToTrinoConverter relToTrinoConverter =
+        new RelToTrinoConverter(ImmutableMap.of(AVOID_TRANSFORM_TO_DATE_UDF, true));
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
 }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -254,8 +254,6 @@ public class HiveToTrinoConverterTest {
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
-  
-  
 
   @Test
   public void testLegacyUnnestArrayOfStruct() {
@@ -295,7 +293,7 @@ public class HiveToTrinoConverterTest {
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
-  
+
   @Test
   public void testFromUnixTimeOneParameter() {
     RelNode relNode = hiveToRelConverter.convertSql("SELECT from_unixtime(10000)");
@@ -318,4 +316,3 @@ public class HiveToTrinoConverterTest {
     assertEquals(expandedSql, targetSql);
   }
 }
-


### PR DESCRIPTION
This PR adds the following configs for LinkedIn's internal use:
1. Legacy unnest array of struct: our internal trino only unnests `ARRAY` in `ARRAY<ROW<...` instead of both `ARRAY` and `ROW`, so we add this config which can avoid the extra wrapping added by #93 
2. Avoid transforming internally registered trino UDF `to_date`

All the external uses of Coral-Trino wouldn't be affected by this patch.

Tests:
1. Unit tests
2. Integration test, no regression