### PR TITLE
Wrap timestamp with "to_unixtime" when casting from timestamp to decimal

### DIFF
--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -353,5 +353,12 @@ public class HiveToTrinoConverterTest {
         "SELECT CAST(\"to_unixtime\"(CAST(\"a_date\" AS TIMESTAMP)) AS DECIMAL(10, 0)) AS \"d\"\nFROM \"test\".\"table_from_utc_timestamp\"";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
+
+    relNode = hiveToRelConverter.convertSql(
+        "SELECT CAST(from_utc_timestamp(a_date, 'America/Los_Angeles') AS DECIMAL(10, 0)) AS d\nFROM test.table_from_utc_timestamp");
+    targetSql =
+        "SELECT CAST(\"to_unixtime\"(CAST(\"at_timezone\"(\"from_unixtime\"(\"to_unixtime\"(\"with_timezone\"(\"a_date\", 'UTC'))), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3))) AS DECIMAL(10, 0)) AS \"d\"\nFROM \"test\".\"table_from_utc_timestamp\"";
+    expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
   }
 }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -330,4 +330,28 @@ public class HiveToTrinoConverterTest {
     String expandedSql2 = relToTrinoConverter.convert(relNode2);
     assertEquals(expandedSql2, targetSql2);
   }
+
+  @Test
+  public void testCastTimestampToDecimal() {
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+
+    RelNode relNode = hiveToRelConverter
+        .convertSql("SELECT CAST(a_timestamp AS DECIMAL(10, 0)) AS d\nFROM test.table_from_utc_timestamp");
+    String targetSql =
+        "SELECT CAST(\"to_unixtime\"(\"a_timestamp\") AS DECIMAL(10, 0)) AS \"d\"\nFROM \"test\".\"table_from_utc_timestamp\"";
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
+
+  @Test
+  public void testCastNestedTimestampToDecimal() {
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+
+    RelNode relNode = hiveToRelConverter.convertSql(
+        "SELECT CAST(CAST(a_date AS TIMESTAMP) AS DECIMAL(10, 0)) AS d\nFROM test.table_from_utc_timestamp");
+    String targetSql =
+        "SELECT CAST(\"to_unixtime\"(CAST(\"a_date\" AS TIMESTAMP)) AS DECIMAL(10, 0)) AS \"d\"\nFROM \"test\".\"table_from_utc_timestamp\"";
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
 }


### PR DESCRIPTION
Hive allows casting TIMESTAMP type to DECIMAL type, which casts the timestamp into unix time with decimal type.

```
0: jdbc:hive2://localhost:10000> describe default.timestamp_test_base_2;
+-----------+------------+----------+
| col_name  | data_type  | comment  |
+-----------+------------+----------+
| t1        | timestamp  |          |
+-----------+------------+----------+
```
```
0: jdbc:hive2://localhost:10000> select cast(timestamp_test_base_2.t1 as decimal(10,0)) as d from default.timestamp_test_base_2;
+-------------+
|      d      |
+-------------+
| 1631137219  |
+-------------+
```

Trino/Presto does not allow for this kind of casting, and attempting the same query results in
`Cannot cast timestamp to decimal(10,0)`

 So we propose mapping
`CAST(timstamp_col AS DECIMAL(10,0))`

To

`CAST("to_unixtime"(timstamp_col) AS DECIMAL(10,0))`

In order to achieve the same behavior.
