### PR TITLE
coral-schema: Support generating union type schema

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -673,20 +673,22 @@ class SchemaUtilities {
         Schema recordSchema = setupNestedNamespaceForRecord(schema, namespace);
         return recordSchema;
       case UNION:
+        List<Schema> types = new ArrayList<>();
         if (isNullableType(schema)) {
           Schema otherType = getOtherTypeFromNullableType(schema);
           Schema otherTypeWithNestedNamespace = setupNestedNamespace(otherType, namespace);
           Schema nullSchema = Schema.create(Schema.Type.NULL);
-          List<Schema> types = new ArrayList<>();
           types.add(nullSchema);
           types.add(otherTypeWithNestedNamespace);
-          Schema unionSchema = Schema.createUnion(types);
-
-          return unionSchema;
         } else {
-          throw new IllegalArgumentException(
-              schema.toString(true) + " is unsupported UNION type. " + "Only nullable UNION is supported");
+          for (Schema type : schema.getTypes()) {
+            Schema typeWithNestNamespace = setupNestedNamespace(type, namespace);
+            types.add(typeWithNestNamespace);
+          }
         }
+        Schema unionSchema = Schema.createUnion(types);
+
+        return unionSchema;
       default:
         throw new IllegalArgumentException("Unsupported Schema type: " + schema.getType().toString());
     }

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
@@ -88,6 +88,7 @@ public class TestUtils {
     String baseNestedComplexSchema = loadSchema("base-nested-complex.avsc");
     String baseNullTypeFieldSchema = loadSchema("base-null-type-field.avsc");
     String baseTimestampTypeFieldSchema = loadSchema("base-timestamp-type-field.avsc");
+    String baseComplexUnionTypeSchema = loadSchema("base-complex-union-type.avsc");
 
     executeCreateTableQuery("default", "basecomplex", baseComplexSchema);
     executeCreateTableQuery("default", "basecomplexunioncompatible", baseComplexUnionCompatible);
@@ -96,6 +97,7 @@ public class TestUtils {
     executeCreateTableQuery("default", "basenullability", baseNullabilitySchema);
     executeCreateTableQuery("default", "basenulltypefield", baseNullTypeFieldSchema);
     executeCreateTableQuery("default", "basetimestamptypefield", baseTimestampTypeFieldSchema);
+    executeCreateTableQuery("default", "basecomplexuniontype", baseComplexUnionTypeSchema);
     executeCreateTableWithPartitionQuery("default", "basecasepreservation", baseCasePreservation);
     executeCreateTableWithPartitionFieldSchemaQuery("default", "basecomplexfieldschema", baseComplexFieldSchema);
     executeCreateTableWithPartitionQuery("default", "basenestedcomplex", baseNestedComplexSchema);

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -882,5 +882,17 @@ public class ViewToAvroSchemaConverterTests {
 
     Assert.assertEquals(actualSchema.toString(true), TestUtils.loadSchema("testDecimalType-expected.avsc"));
   }
+
+  @Test
+  public void testComplexUnionType() {
+    String viewSql = "CREATE VIEW v AS SELECT * FROM basecomplexuniontype";
+    TestUtils.executeCreateViewQuery("default", "v", viewSql);
+
+    ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);
+    Schema actualSchema = viewToAvroSchemaConverter.toAvroSchema("default", "v");
+
+    Assert.assertEquals(actualSchema.toString(true), TestUtils.loadSchema("testComplexUnionType-expected.avsc"));
+  }
+
   // TODO: add more unit tests
 }

--- a/coral-schema/src/test/resources/base-complex-union-type.avsc
+++ b/coral-schema/src/test/resources/base-complex-union-type.avsc
@@ -1,0 +1,9 @@
+{
+  "type" : "record",
+  "name" : "basecomplexuniontype",
+  "namespace" : "coral.schema.avro.base.complex.union.type",
+  "fields" : [ {
+    "name" : "unionCol",
+    "type" : [ "int", "string" ]
+  } ]
+}

--- a/coral-schema/src/test/resources/testComplexUnionType-expected.avsc
+++ b/coral-schema/src/test/resources/testComplexUnionType-expected.avsc
@@ -1,0 +1,9 @@
+{
+  "type" : "record",
+  "name" : "v",
+  "namespace" : "default.v",
+  "fields" : [ {
+    "name" : "unionCol",
+    "type" : [ "int", "string" ]
+  } ]
+}


### PR DESCRIPTION
This PR adds support for generating union type schema

Test Done:
1. unit tests
2. regression tests