### PR TITLE
coral-schema: Generate documentation for function calls

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.StringJoiner;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -22,12 +23,16 @@ import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
+import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.logical.LogicalAggregate;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.validate.SqlUserDefinedFunction;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -273,18 +278,61 @@ class SchemaUtilities {
     return newName;
   }
 
-  static String generateDocumentationForLiteral(RexLiteral rexLiteral) {
+  private static String getLiteralValueAsString(@Nonnull RexLiteral rexLiteral) {
     StringWriter documentationWriter = new StringWriter();
     PrintWriter printWriter = new PrintWriter(documentationWriter);
 
     rexLiteral.printAsJava(printWriter);
     printWriter.flush();
 
-    return "Field created from view literal with value: " + documentationWriter;
+    return documentationWriter.toString();
   }
 
-  static String generateDocumentationForAggregate(AggregateCall aggregateCall) {
+  /**
+   * Given an input {@link RelNode} and the index of a field in the {@link RelNode}'s corresponding Avro schema,
+   * determine if the field with the specified index is a column from a table.
+   * @param fieldIndex the index of a field in the <code>inputRelNode</code>'s corresponding Avro schema
+   * @param inputRelNode the input {@link RelNode}
+   * @return true if the field at <code>fieldIndex</code> is a column from a table
+   */
+  private static boolean isColumn(int fieldIndex, @Nonnull RelNode inputRelNode) {
+    return !(inputRelNode instanceof LogicalAggregate)
+        || fieldIndex < ((LogicalAggregate) inputRelNode).getGroupSet().cardinality();
+  }
+
+  static String generateDocumentationForLiteral(@Nonnull RexLiteral rexLiteral) {
+    return "Field created from view literal with value: " + getLiteralValueAsString(rexLiteral);
+  }
+
+  static String generateDocumentationForAggregate(@Nonnull AggregateCall aggregateCall) {
     return "Field created in view by applying aggregate function of type: " + aggregateCall.getAggregation().getKind();
+  }
+
+  static String generateDocumentationForFunctionCall(@Nonnull RexCall rexCall, @Nonnull Schema inputSchema,
+      @Nonnull RelNode inputRelNode) {
+    StringJoiner args = new StringJoiner(", ");
+
+    for (RexNode rexNode : rexCall.getOperands()) {
+      SqlKind nodeKind = rexNode.getKind();
+      switch (nodeKind) {
+        case LITERAL:
+          args.add(getLiteralValueAsString((RexLiteral) rexNode));
+          break;
+        case INPUT_REF:
+          int fieldIndex = ((RexInputRef) rexNode).getIndex();
+          if (isColumn(fieldIndex, inputRelNode)) {
+            args.add(inputSchema.getFullName() + "." + inputSchema.getFields().get(fieldIndex).name());
+            break;
+          }
+        default:
+          args.add("value with type " + rexNode.getType().toString());
+          break;
+      }
+    }
+
+    String functionType = rexCall.getOperator() instanceof SqlUserDefinedFunction ? "UDF" : "operator";
+    return "Field created in view by applying " + functionType + " '" + rexCall.getOperator().getName() + "'"
+        + (args.length() > 0 ? " with argument(s): " + args : "");
   }
 
   static String toAvroQualifiedName(@Nonnull String name) {

--- a/coral-schema/src/test/resources/docTestResources/testMultipleUdfs-expected-with-doc.avsc
+++ b/coral-schema/src/test/resources/docTestResources/testMultipleUdfs-expected-with-doc.avsc
@@ -8,12 +8,15 @@
     "doc" : "Sample id of the record."
   }, {
     "name" : "Id_View_LessThanHundred_Col",
-    "type" : "boolean"
+    "type" : "boolean",
+    "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF1' with argument(s): coral.schema.avro.base.complex.basecomplex.Id"
   }, {
     "name" : "Id_View_GreaterThanHundred_Col",
-    "type" : "boolean"
+    "type" : "boolean",
+    "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF2' with argument(s): coral.schema.avro.base.complex.basecomplex.Id"
   }, {
     "name" : "Id_View_FuncSquare_Col",
-    "type" : "int"
+    "type" : "int",
+    "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF3' with argument(s): coral.schema.avro.base.complex.basecomplex.Id"
   } ]
 }

--- a/coral-schema/src/test/resources/docTestResources/testRexCallAggregate-expected-with-doc.avsc
+++ b/coral-schema/src/test/resources/docTestResources/testRexCallAggregate-expected-with-doc.avsc
@@ -4,6 +4,7 @@
   "namespace" : "default.v",
   "fields" : [ {
     "name" : "Temp",
-    "type" : [ "null", "int" ]
+    "type" : [ "null", "int" ],
+    "doc" : "Field created in view by applying operator '*' with argument(s): 22, value with type BIGINT"
   } ]
 }

--- a/coral-schema/src/test/resources/testAggregate-expected.avsc
+++ b/coral-schema/src/test/resources/testAggregate-expected.avsc
@@ -11,7 +11,8 @@
     "doc" : "Field created in view by applying aggregate function of type: COUNT"
   }, {
     "name" : "EXPR_2",
-    "type" : [ "null", "int" ]
+    "type" : [ "null", "int" ],
+    "doc" : "Field created in view by applying operator '+' with argument(s): 1, 1"
   }, {
     "name" : "Additional_Int",
     "type" : [ "null", "int" ],

--- a/coral-schema/src/test/resources/testMultipleUdfs-expected.avsc
+++ b/coral-schema/src/test/resources/testMultipleUdfs-expected.avsc
@@ -7,12 +7,15 @@
     "type" : "int"
   }, {
     "name" : "Id_View_LessThanHundred_Col",
-    "type" : "boolean"
+    "type" : "boolean",
+    "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF1' with argument(s): coral.schema.avro.base.complex.basecomplex.Id"
   }, {
     "name" : "Id_View_GreaterThanHundred_Col",
-    "type" : "boolean"
+    "type" : "boolean",
+    "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF2' with argument(s): coral.schema.avro.base.complex.basecomplex.Id"
   }, {
     "name" : "Id_View_FuncSquare_Col",
-    "type" : "int"
+    "type" : "int",
+    "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF3' with argument(s): coral.schema.avro.base.complex.basecomplex.Id"
   } ]
 }

--- a/coral-schema/src/test/resources/testNullabilitySqlOperator-expected.avsc
+++ b/coral-schema/src/test/resources/testNullabilitySqlOperator-expected.avsc
@@ -4,33 +4,43 @@
   "namespace" : "default.v",
   "fields" : [ {
     "name" : "EXPR_0",
-    "type" : [ "null", "int" ]
+    "type" : [ "null", "int" ],
+    "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.nullability.basenullability.Id, coral.schema.avro.base.nullability.basenullability.Int_Field_1"
   }, {
     "name" : "EXPR_1",
-    "type" : "int"
+    "type" : "int",
+    "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.nullability.basenullability.Id, coral.schema.avro.base.nullability.basenullability.Int_Field_2"
   }, {
     "name" : "EXPR_2",
-    "type" : [ "null", "int" ]
+    "type" : [ "null", "int" ],
+    "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.nullability.basenullability.Int_Field_1, coral.schema.avro.base.nullability.basenullability.Int_Field_1"
   }, {
     "name" : "EXPR_3",
-    "type" : [ "null", "int" ]
+    "type" : [ "null", "int" ],
+    "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.nullability.basenullability.Int_Field_1, 1"
   }, {
     "name" : "EXPR_4",
-    "type" : [ "null", "int" ]
+    "type" : [ "null", "int" ],
+    "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.nullability.basenullability.Int_Field_2, 1"
   }, {
     "name" : "EXPR_5",
-    "type" : [ "null", "double" ]
+    "type" : [ "null", "double" ],
+    "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.nullability.basenullability.Double_Field_1, coral.schema.avro.base.nullability.basenullability.Double_Field_1"
   }, {
     "name" : "EXPR_6",
-    "type" : "double"
+    "type" : "double",
+    "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.nullability.basenullability.Double_Field_2, coral.schema.avro.base.nullability.basenullability.Double_Field_2"
   }, {
     "name" : "EXPR_7",
-    "type" : [ "null", "double" ]
+    "type" : [ "null", "double" ],
+    "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.nullability.basenullability.Double_Field_1, coral.schema.avro.base.nullability.basenullability.Double_Field_2"
   }, {
     "name" : "EXPR_8",
-    "type" : [ "null", "boolean" ]
+    "type" : [ "null", "boolean" ],
+    "doc" : "Field created in view by applying operator 'NOT' with argument(s): coral.schema.avro.base.nullability.basenullability.Bool_Field_1"
   }, {
     "name" : "EXPR_9",
-    "type" : "boolean"
+    "type" : "boolean",
+    "doc" : "Field created in view by applying operator 'NOT' with argument(s): coral.schema.avro.base.nullability.basenullability.Bool_Field_2"
   } ]
 }

--- a/coral-schema/src/test/resources/testNullabilityUdf-expected.avsc
+++ b/coral-schema/src/test/resources/testNullabilityUdf-expected.avsc
@@ -4,60 +4,79 @@
   "namespace" : "default.foo_dali_udf_nullability",
   "fields" : [ {
     "name" : "EXPR_0",
-    "type" : [ "null", "boolean" ]
+    "type" : [ "null", "boolean" ],
+    "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF1' with argument(s): coral.schema.avro.base.nullability.basenullability.Int_Field_1"
   }, {
     "name" : "EXPR_1",
-    "type" : "boolean"
+    "type" : "boolean",
+    "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF1' with argument(s): coral.schema.avro.base.nullability.basenullability.Int_Field_2"
   }, {
     "name" : "EXPR_2",
-    "type" : [ "null", "boolean" ]
+    "type" : [ "null", "boolean" ],
+    "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF2' with argument(s): coral.schema.avro.base.nullability.basenullability.Int_Field_1"
   }, {
     "name" : "EXPR_3",
-    "type" : "boolean"
+    "type" : "boolean",
+    "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF2' with argument(s): coral.schema.avro.base.nullability.basenullability.Int_Field_2"
   }, {
     "name" : "EXPR_4",
-    "type" : [ "null", "int" ]
+    "type" : [ "null", "int" ],
+    "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF3' with argument(s): coral.schema.avro.base.nullability.basenullability.Int_Field_1"
   }, {
     "name" : "EXPR_5",
-    "type" : "int"
+    "type" : "int",
+    "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF3' with argument(s): coral.schema.avro.base.nullability.basenullability.Int_Field_2"
   }, {
     "name" : "EXPR_6",
-    "type" : [ "null", "boolean" ]
+    "type" : [ "null", "boolean" ],
+    "doc" : "Field created in view by applying operator 'AND' with argument(s): value with type BOOLEAN, value with type BOOLEAN"
   }, {
     "name" : "EXPR_7",
-    "type" : [ "null", "boolean" ]
+    "type" : [ "null", "boolean" ],
+    "doc" : "Field created in view by applying operator 'OR' with argument(s): value with type BOOLEAN, value with type BOOLEAN"
   }, {
     "name" : "EXPR_8",
-    "type" : [ "null", "int" ]
+    "type" : [ "null", "int" ],
+    "doc" : "Field created in view by applying operator '+' with argument(s): value with type INTEGER, coral.schema.avro.base.nullability.basenullability.Id"
   }, {
     "name" : "EXPR_9",
-    "type" : "int"
+    "type" : "int",
+    "doc" : "Field created in view by applying operator '+' with argument(s): value with type INTEGER, coral.schema.avro.base.nullability.basenullability.Id"
   }, {
     "name" : "EXPR_10",
-    "type" : [ "null", "string" ]
+    "type" : [ "null", "string" ],
+    "doc" : "Field created in view by applying UDF 'concat' with argument(s): coral.schema.avro.base.nullability.basenullability.String_Field_1, coral.schema.avro.base.nullability.basenullability.String_Field_1"
   }, {
     "name" : "EXPR_11",
-    "type" : "string"
+    "type" : "string",
+    "doc" : "Field created in view by applying UDF 'concat' with argument(s): coral.schema.avro.base.nullability.basenullability.String_Field_2, coral.schema.avro.base.nullability.basenullability.String_Field_2"
   }, {
     "name" : "EXPR_12",
-    "type" : [ "null", "string" ]
+    "type" : [ "null", "string" ],
+    "doc" : "Field created in view by applying UDF 'concat' with argument(s): coral.schema.avro.base.nullability.basenullability.String_Field_1, coral.schema.avro.base.nullability.basenullability.String_Field_2"
   }, {
     "name" : "EXPR_13",
-    "type" : [ "null", "int" ]
+    "type" : [ "null", "int" ],
+    "doc" : "Field created in view by applying operator '+' with argument(s): value with type INTEGER, 1"
   }, {
     "name" : "EXPR_14",
-    "type" : [ "null", "int" ]
+    "type" : [ "null", "int" ],
+    "doc" : "Field created in view by applying operator '+' with argument(s): value with type INTEGER, 1"
   }, {
     "name" : "EXPR_15",
-    "type" : "int"
+    "type" : "int",
+    "doc" : "Field created in view by applying operator '+' with argument(s): value with type INTEGER, coral.schema.avro.base.nullability.basenullability.Id"
   }, {
     "name" : "EXPR_16",
-    "type" : [ "null", "int" ]
+    "type" : [ "null", "int" ],
+    "doc" : "Field created in view by applying operator '+' with argument(s): value with type INTEGER, coral.schema.avro.base.nullability.basenullability.Id"
   }, {
     "name" : "EXPR_17",
-    "type" : "int"
+    "type" : "int",
+    "doc" : "Field created in view by applying operator '+' with argument(s): value with type INTEGER, coral.schema.avro.base.nullability.basenullability.Id"
   }, {
     "name" : "EXPR_18",
-    "type" : "int"
+    "type" : "int",
+    "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.nullability.basenullability.Id, value with type INTEGER"
   } ]
 }

--- a/coral-schema/src/test/resources/testRexCallAggregate-expected.avsc
+++ b/coral-schema/src/test/resources/testRexCallAggregate-expected.avsc
@@ -4,6 +4,7 @@
   "namespace" : "default.v",
   "fields" : [ {
     "name" : "Temp",
-    "type" : [ "null", "int" ]
+    "type" : [ "null", "int" ],
+    "doc" : "Field created in view by applying operator '*' with argument(s): 22, value with type BIGINT"
   } ]
 }

--- a/coral-schema/src/test/resources/testRexCallAggregateMultiple-expected.avsc
+++ b/coral-schema/src/test/resources/testRexCallAggregateMultiple-expected.avsc
@@ -7,10 +7,12 @@
     "type" : "int"
   }, {
     "name" : "Array_Count",
-    "type" : [ "null", "int" ]
+    "type" : [ "null", "int" ],
+    "doc" : "Field created in view by applying operator '*' with argument(s): 22, value with type BIGINT"
   }, {
     "name" : "Map_Count",
-    "type" : [ "null", "int" ]
+    "type" : [ "null", "int" ],
+    "doc" : "Field created in view by applying operator '*' with argument(s): 33, value with type BIGINT"
   }, {
     "name" : "EXPR_3",
     "type" : [ "null", "long" ],

--- a/coral-schema/src/test/resources/testUdfGreaterThanHundred-expected.avsc
+++ b/coral-schema/src/test/resources/testUdfGreaterThanHundred-expected.avsc
@@ -7,6 +7,7 @@
     "type" : "int"
   }, {
     "name" : "Id_View_GreaterThanHundred_Col",
-    "type" : "boolean"
+    "type" : "boolean",
+    "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF2' with argument(s): coral.schema.avro.base.complex.basecomplex.Id"
   } ]
 }

--- a/coral-schema/src/test/resources/testUdfLessThanHundred-expected.avsc
+++ b/coral-schema/src/test/resources/testUdfLessThanHundred-expected.avsc
@@ -7,6 +7,7 @@
     "type" : "int"
   }, {
     "name" : "Id_View_LessThanHundred_Col",
-    "type" : "boolean"
+    "type" : "boolean",
+    "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF1' with argument(s): coral.schema.avro.base.complex.basecomplex.Id"
   } ]
 }

--- a/coral-schema/src/test/resources/testUdfSquare-expected.avsc
+++ b/coral-schema/src/test/resources/testUdfSquare-expected.avsc
@@ -7,6 +7,7 @@
     "type" : "int"
   }, {
     "name" : "Id_View_FuncSquare_Col",
-    "type" : "int"
+    "type" : "int",
+    "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF3' with argument(s): coral.schema.avro.base.complex.basecomplex.Id"
   } ]
 }

--- a/coral-schema/src/test/resources/testUdfWithOperator-expected.avsc
+++ b/coral-schema/src/test/resources/testUdfWithOperator-expected.avsc
@@ -7,27 +7,35 @@
     "type" : "int"
   }, {
     "name" : "EXPR_1",
-    "type" : "boolean"
+    "type" : "boolean",
+    "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF1' with argument(s): coral.schema.avro.base.complex.basecomplex.Id"
   }, {
     "name" : "EXPR_2",
-    "type" : "boolean"
+    "type" : "boolean",
+    "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF2' with argument(s): coral.schema.avro.base.complex.basecomplex.Id"
   }, {
     "name" : "EXPR_3",
-    "type" : "int"
+    "type" : "int",
+    "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF3' with argument(s): coral.schema.avro.base.complex.basecomplex.Id"
   }, {
     "name" : "EXPR_4",
-    "type" : [ "null", "int" ]
+    "type" : [ "null", "int" ],
+    "doc" : "Field created in view by applying operator '+' with argument(s): 1, 1"
   }, {
     "name" : "EXPR_5",
-    "type" : [ "null", "int" ]
+    "type" : [ "null", "int" ],
+    "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.complex.basecomplex.Id, 1"
   }, {
     "name" : "EXPR_6",
-    "type" : [ "null", "int" ]
+    "type" : [ "null", "int" ],
+    "doc" : "Field created in view by applying operator '+' with argument(s): value with type INTEGER, 1"
   }, {
     "name" : "EXPR_7",
-    "type" : [ "null", "int" ]
+    "type" : [ "null", "int" ],
+    "doc" : "Field created in view by applying operator '+' with argument(s): value with type INTEGER, 1"
   }, {
     "name" : "EXPR_8",
-    "type" : "int"
+    "type" : "int",
+    "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.complex.basecomplex.Id, value with type INTEGER"
   } ]
 }


### PR DESCRIPTION
### Summary

Previously, field-level documentation in schemas produced by the `ViewToAvroSchemaConverter` was only available for fields that were:
* directly selected from base tables (#115)
* created from literal values (#172)
* created from aggregate function calls (#186)

This PR adds documentation for fields created from other types of function calls (i.e. UDFs and operators).

The documentation is in the form of: `"Field created in view by applying UDF / operator '<FUNCTION-NAME>' with argument(s): <LIST-OF-ARGUMENTS>"`

### Testing
There are existing unit tests covering function calls. The `.avsc` files containing expected schemas for those test cases have been updated to include the documentation field.