### PR TITLE
coral-schema: Generate documentation for aggregates in views

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
@@ -295,7 +295,8 @@ public class RelToAvroSchemaConverter {
       for (Pair<AggregateCall, String> aggCall : logicalAggregate.getNamedAggCalls()) {
         String fieldName = SchemaUtilities.toAvroQualifiedName(aggCall.right);
         RelDataType fieldType = aggCall.left.getType();
-        SchemaUtilities.appendField(fieldName, fieldType, null, logicalAggregateFieldAssembler, true);
+        SchemaUtilities.appendField(fieldName, fieldType,
+            SchemaUtilities.generateDocumentationForAggregate(aggCall.left), logicalAggregateFieldAssembler, true);
       }
 
       schemaMap.put(logicalAggregate, logicalAggregateFieldAssembler.endRecord());

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
+import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
@@ -280,6 +281,10 @@ class SchemaUtilities {
     printWriter.flush();
 
     return "Field created from view literal with value: " + documentationWriter;
+  }
+
+  static String generateDocumentationForAggregate(AggregateCall aggregateCall) {
+    return "Field created in view by applying aggregate function of type: " + aggregateCall.getAggregation().getKind();
   }
 
   static String toAvroQualifiedName(@Nonnull String name) {

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -115,6 +115,19 @@ public class ViewToAvroSchemaConverterTests {
   }
 
   @Test
+  public void testMultipleAggregates() {
+    String viewSql = "CREATE VIEW v AS SELECT MAX(bc.Id) AS Max_Id_Col, MIN(bc.Id) AS Min_Id_Col, "
+        + "AVG(bc.Id) AS Avg_Id_Col, SUM(bc.Id) AS Sum_Id_Col FROM basecomplex bc GROUP BY bc.Array_Col";
+
+    TestUtils.executeCreateViewQuery("default", "v", viewSql);
+
+    ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);
+    Schema actualSchema = viewToAvroSchemaConverter.toAvroSchema("default", "v");
+
+    Assert.assertEquals(actualSchema.toString(true), TestUtils.loadSchema("testMultipleAggregates-expected.avsc"));
+  }
+
+  @Test
   public void testRexCallAggregate() {
     String viewSql = "CREATE VIEW v AS " + "SELECT 22*COUNT(bc.Id) AS Temp " + "FROM basecomplex bc";
 

--- a/coral-schema/src/test/resources/docTestResources/testAggregateRename-expected-with-doc.avsc
+++ b/coral-schema/src/test/resources/docTestResources/testAggregateRename-expected-with-doc.avsc
@@ -8,6 +8,7 @@
     "doc" : "Sample id of the record."
   }, {
     "name" : "Count_Col",
-    "type" : [ "null", "long" ]
+    "type" : [ "null", "long" ],
+    "doc" : "Field created in view by applying aggregate function of type: COUNT"
   } ]
 }

--- a/coral-schema/src/test/resources/testAggregate-expected.avsc
+++ b/coral-schema/src/test/resources/testAggregate-expected.avsc
@@ -7,7 +7,8 @@
     "type" : "int"
   }, {
     "name" : "EXPR_1",
-    "type" : [ "null", "long" ]
+    "type" : [ "null", "long" ],
+    "doc" : "Field created in view by applying aggregate function of type: COUNT"
   }, {
     "name" : "EXPR_2",
     "type" : [ "null", "int" ]

--- a/coral-schema/src/test/resources/testAggregateRename-expected.avsc
+++ b/coral-schema/src/test/resources/testAggregateRename-expected.avsc
@@ -7,6 +7,7 @@
     "type" : "int"
   }, {
     "name" : "Count_Col",
-    "type" : [ "null", "long" ]
+    "type" : [ "null", "long" ],
+    "doc" : "Field created in view by applying aggregate function of type: COUNT"
   } ]
 }

--- a/coral-schema/src/test/resources/testMultipleAggregates-expected.avsc
+++ b/coral-schema/src/test/resources/testMultipleAggregates-expected.avsc
@@ -1,0 +1,22 @@
+{
+  "type" : "record",
+  "name" : "v",
+  "namespace" : "default.v",
+  "fields" : [ {
+    "name" : "Max_Id_Col",
+    "type" : [ "null", "int" ],
+    "doc" : "Field created in view by applying aggregate function of type: MAX"
+  }, {
+    "name" : "Min_Id_Col",
+    "type" : [ "null", "int" ],
+    "doc" : "Field created in view by applying aggregate function of type: MIN"
+  }, {
+    "name" : "Avg_Id_Col",
+    "type" : [ "null", "int" ],
+    "doc" : "Field created in view by applying aggregate function of type: AVG"
+  }, {
+    "name" : "Sum_Id_Col",
+    "type" : [ "null", "long" ],
+    "doc" : "Field created in view by applying aggregate function of type: SUM"
+  } ]
+}

--- a/coral-schema/src/test/resources/testRexCallAggregateMultiple-expected.avsc
+++ b/coral-schema/src/test/resources/testRexCallAggregateMultiple-expected.avsc
@@ -13,9 +13,11 @@
     "type" : [ "null", "int" ]
   }, {
     "name" : "EXPR_3",
-    "type" : [ "null", "long" ]
+    "type" : [ "null", "long" ],
+    "doc" : "Field created in view by applying aggregate function of type: COUNT"
   }, {
     "name" : "EXPR_4",
-    "type" : [ "null", "long" ]
+    "type" : [ "null", "long" ],
+    "doc" : "Field created in view by applying aggregate function of type: COUNT"
   } ]
 }


### PR DESCRIPTION
### Summary

Previously, field-level documentation in schemas produced by the `ViewToAvroSchemaConverter` was only available for fields directly selected from underlying base tables (#115), or those created from literal values (#172). This PR adds documentation for fields created from aggregate function calls (e.g. `COUNT`, `SUM`, `AVG`, etc).

The documentation is in the form of: `"Field created in view by applying aggregate function of type: <TYPE>"`

### Testing
One new unit test has been added (`testMultipleAggregates`). Some existing test cases include aggregate function calls and the `.avsc` files with their expected schemas have been updated to include the expected documentation.