### PR TITLE
Coral-Hive: Support `xpath` functions

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveReturnTypes.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveReturnTypes.java
@@ -41,6 +41,7 @@ public class HiveReturnTypes {
   public static final SqlReturnTypeInference STRING = ReturnTypes.explicit(SqlTypeName.VARCHAR);
   public static final SqlReturnTypeInference BINARY = ReturnTypes.explicit(SqlTypeName.BINARY);
   public static final SqlReturnTypeInference BIGINT = ReturnTypes.explicit(SqlTypeName.BIGINT);
+  public static final SqlReturnTypeInference SMALLINT = ReturnTypes.explicit(SqlTypeName.SMALLINT);
   public static final SqlReturnTypeInference DATE = ReturnTypes.explicit(SqlTypeName.DATE);
   public static final SqlReturnTypeInference TIMESTAMP = ReturnTypes.explicit(SqlTypeName.TIMESTAMP);
 

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -298,9 +298,9 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
     createAddUserDefinedFunction("xpath", HiveReturnTypes.arrayOfType(SqlTypeName.VARCHAR), STRING_STRING);
     createAddUserDefinedFunction("xpath_string", HiveReturnTypes.STRING, STRING_STRING);
     createAddUserDefinedFunction("xpath_boolean", ReturnTypes.BOOLEAN, STRING_STRING);
-    createAddUserDefinedFunction("xpath_short", ReturnTypes.INTEGER, STRING_STRING);
+    createAddUserDefinedFunction("xpath_short", HiveReturnTypes.SMALLINT, STRING_STRING);
     createAddUserDefinedFunction("xpath_int", ReturnTypes.INTEGER, STRING_STRING);
-    createAddUserDefinedFunction("xpath_long", ReturnTypes.INTEGER, STRING_STRING);
+    createAddUserDefinedFunction("xpath_long", HiveReturnTypes.BIGINT, STRING_STRING);
     createAddUserDefinedFunction("xpath_float", DOUBLE_NULLABLE, STRING_STRING);
     createAddUserDefinedFunction("xpath_double", DOUBLE_NULLABLE, STRING_STRING);
     createAddUserDefinedFunction("xpath_number", DOUBLE_NULLABLE, STRING_STRING);

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -294,6 +294,17 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
     createAddUserDefinedFunction("crc32", HiveReturnTypes.BIGINT,
         or(family(SqlTypeFamily.STRING), family(SqlTypeFamily.BINARY)));
 
+    // xpath functions
+    createAddUserDefinedFunction("xpath", HiveReturnTypes.arrayOfType(SqlTypeName.VARCHAR), STRING_STRING);
+    createAddUserDefinedFunction("xpath_string", HiveReturnTypes.STRING, STRING_STRING);
+    createAddUserDefinedFunction("xpath_boolean", ReturnTypes.BOOLEAN, STRING_STRING);
+    createAddUserDefinedFunction("xpath_short", ReturnTypes.INTEGER, STRING_STRING);
+    createAddUserDefinedFunction("xpath_int", ReturnTypes.INTEGER, STRING_STRING);
+    createAddUserDefinedFunction("xpath_long", ReturnTypes.INTEGER, STRING_STRING);
+    createAddUserDefinedFunction("xpath_float", DOUBLE_NULLABLE, STRING_STRING);
+    createAddUserDefinedFunction("xpath_double", DOUBLE_NULLABLE, STRING_STRING);
+    createAddUserDefinedFunction("xpath_number", DOUBLE_NULLABLE, STRING_STRING);
+
     // Date Functions
     createAddUserDefinedFunction("from_unixtime", HiveReturnTypes.STRING,
         family(ImmutableList.of(SqlTypeFamily.NUMERIC, SqlTypeFamily.STRING), optionalOrd(1)));

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -301,9 +301,9 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
     createAddUserDefinedFunction("xpath_short", HiveReturnTypes.SMALLINT, STRING_STRING);
     createAddUserDefinedFunction("xpath_int", ReturnTypes.INTEGER, STRING_STRING);
     createAddUserDefinedFunction("xpath_long", HiveReturnTypes.BIGINT, STRING_STRING);
-    createAddUserDefinedFunction("xpath_float", DOUBLE_NULLABLE, STRING_STRING);
-    createAddUserDefinedFunction("xpath_double", DOUBLE_NULLABLE, STRING_STRING);
-    createAddUserDefinedFunction("xpath_number", DOUBLE_NULLABLE, STRING_STRING);
+    createAddUserDefinedFunction("xpath_float", DOUBLE, STRING_STRING);
+    createAddUserDefinedFunction("xpath_double", DOUBLE, STRING_STRING);
+    createAddUserDefinedFunction("xpath_number", DOUBLE, STRING_STRING);
 
     // Date Functions
     createAddUserDefinedFunction("from_unixtime", HiveReturnTypes.STRING,

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -465,6 +465,45 @@ public class CoralSparkTest {
   }
 
   @Test
+  public void testXpathFunctions() {
+    RelNode relNode = TestUtils.toRelNode("select xpath('<a><b>b1</b><b>b2</b></a>','a/*') FROM foo");
+    String targetSql = "SELECT xpath('<a><b>b1</b><b>b2</b></a>', 'a/*')\n" + "FROM default.foo";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+
+    relNode = TestUtils.toRelNode("SELECT xpath_string('<a><b>bb</b><c>cc</c></a>', 'a/b') FROM foo");
+    targetSql = "SELECT xpath_string('<a><b>bb</b><c>cc</c></a>', 'a/b')\n" + "FROM default.foo";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+
+    relNode = TestUtils.toRelNode("SELECT xpath_boolean('<a><b>b</b></a>', 'a/b') FROM foo");
+    targetSql = "SELECT xpath_boolean('<a><b>b</b></a>', 'a/b')\n" + "FROM default.foo";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+
+    relNode = TestUtils.toRelNode("SELECT xpath_int('<a>b</a>', 'a = 10') FROM foo");
+    targetSql = "SELECT xpath_int('<a>b</a>', 'a = 10')\n" + "FROM default.foo";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+
+    relNode = TestUtils.toRelNode("SELECT xpath_short('<a>b</a>', 'a = 10') FROM foo");
+    targetSql = "SELECT xpath_short('<a>b</a>', 'a = 10')\n" + "FROM default.foo";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+
+    relNode = TestUtils.toRelNode("SELECT xpath_long('<a>b</a>', 'a = 10') FROM foo");
+    targetSql = "SELECT xpath_long('<a>b</a>', 'a = 10')\n" + "FROM default.foo";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+
+    relNode = TestUtils.toRelNode("SELECT xpath_float('<a>b</a>', 'a = 10') FROM foo");
+    targetSql = "SELECT xpath_float('<a>b</a>', 'a = 10')\n" + "FROM default.foo";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+
+    relNode = TestUtils.toRelNode("SELECT xpath_double('<a>b</a>', 'a = 10') FROM foo");
+    targetSql = "SELECT xpath_double('<a>b</a>', 'a = 10')\n" + "FROM default.foo";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+
+    relNode = TestUtils.toRelNode("SELECT xpath_number('<a>b</a>', 'a = 10') FROM foo");
+    targetSql = "SELECT xpath_number('<a>b</a>', 'a = 10')\n" + "FROM default.foo";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+  }
+
+  @Test
   public void testConcat() {
     RelNode relNode = TestUtils.toRelNode("SELECT 'a' || 'b'");
 

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -295,6 +295,49 @@ public class HiveToTrinoConverterTest {
   }
 
   @Test
+  public void testXpathFunctions() {
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+
+    RelNode relNode = hiveToRelConverter.convertSql("select xpath('<a><b>b1</b><b>b2</b></a>','a/*')");
+    String targetSql =
+        "SELECT \"xpath\"('<a><b>b1</b><b>b2</b></a>', 'a/*')\n" + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+    assertEquals(relToTrinoConverter.convert(relNode), targetSql);
+
+    relNode = hiveToRelConverter.convertSql("SELECT xpath_string('<a><b>bb</b><c>cc</c></a>', 'a/b')");
+    targetSql =
+        "SELECT \"xpath_string\"('<a><b>bb</b><c>cc</c></a>', 'a/b')\n" + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+    assertEquals(relToTrinoConverter.convert(relNode), targetSql);
+
+    relNode = hiveToRelConverter.convertSql("SELECT xpath_boolean('<a><b>b</b></a>', 'a/b')");
+    targetSql = "SELECT \"xpath_boolean\"('<a><b>b</b></a>', 'a/b')\n" + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+    assertEquals(relToTrinoConverter.convert(relNode), targetSql);
+
+    relNode = hiveToRelConverter.convertSql("SELECT xpath_int('<a>b</a>', 'a = 10')");
+    targetSql = "SELECT \"xpath_int\"('<a>b</a>', 'a = 10')\n" + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+    assertEquals(relToTrinoConverter.convert(relNode), targetSql);
+
+    relNode = hiveToRelConverter.convertSql("SELECT xpath_short('<a>b</a>', 'a = 10')");
+    targetSql = "SELECT \"xpath_short\"('<a>b</a>', 'a = 10')\n" + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+    assertEquals(relToTrinoConverter.convert(relNode), targetSql);
+
+    relNode = hiveToRelConverter.convertSql("SELECT xpath_long('<a>b</a>', 'a = 10')");
+    targetSql = "SELECT \"xpath_long\"('<a>b</a>', 'a = 10')\n" + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+    assertEquals(relToTrinoConverter.convert(relNode), targetSql);
+
+    relNode = hiveToRelConverter.convertSql("SELECT xpath_float('<a>b</a>', 'a = 10')");
+    targetSql = "SELECT \"xpath_float\"('<a>b</a>', 'a = 10')\n" + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+    assertEquals(relToTrinoConverter.convert(relNode), targetSql);
+
+    relNode = hiveToRelConverter.convertSql("SELECT xpath_double('<a>b</a>', 'a = 10')");
+    targetSql = "SELECT \"xpath_double\"('<a>b</a>', 'a = 10')\n" + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+    assertEquals(relToTrinoConverter.convert(relNode), targetSql);
+
+    relNode = hiveToRelConverter.convertSql("SELECT xpath_number('<a>b</a>', 'a = 10')");
+    targetSql = "SELECT \"xpath_number\"('<a>b</a>', 'a = 10')\n" + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+    assertEquals(relToTrinoConverter.convert(relNode), targetSql);
+  }
+
+  @Test
   public void testFromUnixTimeOneParameter() {
     RelNode relNode = hiveToRelConverter.convertSql("SELECT from_unixtime(10000)");
     String targetSql = "SELECT \"format_datetime\"(\"from_unixtime\"(10000), 'yyyy-MM-dd HH:mm:ss')\n"

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -295,6 +295,28 @@ public class HiveToTrinoConverterTest {
   }
 
   @Test
+  public void testFromUnixTimeOneParameter() {
+    RelNode relNode = hiveToRelConverter.convertSql("SELECT from_unixtime(10000)");
+    String targetSql = "SELECT \"format_datetime\"(\"from_unixtime\"(10000), 'yyyy-MM-dd HH:mm:ss')\n"
+        + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
+
+  @Test
+  public void testFromUnixTimeTwoParameters() {
+    RelNode relNode = hiveToRelConverter.convertSql("SELECT from_unixtime(10000, 'yyyy-MM-dd')");
+    String targetSql = "SELECT \"format_datetime\"(\"from_unixtime\"(10000), 'yyyy-MM-dd')\n"
+        + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
+
+  @Test
   public void testXpathFunctions() {
     RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
 
@@ -335,28 +357,6 @@ public class HiveToTrinoConverterTest {
     relNode = hiveToRelConverter.convertSql("SELECT xpath_number('<a>b</a>', 'a = 10')");
     targetSql = "SELECT \"xpath_number\"('<a>b</a>', 'a = 10')\n" + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
     assertEquals(relToTrinoConverter.convert(relNode), targetSql);
-  }
-
-  @Test
-  public void testFromUnixTimeOneParameter() {
-    RelNode relNode = hiveToRelConverter.convertSql("SELECT from_unixtime(10000)");
-    String targetSql = "SELECT \"format_datetime\"(\"from_unixtime\"(10000), 'yyyy-MM-dd HH:mm:ss')\n"
-        + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
-
-    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
-    String expandedSql = relToTrinoConverter.convert(relNode);
-    assertEquals(expandedSql, targetSql);
-  }
-
-  @Test
-  public void testFromUnixTimeTwoParameters() {
-    RelNode relNode = hiveToRelConverter.convertSql("SELECT from_unixtime(10000, 'yyyy-MM-dd')");
-    String targetSql = "SELECT \"format_datetime\"(\"from_unixtime\"(10000), 'yyyy-MM-dd')\n"
-        + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
-
-    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
-    String expandedSql = relToTrinoConverter.convert(relNode);
-    assertEquals(expandedSql, targetSql);
   }
 
   @Test


### PR DESCRIPTION
[xpath](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+XPathUDF) functions are not supported yet, this PR is to support them for some affected production views.

Tests:
1. Unit tests
2. Test on affected production views