### PR TITLE
Coral-Spark: Support `reflect` and `java_method` functions

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveGenericUDFReturnTypeInference.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveGenericUDFReturnTypeInference.java
@@ -7,6 +7,7 @@ package com.linkedin.coral.hive.hive2rel.functions;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -40,17 +41,20 @@ public class HiveGenericUDFReturnTypeInference implements SqlReturnTypeInference
   public RelDataType inferReturnType(SqlOperatorBinding sqlOperatorBinding) {
     int operandCount = sqlOperatorBinding.getOperandCount();
     ObjectInspector[] inputObjectInspectors = new ObjectInspector[operandCount];
-    for (int i = 0; i < sqlOperatorBinding.getOperandCount(); i++) {
+    for (int i = 0; i < operandCount; i++) {
       inputObjectInspectors[i] = getObjectInspector(sqlOperatorBinding.getOperandType(i));
     }
+    return inferReturnType(inputObjectInspectors, sqlOperatorBinding.getTypeFactory());
+  }
+
+  public RelDataType inferReturnType(ObjectInspector[] inputObjectInspectors, RelDataTypeFactory relDataTypeFactory) {
     try {
       Class dynamicallyLoadedUdfClass = getDynamicallyLoadedUdfClass();
-      return getRelDataType(
-          getContextObjectInspector(
-              dynamicallyLoadedUdfClass.getMethod("initialize", getDynamicallyLoadedObjectInspectorArrayClass()).invoke(
-                  dynamicallyLoadedUdfClass.newInstance(),
-                  new Object[] { getDynamicallyLoadedObjectInspectors(inputObjectInspectors) })),
-          sqlOperatorBinding.getTypeFactory());
+      final Method initializeMethod =
+          dynamicallyLoadedUdfClass.getMethod("initialize", getDynamicallyLoadedObjectInspectorArrayClass());
+      final Object oi = initializeMethod.invoke(dynamicallyLoadedUdfClass.newInstance(),
+          getDynamicallyLoadedObjectInspectors(inputObjectInspectors));
+      return getRelDataType(getContextObjectInspector(oi), relDataTypeFactory);
     } catch (NoSuchMethodException e) {
       throw new RuntimeException(
           "Unable to find org.apache.hadoop.hive.ql.udf.generic.GenericUDF.initialize() on: " + _udfClassName, e);

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveReflectOperator.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveReflectOperator.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.hive.hive2rel.functions;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlCallBinding;
+import org.apache.calcite.sql.SqlFunctionalOperator;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperandCountRange;
+import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.type.SqlOperandCountRanges;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+
+import com.linkedin.coral.com.google.common.collect.ImmutableList;
+import com.linkedin.coral.hive.hive2rel.TypeConverter;
+
+
+/**
+ * Calcite operator representation for Hive reflect function.
+ * reflect(class,method[,arg1[,arg2..]]) calls method with reflection.
+ */
+public class HiveReflectOperator extends SqlFunctionalOperator {
+
+  public static final HiveReflectOperator REFLECT = new HiveReflectOperator();
+
+  public HiveReflectOperator() {
+    super("reflect", SqlKind.OTHER_FUNCTION, 200, true, null, null, null);
+  }
+
+  @Override
+  public boolean checkOperandTypes(SqlCallBinding callBinding, boolean throwOnFailure) {
+    return callBinding.getOperandType(0).getSqlTypeName() == SqlTypeName.VARCHAR
+        && callBinding.getOperandType(1).getSqlTypeName() == SqlTypeName.VARCHAR;
+  }
+
+  @Override
+  public SqlOperandCountRange getOperandCountRange() {
+    return SqlOperandCountRanges.from(2);
+  }
+
+  @Override
+  public RelDataType inferReturnType(SqlOperatorBinding sqlOperatorBinding) {
+    int operandCount = sqlOperatorBinding.getOperandCount();
+    ObjectInspector[] inputObjectInspectors = new ObjectInspector[operandCount];
+    // Since `reflect` is implemented as a GenericUDF, we can use `HiveGenericUDFReturnTypeInference` to get its return type
+    HiveGenericUDFReturnTypeInference hiveGenericUDFReturnTypeInference = new HiveGenericUDFReturnTypeInference(
+        "org.apache.hadoop.hive.ql.udf.generic.GenericUDFReflect", ImmutableList.of("org.apache.hive:hive-exec:1.1.0"));
+
+    // We need to reset the first two object inspectors because they are required to be instances of `StringObjectInspector`
+    // Otherwise, the provided will be `JavaHiveCharObjectInspector` and can't pass the validation while calling `initialize` function
+    // in `org.apache.hadoop.hive.ql.udf.generic.GenericUDFReflect`
+    inputObjectInspectors[0] = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+    inputObjectInspectors[1] = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+    for (int i = 2; i < operandCount; i++) {
+      TypeInfo typeInfo = TypeConverter.convert(sqlOperatorBinding.getOperandType(i));
+      inputObjectInspectors[i] = TypeInfoUtils.getStandardJavaObjectInspectorFromTypeInfo(typeInfo);
+    }
+    return hiveGenericUDFReturnTypeInference.inferReturnType(inputObjectInspectors,
+        sqlOperatorBinding.getTypeFactory());
+  }
+}

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -519,6 +519,10 @@ public class StaticHiveFunctionRegistry implements HiveFunctionRegistry {
     addFunctionEntry("explode", HiveExplodeOperator.EXPLODE);
     addFunctionEntry("json_tuple", HiveJsonTupleOperator.JSON_TUPLE);
 
+    // reflect functions
+    addFunctionEntry("reflect", HiveReflectOperator.REFLECT);
+    addFunctionEntry("java_method", HiveReflectOperator.REFLECT);
+
     // Generic UDTFs
     createAddUserDefinedTableFunction("com.linkedin.tsar.hive.udf.ToJymbiiScores",
         ImmutableList.of("job_urn", "rank", "glmix_score", "global_model_score", "sentinel_score", "job_effect_score",

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -520,14 +520,14 @@ public class CoralSparkTest {
 
   @Test
   public void testReflectFunction() {
-    RelNode relNode = TestUtils.toRelNode("select reflect('java.lang.String', 'valueOf', 1) FROM default.complex");
+    RelNode relNode = TestUtils.toRelNode("SELECT reflect('java.lang.String', 'valueOf', 1) FROM default.complex");
     String targetSql = "SELECT reflect('java.lang.String', 'valueOf', 1)\n" + "FROM default.complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testJavaMethodFunction() {
-    RelNode relNode = TestUtils.toRelNode("select java_method('java.lang.String', 'valueOf', 1) FROM default.complex");
+    RelNode relNode = TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) FROM default.complex");
     String targetSql = "SELECT reflect('java.lang.String', 'valueOf', 1)\n" + "FROM default.complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -528,8 +528,8 @@ public class CoralSparkTest {
   @Test
   public void testReflectFunctionReturnType() {
     RelNode relNode = TestUtils.toRelNode("SELECT reflect('java.lang.String', 'valueOf', 1) + 1 FROM default.complex");
-    String targetSql = "SELECT CAST(reflect('java.lang.String', 'valueOf', 1) AS INTEGER) + 1\n"
-        + "FROM default.complex";
+    String targetSql =
+        "SELECT CAST(reflect('java.lang.String', 'valueOf', 1) AS INTEGER) + 1\n" + "FROM default.complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
 
     relNode = TestUtils.toRelNode("SELECT reflect('java.lang.String', 'valueOf', 1) || 'a' FROM default.complex");
@@ -546,9 +546,10 @@ public class CoralSparkTest {
 
   @Test
   public void testJavaMethodFunctionReturnType() {
-    RelNode relNode = TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) + 1 FROM default.complex");
-    String targetSql = "SELECT CAST(reflect('java.lang.String', 'valueOf', 1) AS INTEGER) + 1\n"
-        + "FROM default.complex";
+    RelNode relNode =
+        TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) + 1 FROM default.complex");
+    String targetSql =
+        "SELECT CAST(reflect('java.lang.String', 'valueOf', 1) AS INTEGER) + 1\n" + "FROM default.complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
 
     relNode = TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) || 'a' FROM default.complex");

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -517,4 +517,18 @@ public class CoralSparkTest {
             + "FROM default.complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
+
+  @Test
+  public void testReflectFunction() {
+    RelNode relNode = TestUtils.toRelNode("select reflect('java.lang.String', 'valueOf', 1) FROM default.complex");
+    String targetSql = "SELECT reflect('java.lang.String', 'valueOf', 1)\n" + "FROM default.complex";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+  }
+
+  @Test
+  public void testJavaMethodFunction() {
+    RelNode relNode = TestUtils.toRelNode("select java_method('java.lang.String', 'valueOf', 1) FROM default.complex");
+    String targetSql = "SELECT reflect('java.lang.String', 'valueOf', 1)\n" + "FROM default.complex";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+  }
 }

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -526,9 +526,33 @@ public class CoralSparkTest {
   }
 
   @Test
+  public void testReflectFunctionReturnType() {
+    RelNode relNode = TestUtils.toRelNode("SELECT reflect('java.lang.String', 'valueOf', 1) + 1 FROM default.complex");
+    String targetSql = "SELECT CAST(reflect('java.lang.String', 'valueOf', 1) AS INTEGER) + 1\n"
+        + "FROM default.complex";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+
+    relNode = TestUtils.toRelNode("SELECT reflect('java.lang.String', 'valueOf', 1) || 'a' FROM default.complex");
+    targetSql = "SELECT concat(reflect('java.lang.String', 'valueOf', 1), 'a')\n" + "FROM default.complex";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+  }
+
+  @Test
   public void testJavaMethodFunction() {
     RelNode relNode = TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) FROM default.complex");
     String targetSql = "SELECT reflect('java.lang.String', 'valueOf', 1)\n" + "FROM default.complex";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+  }
+
+  @Test
+  public void testJavaMethodFunctionReturnType() {
+    RelNode relNode = TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) + 1 FROM default.complex");
+    String targetSql = "SELECT CAST(reflect('java.lang.String', 'valueOf', 1) AS INTEGER) + 1\n"
+        + "FROM default.complex";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+
+    relNode = TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) || 'a' FROM default.complex");
+    targetSql = "SELECT concat(reflect('java.lang.String', 'valueOf', 1), 'a')\n" + "FROM default.complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 }


### PR DESCRIPTION
[reflect](https://cwiki.apache.org/confluence/display/Hive/ReflectUDF) and its synonym `java_method` are not supported yet, this PR is to support them for some affected production views.

There seems no similar function support in Trino, so I only added the tests for Spark.

Tests:
1. Unit tests
2. Test on affected production views, which could be translated well with this patch
3. Integration test, no regression
