### PR TITLE
Coral-Hive: Add `hive-exec` if `GenericUDF` class could not be found

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveGenericUDFReturnTypeInference.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveGenericUDFReturnTypeInference.java
@@ -105,7 +105,7 @@ public class HiveGenericUDFReturnTypeInference implements SqlReturnTypeInference
       if (error.getMessage().contains("GenericUDF")) {
         // If GenericUDF class could not be found, add `hive-exec:core` in `_udfDependencies` to download the missing class
         _udfClassLoader = null; // set it to null to re-download
-        _udfDependencies.add("com.linkedin.hive:hive-exec:1.1.0.+:core");
+        _udfDependencies.add("org.apache.hive:hive-exec:1.1.0");
         return Class.forName(_udfClassName, true, getUdfClassLoader());
       }
       throw error;


### PR DESCRIPTION
If `GenericUDF` class could not be found, add `hive-exec:core` in `_udfDependencies` to download the missing class.

Tested on the affected views, which could be translated well with this PR.
No regression in integration test.