### PR TITLE
Coral-Trino: Reset `transformColumnFieldName` for `generic_project` if necessary

### DIFF
--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/functions/GenericProjectToTrinoConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/functions/GenericProjectToTrinoConverter.java
@@ -6,14 +6,19 @@
 package com.linkedin.coral.trino.rel2trino.functions;
 
 import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedList;
 import java.util.List;
 
+import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rel.type.RelRecordType;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.ArraySqlType;
 import org.apache.calcite.sql.type.MapSqlType;
@@ -109,9 +114,10 @@ public class GenericProjectToTrinoConverter {
    *     - N/A
    * @param builder RexBuilder for the call
    * @param call a GenericProject call
+   * @param node parent relNode of call
    * @return a Trino UDF call equivalent for the given GenericProject call
    */
-  public static RexCall convertGenericProject(RexBuilder builder, RexCall call) {
+  public static RexCall convertGenericProject(RexBuilder builder, RexCall call, RelNode node) {
     // We build a RexCall to a UDF based on the outermost return type.
     // Although other transformations may be necessary, we do not recursively build RexCalls.
     // Instead, we represent these nested transformations as an input string to the top level RexCall.
@@ -179,9 +185,36 @@ public class GenericProjectToTrinoConverter {
     //           [RexLiteral: 'col1, (k, v) -> transform(v , x -> cast(row(x.a) as row(a int)))']
     // The resolved SQL string will look like:
     //   'transform_values(col1, (k, v) -> transform(v , x -> cast(row(x.a) as row(a int))))'
+
     RexLiteral columnNameLiteral = (RexLiteral) call.getOperands().get(1);
     String transformColumnFieldName = RexLiteral.stringValue(columnNameLiteral);
-    RelDataType fromDataType = call.getOperands().get(0).getType();
+    final RexNode transformColumn = call.getOperands().get(0);
+
+    // `transformColumnFieldName` could be the column name in an intermediate view, which might be different
+    // from the base table's column name because of the alias operation. In this case, the translated SQL couldn't be resolved.
+    // Therefore, we add the following `if` block to reset `transformColumnFieldName` if necessary.
+    // It traverses the base nodes, and if the column type on the corresponding index equals to the type of `transformColumn`
+    // but the column name is different from `transformColumnFieldName`, we reset `transformColumnFieldName`
+    // Corresponding unit test is `HiveToTrinoConverterTest#testResetTransformColumnFieldNameForGenericProject`
+    if (transformColumn instanceof RexInputRef) {
+      int columnIndexInBaseTable = ((RexInputRef) transformColumn).getIndex();
+      Deque<RelNode> nodeDeque = new LinkedList<>(node.getInputs());
+      while (!nodeDeque.isEmpty()) {
+        RelNode currentNode = nodeDeque.pollFirst();
+        final List<RelDataTypeField> fieldList = currentNode.getRowType().getFieldList();
+        if (columnIndexInBaseTable < fieldList.size()) {
+          final RelDataTypeField relDataTypeField = fieldList.get(columnIndexInBaseTable);
+          if (relDataTypeField.getType() == transformColumn.getType()
+              && !transformColumnFieldName.equalsIgnoreCase(relDataTypeField.getName())) {
+            transformColumnFieldName = relDataTypeField.getName();
+            break;
+          }
+        }
+        nodeDeque.addAll(currentNode.getInputs());
+      }
+    }
+
+    RelDataType fromDataType = transformColumn.getType();
     RelDataType toDataType = call.getOperator().inferReturnType(null);
     switch (toDataType.getSqlTypeName()) {
       case ROW:

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
@@ -344,6 +344,13 @@ public class TestUtils {
     run(driver, "CREATE VIEW IF NOT EXISTS test.least_view AS \n"
         + "SELECT least(t.a, t.b) as g_int, least(t.c, t.d) as g_string FROM test.table_ints_strings t");
 
+    run(driver, "CREATE TABLE IF NOT EXISTS test.tableS (structCol struct<a:int>)");
+    run(driver, "CREATE TABLE IF NOT EXISTS test.tableT (structCol struct<a:int>)");
+    run(driver, "CREATE VIEW IF NOT EXISTS test.viewA AS SELECT structCol as struct_col FROM test.tableS");
+    run(driver, "CREATE VIEW IF NOT EXISTS test.viewB AS SELECT structCol as struct_col FROM test.tableT");
+    run(driver,
+        "CREATE VIEW IF NOT EXISTS test.view_with_transform_column_name_reset AS SELECT struct_col AS structCol FROM (SELECT * FROM test.viewA UNION ALL SELECT * FROM test.viewB) X");
+    run(driver, "ALTER TABLE test.tableT CHANGE COLUMN structCol structCol struct<a:int, b:string>");
   }
 
   public static RelNode convertView(String db, String view) {


### PR DESCRIPTION
`transformColumnFieldName` could be the column name in an intermediate view, which might be different from the base table's column name because of the alias operation. In this case, the translated SQL couldn't be resolved.
Therefore, we add the `if` block in `GenericProjectToTrinoConverter` to reset `transformColumnFieldName` if necessary.
It traverses the base nodes, and if the column type on the corresponding index equals to the type of `transformColumn` but the column name is different from `transformColumnFieldName`, we reset `transformColumnFieldName`. For more information, please refer to the added unit test.

Tests:
1. Unit test
2. Test on affected production views, translated SQL could be resolved by trino with this patch
3. Integration test, no regression