### PR TITLE
Wrap non-string input to substring function

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -277,8 +277,11 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
     createAddUserDefinedFunction("split", HiveReturnTypes.arrayOfType(SqlTypeName.VARCHAR), STRING_STRING);
     createAddUserDefinedFunction("str_to_map", HiveReturnTypes.mapOfType(SqlTypeName.VARCHAR, SqlTypeName.VARCHAR),
         family(Collections.nCopies(3, SqlTypeFamily.STRING), optionalOrd(ImmutableList.of(1, 2))));
-    addFunctionEntry("substr", SUBSTRING);
-    addFunctionEntry("substring", SUBSTRING);
+    createAddUserDefinedFunction("substr", HiveReturnTypes.STRING,
+        family(ImmutableList.of(SqlTypeFamily.STRING, SqlTypeFamily.INTEGER, SqlTypeFamily.INTEGER), optionalOrd(2)));
+    createAddUserDefinedFunction("substring", HiveReturnTypes.STRING,
+        family(ImmutableList.of(SqlTypeFamily.STRING, SqlTypeFamily.INTEGER, SqlTypeFamily.INTEGER), optionalOrd(2)));
+
     createAddUserDefinedFunction("substring_index", HiveReturnTypes.STRING, STRING_STRING_INTEGER);
     createAddUserDefinedFunction("trim", HiveReturnTypes.STRING, STRING);
     createAddUserDefinedFunction("unbase64", explicit(SqlTypeName.VARBINARY), or(STRING, NULLABLE_LITERAL));

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -551,6 +551,15 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
       return new SqlBasicCall(SqlStdOperatorTable.OVER, new SqlNode[] { func, window }, ZERO);
     }
 
+    if (functionName.equalsIgnoreCase("SUBSTRING")) {
+      // Calcite overrides instance of SUBSTRING with its default SUBSTRING function as defined in SqlStdOperatorTable,
+      // so we rewrite instances of SUBSTRING as SUBSTR
+      SqlNode originalNode = sqlOperands.get(0);
+      SqlNode substrNode = new SqlIdentifier(ImmutableList.of("SUBSTR"), null, originalNode.getParserPosition(), null);
+      hiveFunction = functionResolver.tryResolve("SUBSTR", ctx.hiveTable.orElse(null), sqlOperands.size() - 1);
+      return hiveFunction.createCall(substrNode, sqlOperands.subList(1, sqlOperands.size()), quantifier);
+    }
+
     return hiveFunction.createCall(sqlOperands.get(0), sqlOperands.subList(1, sqlOperands.size()), quantifier);
   }
 

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -584,8 +584,8 @@ public class CoralSparkTest {
   public void testAliasOrderBy() {
     RelNode relNode =
         TestUtils.toRelNode("SELECT a, SUBSTR(b, 1, 1) AS aliased_column, c FROM foo ORDER BY aliased_column DESC");
-    String targetSql = "SELECT a, SUBSTRING(b, 1, 1) aliased_column, c\n" + "FROM default.foo\n"
-        + "ORDER BY SUBSTRING(b, 1, 1) DESC NULLS LAST";
+    String targetSql = "SELECT a, substr(b, 1, 1) aliased_column, c\n" + "FROM default.foo\n"
+        + "ORDER BY substr(b, 1, 1) DESC NULLS LAST";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -593,8 +593,8 @@ public class CoralSparkTest {
   public void testAliasHaving() {
     RelNode relNode = TestUtils.toRelNode(
         "SELECT a, SUBSTR(b, 1, 1) AS aliased_column FROM foo GROUP BY a, b HAVING aliased_column in ('dummy_value')");
-    String targetSql = "SELECT a, SUBSTRING(b, 1, 1) aliased_column\n" + "FROM default.foo\n" + "GROUP BY a, b\n"
-        + "HAVING SUBSTRING(b, 1, 1)\n" + "IN ('dummy_value')";
+    String targetSql = "SELECT a, substr(b, 1, 1) aliased_column\n" + "FROM default.foo\n" + "GROUP BY a, b\n"
+        + "HAVING substr(b, 1, 1)\n" + "IN ('dummy_value')";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 }

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -328,7 +328,7 @@ public class CoralSparkTest {
   public void testSelectSubstring() {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT substring(b,1,2)", "FROM complex"));
     // Default operator SqlSubstringFunction would generate SUBSTRING(b FROM 1 for 2)
-    String targetSql = String.join("\n", "SELECT SUBSTRING(b, 1, 2)", "FROM default.complex");
+    String targetSql = String.join("\n", "SELECT substr(b, 1, 2)", "FROM default.complex");
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/Calcite2TrinoUDFConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/Calcite2TrinoUDFConverter.java
@@ -211,6 +211,13 @@ public class Calcite2TrinoUDFConverter {
         }
       }
 
+      if (operatorName.equalsIgnoreCase("substr")) {
+        Optional<RexNode> modifiedCall = visitSubstring(call);
+        if (modifiedCall.isPresent()) {
+          return modifiedCall.get();
+        }
+      }
+
       final UDFTransformer transformer = CalciteTrinoUDFMap.getUDFTransformer(operatorName, call.operands.size());
       if (transformer != null && shouldTransformOperator(operatorName)) {
         return super.visitCall((RexCall) transformer.transformCall(rexBuilder, call.getOperands()));
@@ -284,6 +291,24 @@ public class Calcite2TrinoUDFConverter {
                     rexBuilder.makeCall(trinoToUnixTime,
                         rexBuilder.makeCall(trinoWithTimeZone, sourceValue, rexBuilder.makeLiteral("UTC")))),
                 rexBuilder.makeCall(trinoCanonicalizeHiveTimezoneId, timezone))));
+      }
+
+      return Optional.empty();
+    }
+
+    // Hive allows passing in a byte array or String to substr/substring, so we can make an effort to emulate the
+    // behavior by casting non-String input to String
+    // https://cwiki.apache.org/confluence/display/hive/languagemanual+udf
+    private Optional<RexNode> visitSubstring(RexCall call) {
+      final SqlOperator op = call.getOperator();
+      List<RexNode> convertedOperands = visitList(call.getOperands(), (boolean[]) null);
+      RexNode inputOperand = convertedOperands.get(0);
+
+      if (inputOperand.getType().getSqlTypeName() != VARCHAR && inputOperand.getType().getSqlTypeName() != CHAR) {
+        List<RexNode> operands = new ImmutableList.Builder<RexNode>()
+            .add(rexBuilder.makeCast(typeFactory.createSqlType(VARCHAR), inputOperand))
+            .addAll(convertedOperands.subList(1, convertedOperands.size())).build();
+        return Optional.of(rexBuilder.makeCall(op, operands));
       }
 
       return Optional.empty();

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -467,7 +467,7 @@ public class HiveToTrinoConverterTest {
     RelNode relNode = hiveToRelConverter
         .convertSql("SELECT a, SUBSTR(b, 1, 1) AS aliased_column, c FROM test.tabler ORDER BY aliased_column DESC");
     String targetSql =
-        "SELECT \"a\", \"SUBSTR\"(\"b\", 1, 1) AS \"aliased_column\", \"c\"\nFROM \"test\".\"tabler\"\nORDER BY \"SUBSTR\"(\"b\", 1, 1) DESC";
+        "SELECT \"a\", \"substr\"(\"b\", 1, 1) AS \"aliased_column\", \"c\"\nFROM \"test\".\"tabler\"\nORDER BY \"substr\"(\"b\", 1, 1) DESC";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
@@ -479,7 +479,7 @@ public class HiveToTrinoConverterTest {
     RelNode relNode = hiveToRelConverter.convertSql(
         "SELECT a, SUBSTR(b, 1, 1) AS aliased_column FROM test.tabler GROUP BY a, b HAVING aliased_column in ('dummy_value')");
     String targetSql =
-        "SELECT \"a\", \"SUBSTR\"(\"b\", 1, 1) AS \"aliased_column\"\nFROM \"test\".\"tabler\"\nGROUP BY \"a\", \"b\"\nHAVING \"SUBSTR\"(\"b\", 1, 1)\nIN ('dummy_value')";
+        "SELECT \"a\", \"substr\"(\"b\", 1, 1) AS \"aliased_column\"\nFROM \"test\".\"tabler\"\nGROUP BY \"a\", \"b\"\nHAVING \"substr\"(\"b\", 1, 1)\nIN ('dummy_value')";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }


### PR DESCRIPTION
Re-open pull request for https://github.com/linkedin/coral/pull/177

Hive substr/substring [function](https://cwiki.apache.org/confluence/display/hive/languagemanual+udf) allows user to input either a String or byte array, but Calcite's substring function only allows String input.

describe string_timestamp_table;
+--------------+------------+----------+
|   col_name   | data_type  | comment  |
+--------------+------------+----------+
| a_string     | string     |          |
| a_timestamp  | timestamp  |          |
+--------------+------------+----------+
select substr(string_timestamp_table.a_timestamp, 12, 8) as newtime from default.string_timestamp_table;
+-----------+
|  newtime  |
+-----------+
| 22:54:24  |
| 22:54:54  |
+-----------+
One way we could try to emulate this behavior would be to attempt to wrap any non-String input in substr/substring function to String type. This might be a bit funky since we need to remove the mapping to Calcite's substring and instead register it as a UDF. Additionally, since Calcite will actually [override](https://github.com/linkedin/linkedin-calcite/blob/c13ba44c6974574d07a47766e32e695e5c5e042f/core/src/main/java/org/apache/calcite/sql/SqlUtil.java#L329) the "substring" UDF with Calcite's static "substring" function, we rewrite "substring" as "substr" to avoid this override.