### PR TITLE
Coral-Trino: Add support for translating `from_unixtime`

### DIFF
--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -252,4 +252,25 @@ public class HiveToTrinoConverterTest {
     assertEquals(expandedSql, targetSql);
   }
 
+  @Test
+  public void testFromUnixTimeOneParameter() {
+    RelNode relNode = hiveToRelConverter.convertSql("SELECT from_unixtime(10000)");
+    String targetSql = "SELECT \"format_datetime\"(\"from_unixtime\"(10000), 'yyyy-MM-dd HH:mm:ss')\n"
+        + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
+
+  @Test
+  public void testFromUnixTimeTwoParameters() {
+    RelNode relNode = hiveToRelConverter.convertSql("SELECT from_unixtime(10000, 'yyyy-MM-dd')");
+    String targetSql = "SELECT \"format_datetime\"(\"from_unixtime\"(10000), 'yyyy-MM-dd')\n"
+        + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
 }


### PR DESCRIPTION
This patch supports the following conversions:
```
from_unixtime(1000) => format_datetime(from_unixtime(1000), 'yyyy-MM-dd HH:mm:ss')

from_unixtime(1000, 'yyyy-MM-dd') => format_datetime(from_unixtime(1000), 'yyyy-MM-dd')
```

This patch didn't handle the translation by adding a transformer like #50, it's because we need to add `from_unixtime` as an operator, using transformer will cause infinite recursion for 1 parameter case like `from_unixtime(1000)`.

Tests:
1. Unit tests
2. Integration test, no regression