### PR TITLE
Coral-Hive: Modify HiveViewExpander#expandView to avoid array index issue

### DIFF
--- a/coral-common/src/main/java/com/linkedin/coral/common/ToRelConverter.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/ToRelConverter.java
@@ -146,7 +146,7 @@ public abstract class ToRelConverter {
    * @return Calcite SqlNode representing parse tree that calcite framework can understand
    */
   @VisibleForTesting
-  protected SqlNode processView(String dbName, String tableName) {
+  public SqlNode processView(String dbName, String tableName) {
     org.apache.hadoop.hive.metastore.api.Table table = hiveMetastoreClient.getTable(dbName, tableName);
     if (table == null) {
       throw new RuntimeException(String.format("Unknown table %s.%s", dbName, tableName));

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveViewExpander.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveViewExpander.java
@@ -14,8 +14,10 @@ import com.google.common.base.Preconditions;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.util.Util;
+
+import com.linkedin.coral.common.FuzzyUnionSqlRewriter;
 
 
 /**
@@ -42,6 +44,8 @@ public class HiveViewExpander implements RelOptTable.ViewExpander {
     String dbName = Util.last(schemaPath);
     String tableName = viewPath.get(0);
 
-    return RelRoot.of(hiveToRelConverter.convertView(dbName, tableName), SqlKind.SELECT);
+    SqlNode sqlNode = hiveToRelConverter.processView(dbName, tableName)
+        .accept(new FuzzyUnionSqlRewriter(tableName, hiveToRelConverter));
+    return hiveToRelConverter.getSqlToRelConverter().convertQuery(sqlNode, true, true);
   }
 }

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -712,4 +712,11 @@ public class CoralSparkTest {
     String targetSql = "SELECT collect_set(a)\n" + "FROM default.foo";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
+
+  @Test
+  public void testSelectArrayIndex() {
+    RelNode relNode = TestUtils.toRelNode("SELECT * FROM default.view_expand_array_index");
+    String targetSql = "SELECT c[1] c1\n" + "FROM default.complex";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+  }
 }

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
@@ -203,6 +203,8 @@ public class TestUtils {
         "CREATE TABLE IF NOT EXISTS union_table(foo uniontype<int, double, array<string>, struct<a:int,b:string>>)");
 
     run(driver, "CREATE TABLE IF NOT EXISTS nested_union(a uniontype<int, struct<a:uniontype<int, double>, b:int>>)");
+
+    run(driver, "CREATE VIEW IF NOT EXISTS view_expand_array_index AS SELECT c[1] c1 FROM default.complex");
   }
 
   public static RelNode toRelNode(String db, String view) {


### PR DESCRIPTION
### Summary
#151 made the change in `HiveViewExpander#expandView`, which is not the same as the previous implementation actually. Because `hiveToRelConverter.convertView` will call an extra `ToRelConverter#standardizeRel`, and then an extra `HiveRelConverter#convertToOneBasedArrayIndex`, finally cause the incorrect array index while expanding the view

For example, without this fixing PR, the translated result of the unit test is:
```
SELECT c[2] c1
FROM default.complex
```

This PR rolls back to the previous implementation to avoid calling `HiveRelConverter#convertToOneBasedArrayIndex` twice.
cc: @wmoustafa 

### Tests
1. Unit test
2. Test on the affected views
3. i-test which is running