### PR TITLE
Coral-Hive: Try to get ivy cache dir from env first, fall back to default if not found

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/ArtifactsResolver.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/ArtifactsResolver.java
@@ -154,10 +154,9 @@ public class ArtifactsResolver {
     }
     String ivyCacheDir = System.getenv(IVY_CACHE_DIR);
     if (ivyCacheDir != null) {
-      setupCacheDir(new File(ivyCacheDir));
-    } else {
-      setupCacheDir(settings.getDefaultCache());
+      settings.setDefaultCache(new File(ivyCacheDir));
     }
+    setupCacheDir(settings.getDefaultCache());
     settings.setVariable("ivy.default.configuration.m2compatible", "true");
     return settings;
   }

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/ArtifactsResolver.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/ArtifactsResolver.java
@@ -36,6 +36,7 @@ public class ArtifactsResolver {
   private static final Logger LOG = LoggerFactory.getLogger(ArtifactsResolver.class);
   private static final String IVY_SETTINGS_LOCATION = "IVY_SETTINGS_LOCATION";
   private static final String IVY_SETTINGS_FILE_NAME = "ivy.settings.xml";
+  private static final String IVY_CACHE_DIR_NAME = "ivy.cache.dir";
   private static final String IVY_LOG_LEVEL = "IVY_LOG_LEVEL";
   private final Ivy _ivyInstance;
   public ArtifactsResolver() {
@@ -151,7 +152,12 @@ public class ArtifactsResolver {
     } catch (IOException e) {
       throw new RuntimeException("Unable to configure Ivy", e);
     }
-    setupCacheDir(settings.getDefaultCache());
+    String ivyCacheDir = System.getenv(IVY_CACHE_DIR_NAME);
+    if (ivyCacheDir != null) {
+      setupCacheDir(new File(ivyCacheDir));
+    } else {
+      setupCacheDir(settings.getDefaultCache());
+    }
     settings.setVariable("ivy.default.configuration.m2compatible", "true");
     return settings;
   }

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/ArtifactsResolver.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/ArtifactsResolver.java
@@ -35,8 +35,8 @@ import org.slf4j.LoggerFactory;
 public class ArtifactsResolver {
   private static final Logger LOG = LoggerFactory.getLogger(ArtifactsResolver.class);
   private static final String IVY_SETTINGS_LOCATION = "IVY_SETTINGS_LOCATION";
+  private static final String IVY_CACHE_DIR = "IVY_CACHE_DIR";
   private static final String IVY_SETTINGS_FILE_NAME = "ivy.settings.xml";
-  private static final String IVY_CACHE_DIR_NAME = "ivy.cache.dir";
   private static final String IVY_LOG_LEVEL = "IVY_LOG_LEVEL";
   private final Ivy _ivyInstance;
   public ArtifactsResolver() {
@@ -152,7 +152,7 @@ public class ArtifactsResolver {
     } catch (IOException e) {
       throw new RuntimeException("Unable to configure Ivy", e);
     }
-    String ivyCacheDir = System.getenv(IVY_CACHE_DIR_NAME);
+    String ivyCacheDir = System.getenv(IVY_CACHE_DIR);
     if (ivyCacheDir != null) {
       setupCacheDir(new File(ivyCacheDir));
     } else {


### PR DESCRIPTION
If `IVY_CACHE_DIR` exists in the system env, we use it for ivy cache. Otherwise, fall to default.