### PR TITLE
Coral-Hive: Avoid outputing report for `ArtifactsResolver`

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/ArtifactsResolver.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/ArtifactsResolver.java
@@ -124,6 +124,7 @@ public class ArtifactsResolver {
     final ResolveOptions resolveOptions = new ResolveOptions().setConfs(new String[] { "default" })
         .setOutputReport(true).setValidate(true).setTransitive(dependencySpec.transitive);
     resolveOptions.setLog(LogOptions.LOG_QUIET);
+    resolveOptions.setOutputReport(false);
     try {
       final ResolveReport report = _ivyInstance.resolve(md, resolveOptions);
       if (report.hasError()) {


### PR DESCRIPTION
It is not necessary to output the resolving report since we will not be using it at all. Outputting the report might bring some unexpected issues like failing to find the required config files if we want to reset the default ivy cache dir.

Tests:
1. Test on the affected view
2. i-test, no regression
