### PR TITLE
Pass down precision/scale when casting to DECIMAL

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -779,6 +779,16 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
 
   @Override
   protected SqlNode visitDecimal(ASTNode node, ParseContext ctx) {
+    if (node.getChildren().size() == 2) {
+      try {
+        final SqlTypeNameSpec typeNameSpec = new SqlBasicTypeNameSpec(SqlTypeName.DECIMAL,
+            Integer.parseInt(((ASTNode) node.getChildren().get(0)).getText()),
+            Integer.parseInt(((ASTNode) node.getChildren().get(1)).getText()), ZERO);
+        return new SqlDataTypeSpec(typeNameSpec, ZERO);
+      } catch (NumberFormatException e) {
+        return createBasicTypeSpec(SqlTypeName.DECIMAL);
+      }
+    }
     return createBasicTypeSpec(SqlTypeName.DECIMAL);
   }
 

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -779,7 +779,7 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
 
   @Override
   protected SqlNode visitDecimal(ASTNode node, ParseContext ctx) {
-    if (node.getChildren().size() == 2) {
+    if (node.getChildCount() == 2) {
       try {
         final SqlTypeNameSpec typeNameSpec = new SqlBasicTypeNameSpec(SqlTypeName.DECIMAL,
             Integer.parseInt(((ASTNode) node.getChildren().get(0)).getText()),

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
@@ -600,6 +600,15 @@ public class HiveToRelConverterTest {
     assertEquals(generated, expected);
   }
 
+  @Test
+  public void testCastToDecimalDefault() {
+    final String expected =
+        "LogicalProject(EXPR$0=[CAST($0):DECIMAL(10, 0)])\n" + "  LogicalTableScan(table=[[hive, default, foo]])\n";
+    final String sql = "SELECT CAST(a AS DECIMAL) FROM foo";
+    String generated = relToString(sql);
+    assertEquals(generated, expected);
+  }
+
   private String relToString(String sql) {
     return RelOptUtil.toString(converter.convertSql(sql));
   }

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
@@ -591,6 +591,15 @@ public class HiveToRelConverterTest {
     assertEquals(generated, expected);
   }
 
+  @Test
+  public void testCastToDecimal() {
+    final String expected =
+        "LogicalProject(EXPR$0=[CAST($0):DECIMAL(6, 2)])\n" + "  LogicalTableScan(table=[[hive, default, foo]])\n";
+    final String sql = "SELECT CAST(a AS DECIMAL(6, 2)) FROM foo";
+    String generated = relToString(sql);
+    assertEquals(generated, expected);
+  }
+
   private String relToString(String sql) {
     return RelOptUtil.toString(converter.convertSql(sql));
   }

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -597,4 +597,18 @@ public class CoralSparkTest {
         + "HAVING SUBSTRING(b, 1, 1)\n" + "IN ('dummy_value')";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
+
+  @Test
+  public void testCastDecimal() {
+    RelNode relNode = TestUtils.toRelNode("SELECT CAST(a as DECIMAL(6, 2)) as casted_decimal FROM default.foo");
+    String targetSql = "SELECT CAST(a AS DECIMAL(6, 2)) casted_decimal\n" + "FROM default.foo";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+  }
+
+  @Test
+  public void testCastDecimalDefault() {
+    RelNode relNode = TestUtils.toRelNode("SELECT CAST(a as DECIMAL) as casted_decimal FROM default.foo");
+    String targetSql = "SELECT CAST(a AS DECIMAL(10, 0)) casted_decimal\n" + "FROM default.foo";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+  }
 }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -480,4 +480,16 @@ public class HiveToTrinoConverterTest {
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
+
+  @Test
+  public void testCastDecimalDefault() {
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+
+    RelNode relNode =
+        hiveToRelConverter.convertSql("SELECT CAST(t.a as DECIMAL) as casted_decimal FROM test.table_ints_strings t");
+    String targetSql =
+        "SELECT CAST(\"a\" AS DECIMAL(10, 0)) AS \"casted_decimal\"\n" + "FROM \"test\".\"table_ints_strings\"";
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
 }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -183,6 +183,9 @@ public class HiveToTrinoConverterTest {
             + "FROM \"test\".\"table_ints_strings\"" },
 
         { "test", "least_view", "SELECT \"least\"(\"a\", \"b\") AS \"g_int\", \"least\"(\"c\", \"d\") AS \"g_string\"\n"
+            + "FROM \"test\".\"table_ints_strings\"" },
+
+        { "test", "cast_decimal_view", "SELECT CAST(\"a\" AS DECIMAL(6, 2)) AS \"casted_decimal\"\n"
             + "FROM \"test\".\"table_ints_strings\"" } };
   }
 
@@ -462,6 +465,18 @@ public class HiveToTrinoConverterTest {
         "SELECT a, SUBSTR(b, 1, 1) AS aliased_column FROM test.tabler GROUP BY a, b HAVING aliased_column in ('dummy_value')");
     String targetSql =
         "SELECT \"a\", \"SUBSTR\"(\"b\", 1, 1) AS \"aliased_column\"\nFROM \"test\".\"tabler\"\nGROUP BY \"a\", \"b\"\nHAVING \"SUBSTR\"(\"b\", 1, 1)\nIN ('dummy_value')";
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
+
+  @Test
+  public void testCastDecimal() {
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+
+    RelNode relNode = hiveToRelConverter
+        .convertSql("SELECT CAST(t.a as DECIMAL(6, 2)) as casted_decimal FROM test.table_ints_strings t");
+    String targetSql =
+        "SELECT CAST(\"a\" AS DECIMAL(6, 2)) AS \"casted_decimal\"\n" + "FROM \"test\".\"table_ints_strings\"";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
@@ -344,6 +344,9 @@ public class TestUtils {
     run(driver, "CREATE VIEW IF NOT EXISTS test.least_view AS \n"
         + "SELECT least(t.a, t.b) as g_int, least(t.c, t.d) as g_string FROM test.table_ints_strings t");
 
+    run(driver, "CREATE VIEW IF NOT EXISTS test.cast_decimal_view AS \n"
+        + "SELECT CAST(t.a as DECIMAL(6,2)) as casted_decimal FROM test.table_ints_strings t");
+
     run(driver, "CREATE TABLE IF NOT EXISTS test.tableS (structCol struct<a:int>)");
     run(driver, "CREATE TABLE IF NOT EXISTS test.tableT (structCol struct<a:int>)");
     run(driver, "CREATE VIEW IF NOT EXISTS test.viewA AS SELECT structCol as struct_col FROM test.tableS");


### PR DESCRIPTION
Related Trino issue:
https://github.com/trinodb/trino/issues/6450

When casting column to DECIMAL type, precision was not being preserved during the Hive -> Rel translation, resulting in default precision/scale of 10,0 respectively.

This PR is to pass the precision/scale in Hive -> Rel translation, if applicable.