### PR TITLE
Allow aliased column in ORDER BY clause in hive query

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveSqlConformance.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveSqlConformance.java
@@ -27,4 +27,9 @@ public class HiveSqlConformance extends SqlDelegatingConformance {
   public boolean isSortByAlias() {
     return true;
   }
+
+  @Override
+  public boolean isHavingAlias() {
+    return true;
+  }
 }

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveSqlConformance.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveSqlConformance.java
@@ -22,4 +22,9 @@ public class HiveSqlConformance extends SqlDelegatingConformance {
   public boolean allowNiladicParentheses() {
     return true;
   }
+
+  @Override
+  public boolean isSortByAlias() {
+    return true;
+  }
 }

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -579,4 +579,22 @@ public class CoralSparkTest {
     String targetSql = "SELECT NOT FALSE a\n" + "FROM default.foo";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
+
+  @Test
+  public void testAliasOrderBy() {
+    RelNode relNode =
+        TestUtils.toRelNode("SELECT a, SUBSTR(b, 1, 1) AS aliased_column, c FROM foo ORDER BY aliased_column DESC");
+    String targetSql = "SELECT a, SUBSTRING(b, 1, 1) aliased_column, c\n" + "FROM default.foo\n"
+        + "ORDER BY SUBSTRING(b, 1, 1) DESC NULLS LAST";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+  }
+
+  @Test
+  public void testAliasHaving() {
+    RelNode relNode = TestUtils.toRelNode(
+        "SELECT a, SUBSTR(b, 1, 1) AS aliased_column FROM foo GROUP BY a, b HAVING aliased_column in ('dummy_value')");
+    String targetSql = "SELECT a, SUBSTRING(b, 1, 1) aliased_column\n" + "FROM default.foo\n" + "GROUP BY a, b\n"
+        + "HAVING SUBSTRING(b, 1, 1)\n" + "IN ('dummy_value')";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+  }
 }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -441,4 +441,16 @@ public class HiveToTrinoConverterTest {
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
+
+  @Test
+  public void testAliasOrderBy() {
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+
+    RelNode relNode = hiveToRelConverter
+        .convertSql("SELECT a, SUBSTR(b, 1, 1) AS aliased_column, c FROM test.tabler ORDER BY aliased_column DESC");
+    String targetSql =
+        "SELECT \"a\", \"SUBSTR\"(\"b\", 1, 1) AS \"aliased_column\", \"c\"\nFROM \"test\".\"tabler\"\nORDER BY \"SUBSTR\"(\"b\", 1, 1) DESC";
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
 }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -453,4 +453,16 @@ public class HiveToTrinoConverterTest {
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
+
+  @Test
+  public void testAliasHaving() {
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+
+    RelNode relNode = hiveToRelConverter.convertSql(
+        "SELECT a, SUBSTR(b, 1, 1) AS aliased_column FROM test.tabler GROUP BY a, b HAVING aliased_column in ('dummy_value')");
+    String targetSql =
+        "SELECT \"a\", \"SUBSTR\"(\"b\", 1, 1) AS \"aliased_column\"\nFROM \"test\".\"tabler\"\nGROUP BY \"a\", \"b\"\nHAVING \"SUBSTR\"(\"b\", 1, 1)\nIN ('dummy_value')";
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
 }


### PR DESCRIPTION
In Hive using aliased columns in ORDER BY clause is valid:

```
select substr(a_string, 1, 1) as aliased_column from string_timestamp_table order by aliased_column;
+---------------+
| aliased_column  |
+---------------+
| b             |
| f             |
+---------------+
``` 

Currently Calcite conversion does not allow for the above Hive sql
```
At line 0, column 0: Column 'aliased_column' not found in any table
org.apache.calcite.runtime.CalciteContextException: At line 0, column 0: Column 'aliased_column' not found in any table
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.apache.calcite.runtime.Resources$ExInstWithCause.ex(Resources.java:463)
	at org.apache.calcite.sql.SqlUtil.newContextException(SqlUtil.java:834)
	at org.apache.calcite.sql.SqlUtil.newContextException(SqlUtil.java:819)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.newValidationError(SqlValidatorImpl.java:4867)
	at org.apache.calcite.sql.validate.DelegatingScope.fullyQualify(DelegatingScope.java:259)
	at org.apache.calcite.sql.validate.OrderByScope.fullyQualify(OrderByScope.java:92)
	at org.apache.calcite.sql.validate.SqlValidatorImpl$Expander.visit(SqlValidatorImpl.java:5759)
	at org.apache.calcite.sql.validate.SqlValidatorImpl$Expander.visit(SqlValidatorImpl.java:5744)
	at org.apache.calcite.sql.SqlIdentifier.accept(SqlIdentifier.java:317)
	at org.apache.calcite.sql.util.SqlShuttle$CallCopyingArgHandler.visitChild(SqlShuttle.java:134)
	at org.apache.calcite.sql.util.SqlShuttle$CallCopyingArgHandler.visitChild(SqlShuttle.java:101)
	at org.apache.calcite.sql.SqlOperator.acceptCall(SqlOperator.java:868)
	at org.apache.calcite.sql.validate.SqlValidatorImpl$Expander.visitScoped(SqlValidatorImpl.java:5777)
	at org.apache.calcite.sql.validate.SqlScopedShuttle.visit(SqlScopedShuttle.java:50)
	at org.apache.calcite.sql.validate.SqlScopedShuttle.visit(SqlScopedShuttle.java:33)
	at org.apache.calcite.sql.SqlCall.accept(SqlCall.java:139)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.expand(SqlValidatorImpl.java:5351)
	at com.linkedin.coral.hive.hive2rel.HiveSqlValidator.expand(HiveSqlValidator.java:63)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.validateOrderList(SqlValidatorImpl.java:3877)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.validateSelect(SqlValidatorImpl.java:3398)
	at org.apache.calcite.sql.validate.SelectNamespace.validateImpl(SelectNamespace.java:60)
	at org.apache.calcite.sql.validate.AbstractNamespace.validate(AbstractNamespace.java:84)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.validateNamespace(SqlValidatorImpl.java:1005)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.validateQuery(SqlValidatorImpl.java:965)
	at org.apache.calcite.sql.SqlSelect.validate(SqlSelect.java:216)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.validateScopedExpression(SqlValidatorImpl.java:940)
	at org.apache.calcite.sql.validate.SqlValidatorImpl.validate(SqlValidatorImpl.java:647)
	at com.linkedin.coral.hive.hive2rel.HiveSqlToRelConverter.convertQuery(HiveSqlToRelConverter.java:59)
```


Adding `isSortByAlias()` override to the SqlConformance to allow the above case to properly resolve to
```
select substr(a_string, 1, 1) as aliased_column from string_timestamp_table order by substr(a_string, 1, 1);
```