### PR TITLE
Coral-Trino: Add type cast for `ceil`, `ceiling` and `floor` functions

### DIFF
--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/Calcite2TrinoUDFConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/Calcite2TrinoUDFConverter.java
@@ -419,9 +419,10 @@ public class Calcite2TrinoUDFConverter {
         return call;
       }
       final String lowercaseOperatorName = ((RexCall) call).getOperator().getName().toLowerCase(Locale.ROOT);
-      final ImmutableMap<String, RelDataType> operatorsToAdjust = ImmutableMap.of("date_diff",
-          typeFactory.createSqlType(INTEGER), "cardinality", typeFactory.createSqlType(INTEGER), "ceil",
-          typeFactory.createSqlType(BIGINT), "ceiling", typeFactory.createSqlType(BIGINT));
+      final ImmutableMap<String, RelDataType> operatorsToAdjust =
+          ImmutableMap.of("date_diff", typeFactory.createSqlType(INTEGER), "cardinality",
+              typeFactory.createSqlType(INTEGER), "ceil", typeFactory.createSqlType(BIGINT), "ceiling",
+              typeFactory.createSqlType(BIGINT), "floor", typeFactory.createSqlType(BIGINT));
       if (operatorsToAdjust.containsKey(lowercaseOperatorName)) {
         return rexBuilder.makeCast(operatorsToAdjust.get(lowercaseOperatorName), call);
       }

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/Calcite2TrinoUDFConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/Calcite2TrinoUDFConverter.java
@@ -420,7 +420,8 @@ public class Calcite2TrinoUDFConverter {
       }
       final String lowercaseOperatorName = ((RexCall) call).getOperator().getName().toLowerCase(Locale.ROOT);
       final ImmutableMap<String, RelDataType> operatorsToAdjust = ImmutableMap.of("date_diff",
-          typeFactory.createSqlType(INTEGER), "cardinality", typeFactory.createSqlType(INTEGER));
+          typeFactory.createSqlType(INTEGER), "cardinality", typeFactory.createSqlType(INTEGER), "ceil",
+          typeFactory.createSqlType(BIGINT), "ceiling", typeFactory.createSqlType(BIGINT));
       if (operatorsToAdjust.containsKey(lowercaseOperatorName)) {
         return rexBuilder.makeCast(operatorsToAdjust.get(lowercaseOperatorName), call);
       }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -528,7 +528,7 @@ public class HiveToTrinoConverterTest {
   }
 
   @Test
-  public void testTypeCastForDateDiff() {
+  public void testTypeCastForDateDiffFunction() {
     RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
 
     RelNode relNode = hiveToRelConverter.convertSql(
@@ -541,7 +541,7 @@ public class HiveToTrinoConverterTest {
   }
 
   @Test
-  public void testTypeCastForDataAdd() {
+  public void testTypeCastForDataAddFunction() {
     RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter(ImmutableMap.of(CAST_DATEADD_TO_STRING, true));
 
     RelNode relNode = hiveToRelConverter.convertSql(
@@ -554,7 +554,27 @@ public class HiveToTrinoConverterTest {
   }
 
   @Test
-  public void testTypeCastForCardinality() {
+  public void testTypeCastForCeilFunction() {
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+
+    RelNode relNode = hiveToRelConverter.convertSql("SELECT ceil(1.5)");
+    String targetSql = "SELECT CAST(CEIL(1.5) AS BIGINT)\n" + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
+
+  @Test
+  public void testTypeCastForCeilingFunction() {
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+
+    RelNode relNode = hiveToRelConverter.convertSql("SELECT ceiling(1.5)");
+    String targetSql = "SELECT CAST(\"ceiling\"(1.5) AS BIGINT)\n" + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
+
+  @Test
+  public void testTypeCastForCardinalityFunction() {
     RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
 
     RelNode relNode = hiveToRelConverter.convertSql("SELECT size(ARRAY (1, 2))");

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -574,6 +574,16 @@ public class HiveToTrinoConverterTest {
   }
 
   @Test
+  public void testTypeCastForFloorFunction() {
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+
+    RelNode relNode = hiveToRelConverter.convertSql("SELECT floor(1.5)");
+    String targetSql = "SELECT CAST(FLOOR(1.5) AS BIGINT)\n" + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
+
+  @Test
   public void testTypeCastForCardinalityFunction() {
     RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
 


### PR DESCRIPTION
These 3 functions all return `BIGINT` in Hive, but the corresponding Trino functions' return type is the same as the input type. 
Return type mismatch might cause issues while querying views on Trino, therefore, we need to cast them to `BIGINT`.


Tests:
1. Unit tests
2. Enhanced i-test
3. Test on affected views

