### PR TITLE
Coral-Spark: Build awareness in Coral for coalsce_struct UDF

### DIFF
--- a/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionReturnTypes.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionReturnTypes.java
@@ -18,8 +18,6 @@ import org.apache.calcite.sql.type.SqlTypeName;
 
 import com.linkedin.coral.com.google.common.collect.ImmutableList;
 
-import static com.linkedin.coral.hive.hive2rel.functions.CoalesceStructUtility.coalesce;
-
 
 /**
  * This class provides function return types that are not in {@link ReturnTypes}
@@ -50,67 +48,6 @@ public final class FunctionReturnTypes {
     RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
     RelDataType strType = typeFactory.createSqlType(SqlTypeName.VARCHAR);
     return typeFactory.createArrayType(typeFactory.createMapType(strType, strType), -1);
-  };
-
-  /**
-   * The semantics for the extract_union is now pass-through: Assuming the engine's reader could deal with
-   * union type and explode it into a struct, this extract_union UDF's return type will simply follow exploded struct's
-   * schema based on how many arguments passed by users.
-   */
-  public static final SqlReturnTypeInference EXTRACT_UNION_FUNCTION_RETURN_STRATEGY = opBinding -> {
-    int numArgs = opBinding.getOperandCount();
-    Preconditions.checkState(numArgs == 1 || numArgs == 2);
-    // 1-arg case
-    if (numArgs == 1) {
-      return opBinding.getOperandType(0);
-    }
-    // 2-arg case
-    else {
-      int ordinal = opBinding.getOperandLiteralValue(1, Integer.class);
-      return opBinding.getOperandType(0).getFieldList().get(ordinal).getType();
-    }
-  };
-
-  /**
-   * Represents the return type for the coalesce_struct UDF that is built for bridging the schema difference
-   * between extract_union UDF's processed schema of union field in Coral IR (let's call it struct_ex) and
-   * Trino's schema when deserializing union field from its reader.
-   * (Let's call it struct_tr, See https://github.com/trinodb/trino/pull/3483 for details).
-   *
-   * The main reason we need this briding capability is due to the fact that we have existing users relying on the
-   * schema of struct_ex. While the underlying reader(e.g. the trino one referenced above) starts to interpret the union
-   * in its own format, Coral tries to maintain backward compatibility on top of that. Notably we also have
-   * Iceberg reader does the same, see Linkedin's (temporary) fork on Iceberg:
-   * https://github.com/linkedin/iceberg/pull/84 (Avro)
-   * https://github.com/linkedin/iceberg/pull/85 (ORC)
-   *
-   *
-   * Further details:
-   * struct_tr looks like:
-   * struct&lt;tag:int, field0:type0, field1:type1, ... fieldN:typeN&gt;
-   *
-   * struct_ex looks like:
-   * struct&lt;tag_0:type0, tag_1:type1, ... tag_N:typeN&gt;
-   *
-   * This new UDF could be stated as the following signatures:
-   * def coalesce_struct(struct:struct_tr) : struct_ex = {...}
-   * def coalesce_struct(struct:struct_tr, ordinal: int): field_at_ordinal = {...}
-   *
-   */
-  public static final SqlReturnTypeInference COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY = opBinding -> {
-    int numArgs = opBinding.getOperandCount();
-    RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
-    Preconditions.checkState(numArgs == 1 || numArgs == 2);
-    RelDataType coalescedDataType = coalesce(opBinding.getOperandType(0), typeFactory);
-    // 1-arg case
-    if (numArgs == 1) {
-      return coalescedDataType;
-    }
-    // 2-arg case
-    else {
-      int ordinal = opBinding.getOperandLiteralValue(1, Integer.class);
-      return coalescedDataType.getFieldList().get(ordinal).getType();
-    }
   };
 
   public static final SqlReturnTypeInference ARRAY_OF_ARG0_TYPE =

--- a/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionReturnTypes.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionReturnTypes.java
@@ -5,19 +5,17 @@
  */
 package com.linkedin.coral.common.functions;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.google.common.base.Preconditions;
+
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
-import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.linkedin.coral.com.google.common.collect.ImmutableList;
 
 import static com.linkedin.coral.hive.hive2rel.functions.CoalesceStructUtility.coalesce;
@@ -119,8 +117,8 @@ public final class FunctionReturnTypes {
       opBinding -> opBinding.getTypeFactory().createArrayType(opBinding.getOperandType(0), -1);
 
   public static SqlReturnTypeInference arrayOfType(final SqlTypeName typeName) {
-    return opBinding -> opBinding.getTypeFactory()
-        .createArrayType(opBinding.getTypeFactory().createSqlType(typeName), -1);
+    return opBinding -> opBinding.getTypeFactory().createArrayType(opBinding.getTypeFactory().createSqlType(typeName),
+        -1);
   }
 
   public static SqlReturnTypeInference mapOfType(final SqlTypeName keyType, final SqlTypeName valueType) {

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
@@ -60,7 +60,7 @@ public class CoalesceStructUtility {
    *
    * Further details:
    * struct_tr looks like:
-   * struct&lt;tag:tinyint, field0:type0, field1:type1, ... fieldN:typeN&gt;
+   * struct&lt;tag:int, field0:type0, field1:type1, ... fieldN:typeN&gt;
    *
    * struct_ex looks like:
    * struct&lt;tag_0:type0, tag_1:type1, ... tag_N:typeN&gt;

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
@@ -43,6 +43,7 @@ public class CoalesceStructUtility {
       return opBinding.getOperandType(0).getFieldList().get(ordinal).getType();
     }
   };
+
   /**
    * Represents the return type for the coalesce_struct UDF that is built for bridging the schema difference
    * between extract_union UDF's processed schema of union field in Coral IR (let's call it struct_ex) and
@@ -92,7 +93,7 @@ public class CoalesceStructUtility {
   }
 
   /**
-   * Converting a {@link RelDataType} that could potentially contains a Trino-format exploded-union(i.e. a struct
+   * Converting a {@link RelDataType} that could potentially contain a Trino-format exploded-union(i.e. a struct
    * in a format of {tag, field0, field1, ..., fieldN} to represent a union after being deserialized)
    * into a exploded-union that complies with Hive's extract_union UDF format
    * (i.e. a struct as {tag_0, tag_1, ..., tag_{N}} to represent a union after being deserialized)

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
@@ -3,18 +3,17 @@
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
-
 package com.linkedin.coral.hive.hive2rel.functions;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
-
-import com.google.common.annotations.VisibleForTesting;
 
 
 /**
@@ -30,7 +29,6 @@ public class CoalesceStructUtility {
   private CoalesceStructUtility() {
     // Utility class, does nothing in constructor
   }
-
 
   /**
    * Converting a {@link RelDataType} that could potentially contains a Trino-format exploded-union(i.e. a struct

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
@@ -10,10 +10,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
 
 
 /**
@@ -23,8 +25,67 @@ import org.apache.calcite.rel.type.RelDataTypeField;
  */
 public class CoalesceStructUtility {
 
-  private static final String NEW_PREFIX = "field";
-  private static final String OLD_PREFIX = "tag_";
+  /**
+   * The semantics for the extract_union is now pass-through: Assuming the engine's reader could deal with
+   * union type and explode it into a struct, this extract_union UDF's return type will simply follow exploded struct's
+   * schema based on how many arguments passed by users.
+   */
+  public static final SqlReturnTypeInference EXTRACT_UNION_FUNCTION_RETURN_STRATEGY = opBinding -> {
+    int numArgs = opBinding.getOperandCount();
+    Preconditions.checkState(numArgs == 1 || numArgs == 2);
+    // 1-arg case
+    if (numArgs == 1) {
+      return opBinding.getOperandType(0);
+    }
+    // 2-arg case
+    else {
+      int ordinal = opBinding.getOperandLiteralValue(1, Integer.class);
+      return opBinding.getOperandType(0).getFieldList().get(ordinal).getType();
+    }
+  };
+  /**
+   * Represents the return type for the coalesce_struct UDF that is built for bridging the schema difference
+   * between extract_union UDF's processed schema of union field in Coral IR (let's call it struct_ex) and
+   * Trino's schema when deserializing union field from its reader.
+   * (Let's call it struct_tr, See https://github.com/trinodb/trino/pull/3483 for details).
+   *
+   * The main reason we need this briding capability is that we have existing users relying on the
+   * schema of struct_ex. While the underlying reader(e.g. the trino one referenced above) starts to interpret the union
+   * in its own format, Coral tries to maintain backward compatibility on top of that. Notably we also have
+   * Iceberg reader does the same, see Linkedin's (temporary) fork on Iceberg:
+   * https://github.com/linkedin/iceberg/pull/84 (Avro)
+   * https://github.com/linkedin/iceberg/pull/85 (ORC)
+   *
+   *
+   * Further details:
+   * struct_tr looks like:
+   * struct&lt;tag:int, field0:type0, field1:type1, ... fieldN:typeN&gt;
+   *
+   * struct_ex looks like:
+   * struct&lt;tag_0:type0, tag_1:type1, ... tag_N:typeN&gt;
+   *
+   * This new UDF could be stated as the following signatures:
+   * def coalesce_struct(struct:struct_tr) : struct_ex = {...}
+   * def coalesce_struct(struct:struct_tr, ordinal: int): field_at_ordinal = {...}
+   *
+   */
+  public static final SqlReturnTypeInference COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY = opBinding -> {
+    int numArgs = opBinding.getOperandCount();
+    RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
+    Preconditions.checkState(numArgs == 1 || numArgs == 2);
+    RelDataType coalescedDataType = coalesce(opBinding.getOperandType(0), typeFactory);
+    // 1-arg case
+    if (numArgs == 1) {
+      return coalescedDataType;
+    }
+    // 2-arg case
+    else {
+      int ordinal = opBinding.getOperandLiteralValue(1, Integer.class);
+      return coalescedDataType.getFieldList().get(ordinal).getType();
+    }
+  };
+  private static final String TRINO_PREFIX = "field";
+  private static final String HIVE_EXTRACT_UNION_PREFIX = "tag_";
 
   private CoalesceStructUtility() {
     // Utility class, does nothing in constructor
@@ -41,7 +102,7 @@ public class CoalesceStructUtility {
   @VisibleForTesting
   static RelDataType coalesce(RelDataType inputNode, RelDataTypeFactory typeFactory) {
     // Using type information implicitly carried in the object of RelDateType
-    // instead of get down to SqlTypeName since the former contains enough categorization
+    // instead of getting down to SqlTypeName since the former contains enough categorization
     // of types to achieve the purpose for this method.
 
     if (inputNode.isStruct()) {
@@ -60,7 +121,7 @@ public class CoalesceStructUtility {
       RelDataTypeFactory typeFactory) {
     List<String> originalNames = inputNode.getFieldNames();
     List<String> convertedNames =
-        coalesceRequired ? originalNames.stream().map(x -> x.replaceFirst(NEW_PREFIX, OLD_PREFIX))
+        coalesceRequired ? originalNames.stream().map(x -> x.replaceFirst(TRINO_PREFIX, HIVE_EXTRACT_UNION_PREFIX))
             .collect(Collectors.toList()).subList(1, originalNames.size()) : originalNames;
     List<RelDataType> originalTypes =
         inputNode.getFieldList().stream().map(RelDataTypeField::getType).collect(Collectors.toList());
@@ -90,7 +151,8 @@ public class CoalesceStructUtility {
    * - The following elements have to follow the naming pattern as "field{N}" where N
    * represents the position of this element in the struct, starting from 0.
    */
-  private static boolean isTrinoStructPattern(List<String> fieldNames) {
+  @VisibleForTesting
+  static boolean isTrinoStructPattern(List<String> fieldNames) {
     if (fieldNames.isEmpty() || !fieldNames.get(0).equals("tag")) {
       return false;
     } else {
@@ -103,7 +165,7 @@ public class CoalesceStructUtility {
           flag = false;
           break;
         }
-        fieldNameRef.deleteCharAt(5);
+        fieldNameRef.delete(5, fieldNameRef.length());
       }
       return flag;
     }

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
@@ -60,7 +60,7 @@ public class CoalesceStructUtility {
    *
    * Further details:
    * struct_tr looks like:
-   * struct&lt;tag:int, field0:type0, field1:type1, ... fieldN:typeN&gt;
+   * struct&lt;tag:tinyint, field0:type0, field1:type1, ... fieldN:typeN&gt;
    *
    * struct_ex looks like:
    * struct&lt;tag_0:type0, tag_1:type1, ... tag_N:typeN&gt;

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+
+package com.linkedin.coral.hive.hive2rel.functions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+
+import com.google.common.annotations.VisibleForTesting;
+
+
+/**
+ * A utility class to coalesce the {@link RelDataType} of struct between Trino's representation and
+ * hive's extract_union UDF's representation on exploded union.
+ *
+ */
+public class CoalesceStructUtility {
+
+  private static final String NEW_PREFIX = "field";
+  private static final String OLD_PREFIX = "tag_";
+
+  private CoalesceStructUtility() {
+    // Utility class, does nothing in constructor
+  }
+
+
+  /**
+   * Converting a {@link RelDataType} that could potentially contains a Trino-format exploded-union(i.e. a struct
+   * in a format of {tag, field0, field1, ..., fieldN} to represent a union after being deserialized)
+   * into a exploded-union that complies with Hive's extract_union UDF format
+   * (i.e. a struct as {tag_0, tag_1, ..., tag_{N}} to represent a union after being deserialized)
+   *
+   * For more information, check: https://github.com/trinodb/trino/pull/3483
+   */
+  @VisibleForTesting
+  static RelDataType coalesce(RelDataType inputNode, RelDataTypeFactory typeFactory) {
+    // Using type information implicitly carried in the object of RelDateType
+    // instead of get down to SqlTypeName since the former contains enough categorization
+    // of types to achieve the purpose for this method.
+
+    if (inputNode.isStruct()) {
+      List<String> fieldNames = inputNode.getFieldNames();
+      return coalesceStruct(inputNode, isTrinoStructPattern(fieldNames), typeFactory);
+    } else if (inputNode.getKeyType() != null) {
+      return coalesceMap(inputNode, typeFactory);
+    } else if (inputNode.getComponentType() != null) {
+      return coalesceCollection(inputNode, typeFactory);
+    } else {
+      return inputNode;
+    }
+  }
+
+  private static RelDataType coalesceStruct(RelDataType inputNode, boolean coalesceRequired,
+      RelDataTypeFactory typeFactory) {
+    List<String> originalNames = inputNode.getFieldNames();
+    List<String> convertedNames =
+        coalesceRequired ? originalNames.stream().map(x -> x.replaceFirst(NEW_PREFIX, OLD_PREFIX))
+            .collect(Collectors.toList()).subList(1, originalNames.size()) : originalNames;
+    List<RelDataType> originalTypes =
+        inputNode.getFieldList().stream().map(RelDataTypeField::getType).collect(Collectors.toList());
+    List<RelDataType> convertedTypes =
+        new ArrayList<>(coalesceRequired ? originalTypes.size() - 1 : originalTypes.size());
+    for (int i = coalesceRequired ? 1 : 0; i < originalTypes.size(); i++) {
+      convertedTypes.add(coalesce(originalTypes.get(i), typeFactory));
+    }
+
+    return typeFactory.createStructType(convertedTypes, convertedNames);
+  }
+
+  private static RelDataType coalesceMap(RelDataType inputNode, RelDataTypeFactory typeFactory) {
+    RelDataType coalescedKeyType = coalesce(inputNode.getKeyType(), typeFactory);
+    RelDataType coalescedValueType = coalesce(inputNode.getValueType(), typeFactory);
+    return typeFactory.createMapType(coalescedKeyType, coalescedValueType);
+  }
+
+  private static RelDataType coalesceCollection(RelDataType inputNode, RelDataTypeFactory typeFactory) {
+    RelDataType coalescedComponentType = coalesce(inputNode.getComponentType(), typeFactory);
+    return typeFactory.createArrayType(coalescedComponentType, -1);
+  }
+
+  /**
+   * Trino's pattern has two elements:
+   * - The first element has to be "tag".
+   * - The following elements have to follow the naming pattern as "field{N}" where N
+   * represents the position of this element in the struct, starting from 0.
+   */
+  private static boolean isTrinoStructPattern(List<String> fieldNames) {
+    if (fieldNames.isEmpty() || !fieldNames.get(0).equals("tag")) {
+      return false;
+    } else {
+      boolean flag = true;
+      StringBuilder fieldNameRef = new StringBuilder("field");
+      for (int i = 1; i < fieldNames.size(); i++) {
+        int index = i - 1;
+        fieldNameRef.append(index);
+        if (!fieldNameRef.toString().equals(fieldNames.get(i))) {
+          flag = false;
+          break;
+        }
+        fieldNameRef.deleteCharAt(5);
+      }
+      return flag;
+    }
+  }
+}

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -44,7 +44,7 @@ import com.linkedin.coral.common.functions.GenericProjectFunction;
 import com.linkedin.coral.common.functions.OperandTypeInference;
 import com.linkedin.coral.common.functions.SameOperandTypeExceptFirstOperandChecker;
 
-import static com.linkedin.coral.hive.hive2rel.functions.CoalesceStructUtility.COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY;
+import static com.linkedin.coral.hive.hive2rel.functions.CoalesceStructUtility.*;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.*;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.*;
 import static org.apache.calcite.sql.type.OperandTypes.*;
@@ -374,7 +374,7 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
 
     createAddUserDefinedFunction("array_contains", ReturnTypes.BOOLEAN, family(SqlTypeFamily.ARRAY, SqlTypeFamily.ANY));
     createAddUserDefinedFunction("sort_array", ARG0, ARRAY);
-    createAddUserDefinedFunction("extract_union", CoalesceStructUtility.EXTRACT_UNION_FUNCTION_RETURN_STRATEGY,
+    createAddUserDefinedFunction("extract_union", EXTRACT_UNION_FUNCTION_RETURN_STRATEGY,
         or(ANY, family(SqlTypeFamily.ANY, SqlTypeFamily.INTEGER)));
     createAddUserDefinedFunction("coalesce_struct", COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY,
         or(ANY, family(SqlTypeFamily.ANY, SqlTypeFamily.INTEGER)));

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -375,6 +375,8 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
     createAddUserDefinedFunction("sort_array", ARG0, ARRAY);
     createAddUserDefinedFunction("extract_union", FunctionReturnTypes.EXTRACT_UNION_FUNCTION_RETURN_STRATEGY,
         or(ANY, family(SqlTypeFamily.ANY, SqlTypeFamily.INTEGER)));
+    createAddUserDefinedFunction("coalesce_struct", HiveReturnTypes.COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY,
+        or(ANY, family(SqlTypeFamily.ANY, SqlTypeFamily.INTEGER)));
 
     // LinkedIn UDFs: Dali stores mapping from UDF name to the implementing Java class as table properties
     // in the HCatalog. So, an UDF implementation may be referred by different names by different views.

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -44,6 +44,7 @@ import com.linkedin.coral.common.functions.GenericProjectFunction;
 import com.linkedin.coral.common.functions.OperandTypeInference;
 import com.linkedin.coral.common.functions.SameOperandTypeExceptFirstOperandChecker;
 
+import static com.linkedin.coral.hive.hive2rel.functions.CoalesceStructUtility.COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.*;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.*;
 import static org.apache.calcite.sql.type.OperandTypes.*;
@@ -373,9 +374,9 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
 
     createAddUserDefinedFunction("array_contains", ReturnTypes.BOOLEAN, family(SqlTypeFamily.ARRAY, SqlTypeFamily.ANY));
     createAddUserDefinedFunction("sort_array", ARG0, ARRAY);
-    createAddUserDefinedFunction("extract_union", FunctionReturnTypes.EXTRACT_UNION_FUNCTION_RETURN_STRATEGY,
+    createAddUserDefinedFunction("extract_union", CoalesceStructUtility.EXTRACT_UNION_FUNCTION_RETURN_STRATEGY,
         or(ANY, family(SqlTypeFamily.ANY, SqlTypeFamily.INTEGER)));
-    createAddUserDefinedFunction("coalesce_struct", HiveReturnTypes.COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY,
+    createAddUserDefinedFunction("coalesce_struct", COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY,
         or(ANY, family(SqlTypeFamily.ANY, SqlTypeFamily.INTEGER)));
 
     // LinkedIn UDFs: Dali stores mapping from UDF name to the implementing Java class as table properties

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveTableTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveTableTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.Test;
 
 import com.linkedin.coral.common.HiveSchema;
 import com.linkedin.coral.common.HiveTable;
+import com.linkedin.coral.common.ToRelConverterTestUtils;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -79,7 +80,7 @@ public class HiveTableTest {
   }
 
   @Test
-  public void testTableWithUnion() throws Exception {
+  public void testTableWithUnion() {
     final RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
 
     // test handling of union
@@ -93,6 +94,40 @@ public class HiveTableTest {
         "RecordType(" + "RecordType(" + "INTEGER tag, INTEGER field0, DOUBLE field1, VARCHAR(65536) ARRAY field2, "
             + "RecordType(INTEGER a, VARCHAR(65536) b) field3" + ") " + "foo)";
     assertEquals(rowType.toString(), expectedTypeString);
+  }
+
+  @Test
+  public void testTableWithUnionComplex() throws Exception {
+    // Two complex scenarios for union:
+    // 1. nested union: a struct within a union that has another union as one of the member types.
+    // 2. when there's existing extract_union UDF (where we replace it with coalesce_struct when
+    // the reader returns a trino-compliant schema for a union field)
+    final RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
+    // Schema: foo uniontype<int, double, struct<a:int, b:uniontype<int, double>>>
+    // it should become struct<tag:int, field0:int, field1:double, field2: struct<a:int,b:struct<tag:int, field0:int, field1:double>>>
+    Table nestedUnionTable = getTable("default", "nested_union");
+    RelDataType rowType = nestedUnionTable.getRowType(typeFactory);
+    assertNotNull(rowType);
+
+    String expectedTypeString =
+    "RecordType("
+        + "RecordType("
+        + "TINYINT tag, INTEGER field0, DOUBLE field1, RecordType("
+        + "INTEGER a, RecordType(TINYINT tag, INTEGER field0, DOUBLE field1) b)"
+        + " field2) foo)";
+    assertEquals(rowType.toString(), expectedTypeString);
+
+    // Case for with extract_union as part of view definition.
+    // Put the alias of foo as bar. The outcome type complies with extract_union's schema recursively
+    ToRelConverterTestUtils.setup();
+    RelDataType rowType2
+        = ToRelConverterTestUtils.toRel("SELECT coalesce_struct(foo) AS bar from nested_union").getRowType();
+    assertNotNull(rowType2);
+    expectedTypeString = "RecordType("
+        + "RecordType("
+        + "INTEGER tag_0, DOUBLE tag_1, "
+        + "RecordType(INTEGER a, RecordType(INTEGER tag_0, DOUBLE tag_1) b) tag_2) bar)";
+    assertEquals(rowType2.toString(), expectedTypeString);
   }
 
   @Test

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveTableTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveTableTest.java
@@ -104,7 +104,7 @@ public class HiveTableTest {
     // the reader returns a trino-compliant schema for a union field)
     final RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
     // Schema: foo uniontype<int, double, struct<a:int, b:uniontype<int, double>>>
-    // it should become struct<tag:int, field0:int, field1:double, field2: struct<a:int,b:struct<tag:tinyint, field0:int, field1:double>>>
+    // it should become struct<tag:tinyint, field0:int, field1:double, field2: struct<a:int,b:struct<tag:tinyint, field0:int, field1:double>>>
     Table nestedUnionTable = getTable("default", "nested_union");
     RelDataType rowType = nestedUnionTable.getRowType(typeFactory);
     assertNotNull(rowType);

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveTableTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveTableTest.java
@@ -104,14 +104,14 @@ public class HiveTableTest {
     // the reader returns a trino-compliant schema for a union field)
     final RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
     // Schema: foo uniontype<int, double, struct<a:int, b:uniontype<int, double>>>
-    // it should become struct<tag:tinyint, field0:int, field1:double, field2: struct<a:int,b:struct<tag:tinyint, field0:int, field1:double>>>
+    // it should become struct<tag:int, field0:int, field1:double, field2: struct<a:int,b:struct<tag:int, field0:int, field1:double>>>
     Table nestedUnionTable = getTable("default", "nested_union");
     RelDataType rowType = nestedUnionTable.getRowType(typeFactory);
     assertNotNull(rowType);
 
     String expectedTypeString =
-        "RecordType(" + "RecordType(" + "TINYINT tag, INTEGER field0, DOUBLE field1, RecordType("
-            + "INTEGER a, RecordType(TINYINT tag, INTEGER field0, DOUBLE field1) b)" + " field2) foo)";
+        "RecordType(" + "RecordType(" + "INTEGER tag, INTEGER field0, DOUBLE field1, RecordType("
+            + "INTEGER a, RecordType(INTEGER tag, INTEGER field0, DOUBLE field1) b)" + " field2) foo)";
     assertEquals(rowType.toString(), expectedTypeString);
 
     // Case for with extract_union as part of view definition.

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveTableTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveTableTest.java
@@ -104,7 +104,7 @@ public class HiveTableTest {
     // the reader returns a trino-compliant schema for a union field)
     final RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
     // Schema: foo uniontype<int, double, struct<a:int, b:uniontype<int, double>>>
-    // it should become struct<tag:int, field0:int, field1:double, field2: struct<a:int,b:struct<tag:int, field0:int, field1:double>>>
+    // it should become struct<tag:int, field0:int, field1:double, field2: struct<a:int,b:struct<tag:tinyint, field0:int, field1:double>>>
     Table nestedUnionTable = getTable("default", "nested_union");
     RelDataType rowType = nestedUnionTable.getRowType(typeFactory);
     assertNotNull(rowType);

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveTableTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveTableTest.java
@@ -28,9 +28,9 @@ import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import com.linkedin.coral.common.HiveMscAdapter;
 import com.linkedin.coral.common.HiveSchema;
 import com.linkedin.coral.common.HiveTable;
-import com.linkedin.coral.common.ToRelConverterTestUtils;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -116,9 +116,10 @@ public class HiveTableTest {
 
     // Case for with extract_union as part of view definition.
     // Put the alias of foo as bar. The outcome type complies with extract_union's schema recursively
-    ToRelConverterTestUtils.setup();
-    RelDataType rowType2 =
-        ToRelConverterTestUtils.toRel("SELECT coalesce_struct(foo) AS bar from nested_union").getRowType();
+
+    HiveMscAdapter mscAdapter = new HiveMscAdapter(hive.getMetastoreClient());
+    HiveToRelConverter converter = new HiveToRelConverter(mscAdapter);
+    RelDataType rowType2 = converter.convertSql("SELECT coalesce_struct(foo) AS bar from nested_union").getRowType();
     assertNotNull(rowType2);
     expectedTypeString = "RecordType(" + "RecordType(" + "INTEGER tag_0, DOUBLE tag_1, "
         + "RecordType(INTEGER a, RecordType(INTEGER tag_0, DOUBLE tag_1) b) tag_2) bar)";

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveTableTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveTableTest.java
@@ -110,22 +110,17 @@ public class HiveTableTest {
     assertNotNull(rowType);
 
     String expectedTypeString =
-    "RecordType("
-        + "RecordType("
-        + "TINYINT tag, INTEGER field0, DOUBLE field1, RecordType("
-        + "INTEGER a, RecordType(TINYINT tag, INTEGER field0, DOUBLE field1) b)"
-        + " field2) foo)";
+        "RecordType(" + "RecordType(" + "TINYINT tag, INTEGER field0, DOUBLE field1, RecordType("
+            + "INTEGER a, RecordType(TINYINT tag, INTEGER field0, DOUBLE field1) b)" + " field2) foo)";
     assertEquals(rowType.toString(), expectedTypeString);
 
     // Case for with extract_union as part of view definition.
     // Put the alias of foo as bar. The outcome type complies with extract_union's schema recursively
     ToRelConverterTestUtils.setup();
-    RelDataType rowType2
-        = ToRelConverterTestUtils.toRel("SELECT coalesce_struct(foo) AS bar from nested_union").getRowType();
+    RelDataType rowType2 =
+        ToRelConverterTestUtils.toRel("SELECT coalesce_struct(foo) AS bar from nested_union").getRowType();
     assertNotNull(rowType2);
-    expectedTypeString = "RecordType("
-        + "RecordType("
-        + "INTEGER tag_0, DOUBLE tag_1, "
+    expectedTypeString = "RecordType(" + "RecordType(" + "INTEGER tag_0, DOUBLE tag_1, "
         + "RecordType(INTEGER a, RecordType(INTEGER tag_0, DOUBLE tag_1) b) tag_2) bar)";
     assertEquals(rowType2.toString(), expectedTypeString);
   }

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/TestUtils.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/TestUtils.java
@@ -191,6 +191,12 @@ public class TestUtils {
       driver.run(
           "CREATE TABLE IF NOT EXISTS union_table(foo uniontype<int, double, array<string>, struct<a:int,b:string>>)");
 
+      // Nested union case.
+      // We don't put a union directly under a union since sources like https://avro.apache.org/docs/current/spec.html#Unions
+      // explicitly put that union cannot be directly nested under a union.
+      driver.run(
+          "CREATE TABLE IF NOT EXISTS nested_union(foo uniontype<int, double, struct<a:int, b:uniontype<int, double>>>)");
+
       testHive.databases =
           ImmutableList.of(new TestHive.DB("test", ImmutableList.of("tableOne", "tableTwo", "tableOneView")),
               new TestHive.DB("default",

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/TestUtils.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/TestUtils.java
@@ -197,18 +197,18 @@ public class TestUtils {
       driver.run(
           "CREATE TABLE IF NOT EXISTS nested_union(foo uniontype<int, double, struct<a:int, b:uniontype<int, double>>>)");
 
-      testHive.databases =
-          ImmutableList.of(new TestHive.DB("test", ImmutableList.of("tableOne", "tableTwo", "tableOneView")),
-              new TestHive.DB("default",
-                  ImmutableList.of("bar", "complex", "foo", "foo_view", "null_check_view", "null_check_wrapper",
-                      "schema_evolve", "view_schema_evolve", "view_schema_evolve_wrapper", "union_table")),
-              new TestHive.DB("fuzzy_union",
-                  ImmutableList.of("tableA", "tableB", "tableC", "union_view", "union_view_with_more_than_two_tables",
-                      "union_view_with_alias", "union_view_single_branch_evolved",
-                      "union_view_double_branch_evolved_different", "union_view_map_with_struct_value_evolved",
-                      "union_view_array_with_struct_value_evolved", "union_view_deeply_nested_struct_evolved",
-                      "union_view_more_than_two_branches_evolved",
-                      "union_view_same_schema_evolution_with_different_ordering")));
+      testHive.databases = ImmutableList.of(
+          new TestHive.DB("test", ImmutableList.of("tableOne", "tableTwo", "tableOneView")),
+          new TestHive.DB("default",
+              ImmutableList.of("bar", "complex", "foo", "foo_view", "null_check_view", "null_check_wrapper",
+                  "schema_evolve", "view_schema_evolve", "view_schema_evolve_wrapper", "union_table", "nested_union")),
+          new TestHive.DB("fuzzy_union",
+              ImmutableList.of("tableA", "tableB", "tableC", "union_view", "union_view_with_more_than_two_tables",
+                  "union_view_with_alias", "union_view_single_branch_evolved",
+                  "union_view_double_branch_evolved_different", "union_view_map_with_struct_value_evolved",
+                  "union_view_array_with_struct_value_evolved", "union_view_deeply_nested_struct_evolved",
+                  "union_view_more_than_two_branches_evolved",
+                  "union_view_same_schema_evolution_with_different_ordering")));
 
       // add some Dali functions to table properties
       IMetaStoreClient msc = testHive.getMetastoreClient();

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtilityTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtilityTest.java
@@ -3,10 +3,11 @@
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
-
 package com.linkedin.coral.hive.hive2rel.functions;
 
 import java.util.List;
+
+import com.google.common.collect.ImmutableList;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -15,7 +16,6 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableList;
 import com.linkedin.coral.common.ToRelConverterTestUtils;
 
 import static com.linkedin.coral.hive.hive2rel.functions.CoalesceStructUtility.coalesce;
@@ -33,26 +33,18 @@ public class CoalesceStructUtilityTest {
     typeFactory = ToRelConverterTestUtils.createRelBuilder().getTypeFactory();
 
     List<String> names = ImmutableList.of("tag", "field0", "field1");
-    List<RelDataType> types = ImmutableList.of(
-        typeFactory.createSqlType(SqlTypeName.INTEGER),
-        typeFactory.createSqlType(SqlTypeName.BOOLEAN),
-        typeFactory.createSqlType(SqlTypeName.DOUBLE)
-    );
+    List<RelDataType> types = ImmutableList.of(typeFactory.createSqlType(SqlTypeName.INTEGER),
+        typeFactory.createSqlType(SqlTypeName.BOOLEAN), typeFactory.createSqlType(SqlTypeName.DOUBLE));
     trinoStruct = typeFactory.createStructType(types, names);
 
     List<String> names2 = ImmutableList.of("tag_0", "tag_1");
-    List<RelDataType> types2 = ImmutableList.of(
-        typeFactory.createSqlType(SqlTypeName.BOOLEAN),
-        typeFactory.createSqlType(SqlTypeName.DOUBLE)
-    );
+    List<RelDataType> types2 =
+        ImmutableList.of(typeFactory.createSqlType(SqlTypeName.BOOLEAN), typeFactory.createSqlType(SqlTypeName.DOUBLE));
     exStruct = typeFactory.createStructType(types2, names2);
 
     List<String> names3 = ImmutableList.of("tag", "field1", "field2");
-    List<RelDataType> types3 = ImmutableList.of(
-        typeFactory.createSqlType(SqlTypeName.INTEGER),
-        typeFactory.createSqlType(SqlTypeName.INTEGER),
-        typeFactory.createSqlType(SqlTypeName.DOUBLE)
-    );
+    List<RelDataType> types3 = ImmutableList.of(typeFactory.createSqlType(SqlTypeName.INTEGER),
+        typeFactory.createSqlType(SqlTypeName.INTEGER), typeFactory.createSqlType(SqlTypeName.DOUBLE));
     nonTrinoStruct = typeFactory.createStructType(types3, names3);
   }
 
@@ -86,7 +78,8 @@ public class CoalesceStructUtilityTest {
     // struct<tag:int, field0: trinoStruct, field1:nonTrinoStruct>
     // expected: struct<tag_0: exStruct, tag_1:nonTrinoStruct>
     List<String> names = ImmutableList.of("tag", "field0", "field1");
-    List<RelDataType> types = ImmutableList.of(typeFactory.createSqlType(SqlTypeName.INTEGER), trinoStruct, nonTrinoStruct);
+    List<RelDataType> types =
+        ImmutableList.of(typeFactory.createSqlType(SqlTypeName.INTEGER), trinoStruct, nonTrinoStruct);
     RelDataType nested = typeFactory.createStructType(types, names);
 
     List<String> names2 = ImmutableList.of("tag_0", "tag_1");

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtilityTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtilityTest.java
@@ -12,13 +12,14 @@ import java.util.Set;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
-import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import com.linkedin.coral.common.ToRelConverterTestUtils;
 
 import static com.linkedin.coral.hive.hive2rel.functions.CoalesceStructUtility.coalesce;
 import static com.linkedin.coral.hive.hive2rel.functions.CoalesceStructUtility.isTrinoStructPattern;
@@ -32,7 +33,8 @@ public class CoalesceStructUtilityTest {
 
   @BeforeClass
   public void setup() throws Exception {
-    typeFactory = new JavaTypeFactoryImpl();
+    ToRelConverterTestUtils.setup();
+    typeFactory = ToRelConverterTestUtils.createRelBuilder().getTypeFactory();
 
     List<String> names = ImmutableList.of("tag", "field0", "field1");
     List<RelDataType> types = ImmutableList.of(typeFactory.createSqlType(SqlTypeName.INTEGER),

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtilityTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtilityTest.java
@@ -20,6 +20,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.linkedin.coral.common.ToRelConverterTestUtils;
+import com.linkedin.coral.hive.hive2rel.TestUtils;
 
 import static com.linkedin.coral.hive.hive2rel.functions.CoalesceStructUtility.coalesce;
 import static com.linkedin.coral.hive.hive2rel.functions.CoalesceStructUtility.isTrinoStructPattern;
@@ -33,7 +34,7 @@ public class CoalesceStructUtilityTest {
 
   @BeforeClass
   public void setup() throws Exception {
-    ToRelConverterTestUtils.setup();
+    ToRelConverterTestUtils.setup(TestUtils.loadResourceHiveConf());
     typeFactory = ToRelConverterTestUtils.createRelBuilder().getTypeFactory();
 
     List<String> names = ImmutableList.of("tag", "field0", "field1");

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtilityTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtilityTest.java
@@ -45,7 +45,7 @@ public class CoalesceStructUtilityTest {
     typeFactory = ToRelConverterTestUtils.createRelBuilder().getTypeFactory();
 
     List<String> names = ImmutableList.of("tag", "field0", "field1");
-    List<RelDataType> types = ImmutableList.of(typeFactory.createSqlType(SqlTypeName.TINYINT),
+    List<RelDataType> types = ImmutableList.of(typeFactory.createSqlType(SqlTypeName.INTEGER),
         typeFactory.createSqlType(SqlTypeName.BOOLEAN), typeFactory.createSqlType(SqlTypeName.DOUBLE));
     trinoStruct = typeFactory.createStructType(types, names);
 
@@ -55,7 +55,7 @@ public class CoalesceStructUtilityTest {
     extractUnionStruct = typeFactory.createStructType(types2, names2);
 
     List<String> names3 = ImmutableList.of("tag", "field1", "field2");
-    List<RelDataType> types3 = ImmutableList.of(typeFactory.createSqlType(SqlTypeName.TINYINT),
+    List<RelDataType> types3 = ImmutableList.of(typeFactory.createSqlType(SqlTypeName.INTEGER),
         typeFactory.createSqlType(SqlTypeName.INTEGER), typeFactory.createSqlType(SqlTypeName.DOUBLE));
     nonTrinoStruct = typeFactory.createStructType(types3, names3);
   }
@@ -108,11 +108,11 @@ public class CoalesceStructUtilityTest {
   @Test
   public void testNested() {
     // Create a complex nested schema:
-    // struct<tag:tinyint, field0: trinoStruct, field1:nonTrinoStruct>
+    // struct<tag:int, field0: trinoStruct, field1:nonTrinoStruct>
     // expected: struct<tag_0: exStruct, tag_1:nonTrinoStruct>
     List<String> names = ImmutableList.of("tag", "field0", "field1");
     List<RelDataType> types =
-        ImmutableList.of(typeFactory.createSqlType(SqlTypeName.TINYINT), trinoStruct, nonTrinoStruct);
+        ImmutableList.of(typeFactory.createSqlType(SqlTypeName.INTEGER), trinoStruct, nonTrinoStruct);
     RelDataType nested = typeFactory.createStructType(types, names);
 
     List<String> names2 = ImmutableList.of("tag_0", "tag_1");

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtilityTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtilityTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+
+package com.linkedin.coral.hive.hive2rel.functions;
+
+import java.util.List;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.linkedin.coral.common.ToRelConverterTestUtils;
+
+import static com.linkedin.coral.hive.hive2rel.functions.CoalesceStructUtility.coalesce;
+
+
+public class CoalesceStructUtilityTest {
+  private RelDataTypeFactory typeFactory;
+  private RelDataType trinoStruct;
+  private RelDataType exStruct;
+  private RelDataType nonTrinoStruct;
+
+  @BeforeClass
+  public void setup() throws Exception {
+    ToRelConverterTestUtils.setup();
+    typeFactory = ToRelConverterTestUtils.createRelBuilder().getTypeFactory();
+
+    List<String> names = ImmutableList.of("tag", "field0", "field1");
+    List<RelDataType> types = ImmutableList.of(
+        typeFactory.createSqlType(SqlTypeName.INTEGER),
+        typeFactory.createSqlType(SqlTypeName.BOOLEAN),
+        typeFactory.createSqlType(SqlTypeName.DOUBLE)
+    );
+    trinoStruct = typeFactory.createStructType(types, names);
+
+    List<String> names2 = ImmutableList.of("tag_0", "tag_1");
+    List<RelDataType> types2 = ImmutableList.of(
+        typeFactory.createSqlType(SqlTypeName.BOOLEAN),
+        typeFactory.createSqlType(SqlTypeName.DOUBLE)
+    );
+    exStruct = typeFactory.createStructType(types2, names2);
+
+    List<String> names3 = ImmutableList.of("tag", "field1", "field2");
+    List<RelDataType> types3 = ImmutableList.of(
+        typeFactory.createSqlType(SqlTypeName.INTEGER),
+        typeFactory.createSqlType(SqlTypeName.INTEGER),
+        typeFactory.createSqlType(SqlTypeName.DOUBLE)
+    );
+    nonTrinoStruct = typeFactory.createStructType(types3, names3);
+  }
+
+  @Test
+  public void testStruct() throws Exception {
+    // coalesce the trino struct directly
+    RelDataType coalescedType = coalesce(trinoStruct, typeFactory);
+    Assert.assertEquals(coalescedType, exStruct);
+
+    // A negative case: a struct that doesn't fulfill trino's pattern should not be changed at all.
+    Assert.assertEquals(coalesce(nonTrinoStruct, typeFactory), nonTrinoStruct);
+  }
+
+  @Test
+  public void testMap() throws Exception {
+    RelDataType structInMap = typeFactory.createMapType(typeFactory.createSqlType(SqlTypeName.VARCHAR), trinoStruct);
+    RelDataType expectedCoalesced = typeFactory.createMapType(typeFactory.createSqlType(SqlTypeName.VARCHAR), exStruct);
+    Assert.assertEquals(coalesce(structInMap, typeFactory), expectedCoalesced);
+  }
+
+  @Test
+  public void testArray() throws Exception {
+    RelDataType structAsArrayElem = typeFactory.createArrayType(trinoStruct, -1);
+    RelDataType expectedCoalesced = typeFactory.createArrayType(exStruct, -1);
+    Assert.assertEquals(coalesce(structAsArrayElem, typeFactory), expectedCoalesced);
+  }
+
+  @Test
+  public void testNested() throws Exception {
+    // Create a complex nested schema:
+    // struct<tag:int, field0: trinoStruct, field1:nonTrinoStruct>
+    // expected: struct<tag_0: exStruct, tag_1:nonTrinoStruct>
+    List<String> names = ImmutableList.of("tag", "field0", "field1");
+    List<RelDataType> types = ImmutableList.of(typeFactory.createSqlType(SqlTypeName.INTEGER), trinoStruct, nonTrinoStruct);
+    RelDataType nested = typeFactory.createStructType(types, names);
+
+    List<String> names2 = ImmutableList.of("tag_0", "tag_1");
+    List<RelDataType> types2 = ImmutableList.of(exStruct, nonTrinoStruct);
+    RelDataType coalescedNestedExpected = typeFactory.createStructType(types2, names2);
+
+    Assert.assertEquals(coalesce(nested, typeFactory), coalescedNestedExpected);
+  }
+}

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtilityTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtilityTest.java
@@ -5,6 +5,8 @@
  */
 package com.linkedin.coral.hive.hive2rel.functions;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -15,7 +17,10 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.testng.Assert;
+import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -31,14 +36,16 @@ public class CoalesceStructUtilityTest {
   private RelDataType trinoStruct;
   private RelDataType extractUnionStruct;
   private RelDataType nonTrinoStruct;
+  private static HiveConf conf;
 
   @BeforeClass
   public void setup() throws Exception {
-    ToRelConverterTestUtils.setup(TestUtils.loadResourceHiveConf());
+    this.conf = TestUtils.loadResourceHiveConf();
+    ToRelConverterTestUtils.setup(this.conf);
     typeFactory = ToRelConverterTestUtils.createRelBuilder().getTypeFactory();
 
     List<String> names = ImmutableList.of("tag", "field0", "field1");
-    List<RelDataType> types = ImmutableList.of(typeFactory.createSqlType(SqlTypeName.INTEGER),
+    List<RelDataType> types = ImmutableList.of(typeFactory.createSqlType(SqlTypeName.TINYINT),
         typeFactory.createSqlType(SqlTypeName.BOOLEAN), typeFactory.createSqlType(SqlTypeName.DOUBLE));
     trinoStruct = typeFactory.createStructType(types, names);
 
@@ -48,9 +55,14 @@ public class CoalesceStructUtilityTest {
     extractUnionStruct = typeFactory.createStructType(types2, names2);
 
     List<String> names3 = ImmutableList.of("tag", "field1", "field2");
-    List<RelDataType> types3 = ImmutableList.of(typeFactory.createSqlType(SqlTypeName.INTEGER),
+    List<RelDataType> types3 = ImmutableList.of(typeFactory.createSqlType(SqlTypeName.TINYINT),
         typeFactory.createSqlType(SqlTypeName.INTEGER), typeFactory.createSqlType(SqlTypeName.DOUBLE));
     nonTrinoStruct = typeFactory.createStructType(types3, names3);
+  }
+
+  @AfterTest
+  public void afterClass() throws IOException {
+    FileUtils.deleteDirectory(new File(conf.get(TestUtils.CORAL_HIVE_TEST_DIR)));
   }
 
   @Test
@@ -100,7 +112,7 @@ public class CoalesceStructUtilityTest {
     // expected: struct<tag_0: exStruct, tag_1:nonTrinoStruct>
     List<String> names = ImmutableList.of("tag", "field0", "field1");
     List<RelDataType> types =
-        ImmutableList.of(typeFactory.createSqlType(SqlTypeName.INTEGER), trinoStruct, nonTrinoStruct);
+        ImmutableList.of(typeFactory.createSqlType(SqlTypeName.TINYINT), trinoStruct, nonTrinoStruct);
     RelDataType nested = typeFactory.createStructType(types, names);
 
     List<String> names2 = ImmutableList.of("tag_0", "tag_1");

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtilityTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtilityTest.java
@@ -12,14 +12,13 @@ import java.util.Set;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import com.linkedin.coral.common.ToRelConverterTestUtils;
 
 import static com.linkedin.coral.hive.hive2rel.functions.CoalesceStructUtility.coalesce;
 import static com.linkedin.coral.hive.hive2rel.functions.CoalesceStructUtility.isTrinoStructPattern;
@@ -33,8 +32,7 @@ public class CoalesceStructUtilityTest {
 
   @BeforeClass
   public void setup() throws Exception {
-    ToRelConverterTestUtils.setup();
-    typeFactory = ToRelConverterTestUtils.createRelBuilder().getTypeFactory();
+    typeFactory = new JavaTypeFactoryImpl();
 
     List<String> names = ImmutableList.of("tag", "field0", "field1");
     List<RelDataType> types = ImmutableList.of(typeFactory.createSqlType(SqlTypeName.INTEGER),

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtilityTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtilityTest.java
@@ -108,7 +108,7 @@ public class CoalesceStructUtilityTest {
   @Test
   public void testNested() {
     // Create a complex nested schema:
-    // struct<tag:int, field0: trinoStruct, field1:nonTrinoStruct>
+    // struct<tag:tinyint, field0: trinoStruct, field1:nonTrinoStruct>
     // expected: struct<tag_0: exStruct, tag_1:nonTrinoStruct>
     List<String> names = ImmutableList.of("tag", "field0", "field1");
     List<RelDataType> types =

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtilityTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtilityTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -18,7 +19,6 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableSet;
 import com.linkedin.coral.common.ToRelConverterTestUtils;
 
 import static com.linkedin.coral.hive.hive2rel.functions.CoalesceStructUtility.coalesce;
@@ -80,8 +80,8 @@ public class CoalesceStructUtilityTest {
   @Test
   public void testMap() {
     RelDataType structInMap = typeFactory.createMapType(typeFactory.createSqlType(SqlTypeName.VARCHAR), trinoStruct);
-    RelDataType expectedCoalesced = typeFactory.createMapType(typeFactory.createSqlType(SqlTypeName.VARCHAR),
-        extractUnionStruct);
+    RelDataType expectedCoalesced =
+        typeFactory.createMapType(typeFactory.createSqlType(SqlTypeName.VARCHAR), extractUnionStruct);
     Assert.assertEquals(coalesce(structInMap, typeFactory), expectedCoalesced);
   }
 

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
@@ -326,9 +326,9 @@ class IRRelToSparkRelTransformer {
 
     /**
      * Instead of leaving extract_union visible to (Hive)Spark, since we adopted the new exploded struct schema(
-     * a.k.a struct_new) that is different from extract_union's output (a.k.a struct_old) to interpret union in Coral IR,
+     * a.k.a struct_tr) that is different from extract_union's output (a.k.a struct_ex) to interpret union in Coral IR,
      * we need to swap the reference of "extract_union" to a new UDF that is coalescing the difference between
-     * struct_new and struct_old.
+     * struct_tr and struct_ex.
      *
      * See com.linkedin.coral.hive.hive2rel.functions.HiveReturnTypes#COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY
      * and its comments for more details.

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
@@ -50,8 +50,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linkedin.coral.com.google.common.collect.ImmutableList;
-import com.linkedin.coral.common.functions.GenericProjectFunction;
 import com.linkedin.coral.com.google.common.collect.Lists;
+import com.linkedin.coral.common.functions.GenericProjectFunction;
 import com.linkedin.coral.hive.hive2rel.functions.CoalesceStructUtility;
 import com.linkedin.coral.hive.hive2rel.functions.HiveNamedStructFunction;
 import com.linkedin.coral.hive.hive2rel.functions.VersionedSqlUserDefinedFunction;
@@ -351,7 +351,8 @@ class IRRelToSparkRelTransformer {
           List<RexNode> operandsCopy = Lists.newArrayList(call.getOperands());
           operandsCopy.set(1, rexBuilder.makeExactLiteral(new BigDecimal(ordinal)));
           return Optional.of(rexBuilder.makeCall(
-              createUDF("coalesce_struct", CoalesceStructUtility.COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY), operandsCopy));
+              createUDF("coalesce_struct", CoalesceStructUtility.COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY),
+              operandsCopy));
         }
       }
       return Optional.empty();

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
@@ -51,6 +51,7 @@ import org.slf4j.LoggerFactory;
 
 import com.linkedin.coral.com.google.common.collect.ImmutableList;
 import com.linkedin.coral.common.functions.GenericProjectFunction;
+import com.linkedin.coral.com.google.common.collect.Lists;
 import com.linkedin.coral.hive.hive2rel.functions.HiveNamedStructFunction;
 import com.linkedin.coral.hive.hive2rel.functions.VersionedSqlUserDefinedFunction;
 import com.linkedin.coral.spark.containers.SparkRelInfo;
@@ -204,7 +205,7 @@ class IRRelToSparkRelTransformer {
           convertToZeroBasedArrayIndex(updatedCall).orElseGet(() -> convertToNamedStruct(updatedCall)
               .orElseGet(() -> convertFuzzyUnionGenericProject(updatedCall).orElseGet(() -> convertDaliUDF(updatedCall)
                   .orElseGet(() -> convertBuiltInUDF(updatedCall).orElseGet(() -> fallbackToHiveUdf(updatedCall)
-                      .orElseGet(() -> removeExtractUnionFunction(updatedCall).orElse(updatedCall)))))));
+                      .orElseGet(() -> swapExtractUnionFunction(updatedCall).orElse(updatedCall)))))));
 
       return convertToNewNode;
     }
@@ -323,16 +324,33 @@ class IRRelToSparkRelTransformer {
       return Optional.empty();
     }
 
-    private Optional<RexNode> removeExtractUnionFunction(RexCall call) {
+    /**
+     * Instead of leaving extract_union visible to (Hive)Spark, since we adopted the new exploded struct schema(
+     * a.k.a struct_new) that is different from extract_union's output (a.k.a struct_old) to interpret union in Coral IR,
+     * we need to swap the reference of "extract_union" to a new UDF that is coalescing the difference between
+     * struct_new and struct_old.
+     *
+     * See com.linkedin.coral.hive.hive2rel.functions.HiveReturnTypes#COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY
+     * and its comments for more details.
+     *
+     * @param call the original extract_union function call.
+     * @return A new {@link RexNode} replacing the original extract_union call.
+     */
+    private Optional<RexNode> swapExtractUnionFunction(RexCall call) {
       if (call.getOperator().getName().equalsIgnoreCase("extract_union")) {
         // one arg case: extract_union(field_name)
         if (call.getOperands().size() == 1) {
-          return Optional.of(call.getOperands().get(0));
+          return Optional.of(rexBuilder.makeCall(
+              createUDF("coalesce_struct", HiveReturnTypes.COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY),
+              call.getOperands()));
         }
         // two arg case: extract_union(field_name, ordinal)
         else if (call.getOperands().size() == 2) {
-          int ordinal = ((RexLiteral) call.getOperands().get(1)).getValueAs(Integer.class);
-          return Optional.of(rexBuilder.makeFieldAccess(call.getOperands().get(0), ordinal));
+          int ordinal = ((RexLiteral) call.getOperands().get(1)).getValueAs(Integer.class) + 1;
+          List<RexNode> operandsCopy = Lists.newArrayList(call.getOperands());
+          operandsCopy.set(1, rexBuilder.makeExactLiteral(new BigDecimal(ordinal)));
+          return Optional.of(rexBuilder.makeCall(
+              createUDF("coalesce_struct", HiveReturnTypes.COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY), operandsCopy));
         }
       }
       return Optional.empty();

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
@@ -52,6 +52,7 @@ import org.slf4j.LoggerFactory;
 import com.linkedin.coral.com.google.common.collect.ImmutableList;
 import com.linkedin.coral.common.functions.GenericProjectFunction;
 import com.linkedin.coral.com.google.common.collect.Lists;
+import com.linkedin.coral.hive.hive2rel.functions.CoalesceStructUtility;
 import com.linkedin.coral.hive.hive2rel.functions.HiveNamedStructFunction;
 import com.linkedin.coral.hive.hive2rel.functions.VersionedSqlUserDefinedFunction;
 import com.linkedin.coral.spark.containers.SparkRelInfo;
@@ -330,7 +331,7 @@ class IRRelToSparkRelTransformer {
      * we need to swap the reference of "extract_union" to a new UDF that is coalescing the difference between
      * struct_tr and struct_ex.
      *
-     * See com.linkedin.coral.hive.hive2rel.functions.HiveReturnTypes#COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY
+     * See com.linkedin.coral.common.functions.FunctionReturnTypes#COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY
      * and its comments for more details.
      *
      * @param call the original extract_union function call.
@@ -341,7 +342,7 @@ class IRRelToSparkRelTransformer {
         // one arg case: extract_union(field_name)
         if (call.getOperands().size() == 1) {
           return Optional.of(rexBuilder.makeCall(
-              createUDF("coalesce_struct", HiveReturnTypes.COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY),
+              createUDF("coalesce_struct", CoalesceStructUtility.COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY),
               call.getOperands()));
         }
         // two arg case: extract_union(field_name, ordinal)
@@ -350,7 +351,7 @@ class IRRelToSparkRelTransformer {
           List<RexNode> operandsCopy = Lists.newArrayList(call.getOperands());
           operandsCopy.set(1, rexBuilder.makeExactLiteral(new BigDecimal(ordinal)));
           return Optional.of(rexBuilder.makeCall(
-              createUDF("coalesce_struct", HiveReturnTypes.COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY), operandsCopy));
+              createUDF("coalesce_struct", CoalesceStructUtility.COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY), operandsCopy));
         }
       }
       return Optional.empty();

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -393,7 +393,7 @@ public class CoralSparkTest {
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
-  @Test(enabled = false)
+  @Test
   public void testUnionExtractUDF() {
     RelNode relNode = TestUtils.toRelNode("SELECT extract_union(foo) from union_table");
     String targetSql = String.join("\n", "SELECT coalesce_struct(foo)", "FROM default.union_table");
@@ -403,9 +403,9 @@ public class CoralSparkTest {
     String targetSql1 = String.join("\n", "SELECT coalesce_struct(foo, 3)", "FROM default.union_table");
     assertEquals(CoralSpark.create(relNode1).getSparkSql(), targetSql1);
 
-    // Recursion case
-    RelNode relNode2 = TestUtils.toRelNode("SELECT extract_union(a) from recursive_union");
-    String targetSql2 = String.join("\n", "SELECT coalesce_struct(a)", "FROM default.recursive_union");
+    // Nested union case
+    RelNode relNode2 = TestUtils.toRelNode("SELECT extract_union(a) from nested_union");
+    String targetSql2 = String.join("\n", "SELECT coalesce_struct(a)", "FROM default.nested_union");
     assertEquals(CoralSpark.create(relNode2).getSparkSql(), targetSql2);
   }
 

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -31,6 +31,7 @@ import com.linkedin.coral.spark.exceptions.UnsupportedUDFException;
 
 import static org.apache.calcite.sql.type.OperandTypes.*;
 import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 
 
 public class CoralSparkTest {
@@ -398,8 +399,13 @@ public class CoralSparkTest {
     String targetSql = String.join("\n", "SELECT coalesce_struct(foo)", "FROM default.union_table");
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
 
-    RelNode relNode2 = TestUtils.toRelNode("SELECT extract_union(foo, 2) from union_table");
-    String targetSql2 = String.join("\n", "SELECT coalesce_struct(foo, 3)", "FROM default.union_table");
+    RelNode relNode1 = TestUtils.toRelNode("SELECT extract_union(foo, 2) from union_table");
+    String targetSql1 = String.join("\n", "SELECT coalesce_struct(foo, 3)", "FROM default.union_table");
+    assertEquals(CoralSpark.create(relNode1).getSparkSql(), targetSql1);
+
+    // Recursion case
+    RelNode relNode2 =  TestUtils.toRelNode("SELECT extract_union(a) from recursive_union");
+    String targetSql2 = String.join("\n", "SELECT coalesce_struct(a)", "FROM default.recursive_union");
     assertEquals(CoralSpark.create(relNode2).getSparkSql(), targetSql2);
   }
 

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -404,7 +404,7 @@ public class CoralSparkTest {
     assertEquals(CoralSpark.create(relNode1).getSparkSql(), targetSql1);
 
     // Recursion case
-    RelNode relNode2 =  TestUtils.toRelNode("SELECT extract_union(a) from recursive_union");
+    RelNode relNode2 = TestUtils.toRelNode("SELECT extract_union(a) from recursive_union");
     String targetSql2 = String.join("\n", "SELECT coalesce_struct(a)", "FROM default.recursive_union");
     assertEquals(CoralSpark.create(relNode2).getSparkSql(), targetSql2);
   }

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -395,11 +395,11 @@ public class CoralSparkTest {
   @Test(enabled = false)
   public void testUnionExtractUDF() {
     RelNode relNode = TestUtils.toRelNode("SELECT extract_union(foo) from union_table");
-    String targetSql = String.join("\n", "SELECT foo", "FROM default.union_table");
+    String targetSql = String.join("\n", "SELECT coalesce_struct(foo)", "FROM default.union_table");
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
 
     RelNode relNode2 = TestUtils.toRelNode("SELECT extract_union(foo, 2) from union_table");
-    String targetSql2 = String.join("\n", "SELECT foo.tag_2", "FROM default.union_table");
+    String targetSql2 = String.join("\n", "SELECT coalesce_struct(foo, 3)", "FROM default.union_table");
     assertEquals(CoralSpark.create(relNode2).getSparkSql(), targetSql2);
   }
 

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
@@ -202,8 +202,7 @@ public class TestUtils {
     run(driver,
         "CREATE TABLE IF NOT EXISTS union_table(foo uniontype<int, double, array<string>, struct<a:int,b:string>>)");
 
-    // Recursive union case
-    run(driver, "CREATE TABLE IF NOT EXISTS recursive_union(a uniontype<int, uniontype<int, double>>)");
+    run(driver, "CREATE TABLE IF NOT EXISTS nested_union(a uniontype<int, struct<a:uniontype<int, double>, b:int>>)");
   }
 
   public static RelNode toRelNode(String db, String view) {

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
@@ -201,6 +201,9 @@ public class TestUtils {
 
     run(driver,
         "CREATE TABLE IF NOT EXISTS union_table(foo uniontype<int, double, array<string>, struct<a:int,b:string>>)");
+
+    // Recursive union case
+    run(driver, "CREATE TABLE IF NOT EXISTS recursive_union(a uniontype<int, uniontype<int, double>>)");
   }
 
   public static RelNode toRelNode(String db, String view) {


### PR DESCRIPTION
This patch includes change to swap `extract_union` UDF with `coalesce_struct` UDF in Coral-Spark during Coral `RelNode` -> Spark `RelNode`. 

In https://github.com/linkedin/coral/pull/192, we have changed the interpretation of union field in IR to a struct that aligns with Trino's after-explosion schema. The output struct which contains `tag` field and names each member field as `fieldN` is backward incompatible with the schema from `extract_union` UDF. This patch is need to bridge the schema difference between both. 

--- 

Note that `coalesce_struct` UDF will be statically registered. 
