### PR TITLE
Coral-Hive: Fix the issue caused by incompatibility with Coral 2.x

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveReflectOperator.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveReflectOperator.java
@@ -19,7 +19,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 
 import com.linkedin.coral.com.google.common.collect.ImmutableList;
-import com.linkedin.coral.hive.hive2rel.TypeConverter;
+import com.linkedin.coral.common.TypeConverter;
 
 
 /**


### PR DESCRIPTION
After #151 was checked in, the building check for other PRs wouldn't run again, so there might be some incompatible issues. We need to check & test locally before merging the PRs which were opened before the merge of #151 to avoid the building issues.

Test: ./gradlew clean build