### PR TITLE
Coral-Hive: Modify the return type of IF function

### DIFF
--- a/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionReturnTypes.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionReturnTypes.java
@@ -28,13 +28,16 @@ public final class FunctionReturnTypes {
 
   }
 
-  public static final SqlReturnTypeInference ARG1_OR_ARG2 = opBinding -> {
+  public static final SqlReturnTypeInference IF_FUNC_RETURN_TYPE = opBinding -> {
     Preconditions.checkState(opBinding.getOperandCount() == 3);
-    if (!opBinding.isOperandNull(1, false)) {
-      return opBinding.getOperandType(1);
-    } else {
-      return opBinding.getOperandType(2);
+    final RelDataType type1 = opBinding.getOperandType(1);
+    final RelDataType type2 = opBinding.getOperandType(2);
+    if (type1 == type2) {
+      return type1;
     }
+    // If the types mismatch, the non-literal one's type should be picked
+    // i.e. the type of `if(..., 0, bigint_type_field)` should be bigint rather than int
+    return opBinding.isOperandLiteral(1, false) ? type2 : type1;
   };
 
   public static final SqlReturnTypeInference STRING = ReturnTypes.explicit(SqlTypeName.VARCHAR);

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -129,7 +129,7 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
     // to SQL to be odd although correct. So, we add 'if' as UDF
     // TODO: add check to verify 2nd and 3rd operands are same
     addFunctionEntry("if",
-        createCalciteUDF("if", FunctionReturnTypes.ARG1_OR_ARG2, OperandTypeInference.BOOLEAN_ANY_SAME,
+        createCalciteUDF("if", FunctionReturnTypes.IF_FUNC_RETURN_TYPE, OperandTypeInference.BOOLEAN_ANY_SAME,
             new SameOperandTypeExceptFirstOperandChecker(3, SqlTypeName.BOOLEAN), null));
 
     addFunctionEntry("coalesce", COALESCE);

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -127,7 +127,6 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
 
     // calcite models 'if' function as CASE operator. We can use CASE but that will cause translation
     // to SQL to be odd although correct. So, we add 'if' as UDF
-    // TODO: add check to verify 2nd and 3rd operands are same
     addFunctionEntry("if",
         createCalciteUDF("if", FunctionReturnTypes.IF_FUNC_RETURN_TYPE, OperandTypeInference.BOOLEAN_ANY_SAME,
             new SameOperandTypeExceptFirstOperandChecker(3, SqlTypeName.BOOLEAN), null));

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveOperatorsTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveOperatorsTest.java
@@ -169,7 +169,8 @@ public class HiveOperatorsTest {
     }
   }
 
-  private void testLikeFamilyOperators(String operator) {
+  @Test
+  public void testLikeFamilyOperators(String operator) {
     final String sql = "SELECT a, b FROM foo WHERE b " + operator + " 'abc%'";
     String expectedRel = "LogicalProject(a=[$0], b=[$1])\n" + "  LogicalFilter(condition=[" + operator.toUpperCase()
         + "($1, 'abc%')])\n" + "    LogicalTableScan(table=[[hive, default, foo]])\n";
@@ -178,5 +179,12 @@ public class HiveOperatorsTest {
     String expectedSql = "SELECT \"a\", \"b\"\nFROM \"hive\".\"default\".\"foo\"\n" + "WHERE \"b\" "
         + operator.toUpperCase() + " 'abc%'";
     assertEquals(relToSql(rel), expectedSql);
+  }
+
+  @Test
+  public void testIfFunctionReturnType() {
+    final String sql = "SELECT IF(FALSE, 0, c) c FROM test.tableOne";
+    RelNode rel = toRel(sql);
+    assertEquals(rel.getRowType().toString(), "RecordType(DOUBLE c)");
   }
 }


### PR DESCRIPTION
### Summary
Previously, the return type of `if(..., a, b)` is the first non-null type of a and b, therefore, the return type of `if(..., 0, bigint_type_field) as bigint_type_field` is `int` rather than `bigint`, which will cause the following issue while querying the view on Trino:
```
View 'xxx' is stale or in invalid state: column [bigint_type_field] of type bigint projected from query view 
at position x cannot be coerced to column [bigint_type_field] of type integer stored in view definition
```
This PR will ensure that the return type of `if(..., 0, bigint_type_field) as bigint_type_field` is `bigint` rather than `int`.

We pick the non-literal one if the types mismatch because the non-literal one (which is usually a field of table) is picked by Trino and we need to ensure the type picked by Trino is the same as the type returned by coral.

### Test
1. Unit test
2. Enhanced i-test, this issue was caught by the enhanced i-test to begin with
3. Test on affected views