### PR TITLE
Coral-Trino: Modify the way of creating `hiveToRelConverter`

### DIFF
--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverter.java
@@ -30,7 +30,7 @@ public class HiveToTrinoConverter {
   public static HiveToTrinoConverter create(HiveMetastoreClient mscClient, Map<String, Boolean> configs) {
     checkNotNull(mscClient);
     checkNotNull(configs);
-    HiveToRelConverter hiveToRelConverter = HiveToRelConverter.create(mscClient);
+    HiveToRelConverter hiveToRelConverter = new HiveToRelConverter(mscClient);
     RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter(configs);
     return new HiveToTrinoConverter(hiveToRelConverter, relToTrinoConverter);
   }


### PR DESCRIPTION
To be aligned with #151, we cannot use `HiveToRelConverter.create` anymore.

Test: `./gradlew clean build`