### PR TITLE
Coral-Hive: Correct the return type of a UDF

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -476,7 +476,7 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
                 "listingtype", "sublistingtype", "istestjob"),
             ImmutableList.of(HiveReturnTypes.BIGINT, HiveReturnTypes.STRING,
                 HiveReturnTypes.arrayOfType(SqlTypeName.BIGINT), HiveReturnTypes.arrayOfType(SqlTypeName.VARCHAR),
-                HiveReturnTypes.STRING, HiveReturnTypes.STRING, HiveReturnTypes.STRING)),
+                HiveReturnTypes.STRING, HiveReturnTypes.STRING, ReturnTypes.BOOLEAN)),
         family(
             ImmutableList.of(SqlTypeFamily.NUMERIC, SqlTypeFamily.STRING, SqlTypeFamily.STRING, SqlTypeFamily.STRING)));
     createAddUserDefinedFunction("com.linkedin.stdudfs.userinterfacelookup.hive.UserInterfaceLookup",


### PR DESCRIPTION
The previous return type is not correct.
Tested on the affected production views.