### PR TITLE
Coral-Common: Using INTEGER for trino-struct tag field

### DIFF
--- a/coral-common/src/main/java/com/linkedin/coral/common/TypeConverter.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/TypeConverter.java
@@ -138,12 +138,17 @@ public class TypeConverter {
 
   // Mimic the StructTypeInfo conversion to convert a UnionTypeInfo to the corresponding RelDataType
   // The schema of output Struct conforms to https://github.com/trinodb/trino/pull/3483
+  // except we adopted "integer" for the type of "tag" field instead of "tinyint" in the Trino patch
+  // for compatibility with other platforms that Iceberg at currently doesn't support tinyint type.
+
+  // Note: this is subject to change in the future pending on the discussion in
+  // https://mail-archives.apache.org/mod_mbox/iceberg-dev/202112.mbox/browser
   public static RelDataType convert(UnionTypeInfo unionType, RelDataTypeFactory dtFactory) {
     List<RelDataType> fTypes = unionType.getAllUnionObjectTypeInfos().stream()
         .map(typeInfo -> convert(typeInfo, dtFactory)).collect(Collectors.toList());
     List<String> fNames = IntStream.range(0, unionType.getAllUnionObjectTypeInfos().size()).mapToObj(i -> "field" + i)
         .collect(Collectors.toList());
-    fTypes.add(0, dtFactory.createSqlType(SqlTypeName.TINYINT));
+    fTypes.add(0, dtFactory.createSqlType(SqlTypeName.INTEGER));
     fNames.add(0, "tag");
 
     RelDataType rowType = dtFactory.createStructType(fTypes, fNames);

--- a/coral-common/src/main/java/com/linkedin/coral/common/TypeConverter.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/TypeConverter.java
@@ -139,7 +139,7 @@ public class TypeConverter {
   // Mimic the StructTypeInfo conversion to convert a UnionTypeInfo to the corresponding RelDataType
   // The schema of output Struct conforms to https://github.com/trinodb/trino/pull/3483
   // except we adopted "integer" for the type of "tag" field instead of "tinyint" in the Trino patch
-  // for compatibility with other platforms that Iceberg at currently doesn't support tinyint type.
+  // for compatibility with other platforms that Iceberg currently doesn't support tinyint type.
 
   // Note: this is subject to change in the future pending on the discussion in
   // https://mail-archives.apache.org/mod_mbox/iceberg-dev/202112.mbox/browser

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveTableTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveTableTest.java
@@ -85,12 +85,12 @@ public class HiveTableTest {
     // test handling of union
     Table unionTable = getTable("default", "union_table");
     // union_table:(foo uniontype<int, double, array<string>, struct<a:int,b:string>>)
-    // expected outcome schema: struct<tag:tinyint, field0:int, field1:double, field2:array<string>, field3:struct<a:int,b:string>>
+    // expected outcome schema: struct<tag:int, field0:int, field1:double, field2:array<string>, field3:struct<a:int,b:string>>
     RelDataType rowType = unionTable.getRowType(typeFactory);
     assertNotNull(rowType);
 
     String expectedTypeString =
-        "RecordType(" + "RecordType(" + "TINYINT tag, INTEGER field0, DOUBLE field1, VARCHAR(65536) ARRAY field2, "
+        "RecordType(" + "RecordType(" + "INTEGER tag, INTEGER field0, DOUBLE field1, VARCHAR(65536) ARRAY field2, "
             + "RecordType(INTEGER a, VARCHAR(65536) b) field3" + ") " + "foo)";
     assertEquals(rowType.toString(), expectedTypeString);
   }


### PR DESCRIPTION
Based on previous PR https://github.com/linkedin/coral/pull/192/files, this PR makes the modification in the data type of `tag` field due to compatibility with other platforms like Avro and Iceberg in which `tinyint` is not supported. 