### PR TITLE
[Document Change] Removing all LIHADOOP ticket reference in comments

### DIFF
--- a/coral-common/src/main/java/com/linkedin/coral/common/HiveViewTable.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/HiveViewTable.java
@@ -74,7 +74,7 @@ public class HiveViewTable extends HiveTable implements TranslatableTable {
     }
   }
 
-  // [LIHADOOP-34428]: Hive-based Dali readers allow extra fields on struct type columns to flow through. We
+  // Hive-based Dali readers allow extra fields on struct type columns to flow through. We
   // try to match that behavior. Hive-based Dali readers do not allow top level columns to flow through
   // Returns true if an explicit cast is required from rowType to castRowType, false otherwise
   private static boolean isRowCastRequired(RelDataType rowType, RelDataType castRowType,

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -472,7 +472,7 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
     createAddUserDefinedFunction("com.linkedin.tscp.reporting.dali.udfs.SponsoredMessageNodeId", ReturnTypes.INTEGER,
         family(SqlTypeFamily.STRING));
 
-    // LIHADOOP-48502: The following UDFs are already defined using Transport UDF.
+    // The following UDFs are already defined using Transport UDF.
     // The class name is the corresponding Hive UDF.
     // We point their class files to the corresponding Spark jar file in TransportableUDFMap.
     createAddUserDefinedFunction("com.linkedin.stdudfs.daliudfs.hive.DateFormatToEpoch", BIGINT_NULLABLE,

--- a/coral-pig/src/main/java/com/linkedin/coral/pig/rel2pig/rel/PigLogicalAggregate.java
+++ b/coral-pig/src/main/java/com/linkedin/coral/pig/rel2pig/rel/PigLogicalAggregate.java
@@ -181,7 +181,7 @@ public class PigLogicalAggregate {
         aggregateCallArguments = bagIdentifier;
       }
 
-      // TODO(ralam): LIHADOOP-49630 - Create a function mapping from Hive/Transport/Built-in functions to Pig
+      // TODO Create a function mapping from Hive/Transport/Built-in functions to Pig
       aggregateStatements
           .add(String.format(AGGREGATE_CALL_TEMPLATE, aggregateCall.getAggregation().getName().toUpperCase(),
               aggregateCallArguments, outputFieldNames.get(groupBySetOffset + i)));

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/TypeInfoToAvroSchemaConverter.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/TypeInfoToAvroSchemaConverter.java
@@ -137,8 +137,8 @@ public class TypeInfoToAvroSchemaConverter {
     return Schema.createUnion(schemas);
   }
 
-  // Previously, Hive use recordType[N] as the recordName for each structType, with the change we made in LIHADOOP-36761,
-  // the new record name will be in the form of "structNamespace.structName"
+  // Previously, Hive use recordType[N] as the recordName for each structType,
+  // now the new record name will be in the form of "structNamespace.structName" given the change made earlier.
   private Schema parseSchemaFromStruct(final StructTypeInfo typeInfo, final String recordNamespace,
       final String recordName) {
     final Schema recordSchema = convertFieldsTypeInfoToAvroSchema(recordNamespace, recordName,

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -431,7 +431,7 @@ public class ViewToAvroSchemaConverterTests {
     Assert.assertEquals(actualSchema.toString(true), TestUtils.loadSchema("testSelfJoin-expected.avsc"));
   }
 
-  // TODO: handle complex type (Array[Struct] in lateral view:  LIHADOOP-46695)
+  // TODO: handle complex type (Array[Struct] in lateral view)
   @Test(enabled = false)
   public void testLateralViewArrayWithComplexType() {
     String viewSql = "CREATE VIEW v AS " + "SELECT bl.Id AS Id_View_Col, bl.Array_Col_Struct AS Array_Struct_View_Col, "

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
@@ -234,7 +234,7 @@ class IRRelToSparkRelTransformer {
     }
 
     /**
-     * [LIHADOOP-43198] After failing to find the function name in BuiltinUDFMap and TransportableUDFMap,
+     * After failing to find the function name in BuiltinUDFMap and TransportableUDFMap,
      * we call this function to fall back to the original Hive UDF defined in HiveFunctionRegistry.
      * This is reasonable since Spark understands and has ability to run Hive UDF.
      */
@@ -251,7 +251,7 @@ class IRRelToSparkRelTransformer {
           // We do not need to handle the keyword built-in functions.
           VersionedSqlUserDefinedFunction daliUdf = (VersionedSqlUserDefinedFunction) sqlOp;
           String expandedFuncName = daliUdf.getViewDependentFunctionName();
-          //[LIHADOOP-44515] need to provide UDF dependency with ivy coordinates
+          // need to provide UDF dependency with ivy coordinates
           List<String> dependencies = daliUdf.getIvyDependencies();
           List<URI> listOfUris = dependencies.stream().map(URI::create).collect(Collectors.toList());
           sparkUDFInfo = Optional.of(

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/SparkSqlRewriter.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/SparkSqlRewriter.java
@@ -37,7 +37,7 @@ import com.linkedin.coral.spark.dialect.SparkSqlDialect;
 public class SparkSqlRewriter extends SqlShuttle {
 
   /**
-   *  [LIHADOOP-43199] Spark SQL doesn't support CASTING the named_struct function to a row/struct.
+   *  Spark SQL doesn't support CASTING the named_struct function to a row/struct.
    *  Sushant suggests that we remove this behavior here.
    *
    *  For example:

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/TransportableUDFMap.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/TransportableUDFMap.java
@@ -45,7 +45,7 @@ class TransportableUDFMap {
 
   static {
 
-    // LIHADOOP-48502: The following UDFs are the legacy Hive UDF. Since they have been converted to
+    // The following UDFs are the legacy Hive UDF. Since they have been converted to
     // Transport UDF, we point their class files to the corresponding Spark jar.
     add("com.linkedin.dali.udf.date.hive.DateFormatToEpoch", "com.linkedin.stdudfs.daliudfs.spark.DateFormatToEpoch",
         DALI_UDFS_IVY_URL_SPARK_2_11, DALI_UDFS_IVY_URL_SPARK_2_12);
@@ -61,7 +61,7 @@ class TransportableUDFMap {
         "com.linkedin.stdudfs.daliudfs.spark.IsGuestMemberId", DALI_UDFS_IVY_URL_SPARK_2_11,
         DALI_UDFS_IVY_URL_SPARK_2_12);
 
-    // LIHADOOP-49851 add the transportudf spark version for lookup UDF
+    // add the transportudf spark version for lookup UDF
     add("com.linkedin.dali.udf.istestmemberid.hive.IsTestMemberId",
         "com.linkedin.stdudfs.daliudfs.spark.IsTestMemberId", DALI_UDFS_IVY_URL_SPARK_2_11,
         DALI_UDFS_IVY_URL_SPARK_2_12);
@@ -72,12 +72,12 @@ class TransportableUDFMap {
     add("com.linkedin.dali.udf.sanitize.hive.Sanitize", "com.linkedin.stdudfs.daliudfs.spark.Sanitize",
         DALI_UDFS_IVY_URL_SPARK_2_11, DALI_UDFS_IVY_URL_SPARK_2_12);
 
-    // LIHADOOP-49851 add the transportudf spark version for lookup UDF
+    // add the transportudf spark version for lookup UDF
     add("com.linkedin.dali.udf.watbotcrawlerlookup.hive.WATBotCrawlerLookup",
         "com.linkedin.stdudfs.daliudfs.spark.WatBotCrawlerLookup", DALI_UDFS_IVY_URL_SPARK_2_11,
         DALI_UDFS_IVY_URL_SPARK_2_12);
 
-    // LIHADOOP-48502: The following UDFs are already defined using Transport UDF.
+    // The following UDFs are already defined using Transport UDF.
     // The class name is the corresponding Hive UDF.
     // We point their class files to the corresponding Spark jar file.
     add("com.linkedin.stdudfs.daliudfs.hive.DateFormatToEpoch", "com.linkedin.stdudfs.daliudfs.spark.DateFormatToEpoch",

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -77,6 +77,7 @@ public class CoralSparkTest {
 
   @Test
   public void testLiteralColumnsFromView() {
+    // use date literal in view definition
     String targetSql = "SELECT '2013-01-01', '2017-08-22 01:02:03', CAST(123 AS SMALLINT), CAST(123 AS TINYINT)\n"
         + "FROM default.foo\n" + "LIMIT 1";
     RelNode relNode = TestUtils.toRelNode("default", "foo_v1");
@@ -122,6 +123,7 @@ public class CoralSparkTest {
     List<String> listOfUriStrings = convertToListOfUriStrings(udfJars.get(0).getArtifactoryUrls());
     String targetArtifactoryUrl = "ivy://com.linkedin.coral.spark.CoralTestUDF";
     assertTrue(listOfUriStrings.contains(targetArtifactoryUrl));
+    // need to check the UDF type
     SparkUDFInfo.UDFTYPE testUdfType = udfJars.get(0).getUdfType();
     SparkUDFInfo.UDFTYPE targetUdfType = SparkUDFInfo.UDFTYPE.TRANSPORTABLE_UDF;
     assertEquals(testUdfType, targetUdfType);
@@ -145,9 +147,11 @@ public class CoralSparkTest {
     String udfFunctionName = udfJars.get(0).getFunctionName();
     String targetFunctionName = "default_foo_dali_udf2_GreaterThanHundred";
     assertEquals(udfFunctionName, targetFunctionName);
+    // check if CoralSpark can fetch artifactory url from Dali View definition.
     List<String> listOfUriStrings = convertToListOfUriStrings(udfJars.get(0).getArtifactoryUrls());
     String targetArtifactoryUrl = "ivy://com.linkedin:udf:1.0";
     assertTrue(listOfUriStrings.contains(targetArtifactoryUrl));
+    // need to check the UDF type
     SparkUDFInfo.UDFTYPE testUdfType = udfJars.get(0).getUdfType();
     SparkUDFInfo.UDFTYPE targetUdfType = SparkUDFInfo.UDFTYPE.HIVE_CUSTOM_UDF;
     assertEquals(testUdfType, targetUdfType);

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -77,7 +77,6 @@ public class CoralSparkTest {
 
   @Test
   public void testLiteralColumnsFromView() {
-    // [LIHADOOP-47172] use date literal in view definition
     String targetSql = "SELECT '2013-01-01', '2017-08-22 01:02:03', CAST(123 AS SMALLINT), CAST(123 AS TINYINT)\n"
         + "FROM default.foo\n" + "LIMIT 1";
     RelNode relNode = TestUtils.toRelNode("default", "foo_v1");
@@ -123,7 +122,6 @@ public class CoralSparkTest {
     List<String> listOfUriStrings = convertToListOfUriStrings(udfJars.get(0).getArtifactoryUrls());
     String targetArtifactoryUrl = "ivy://com.linkedin.coral.spark.CoralTestUDF";
     assertTrue(listOfUriStrings.contains(targetArtifactoryUrl));
-    // LIHADOOP-48379: need to check the UDF type
     SparkUDFInfo.UDFTYPE testUdfType = udfJars.get(0).getUdfType();
     SparkUDFInfo.UDFTYPE targetUdfType = SparkUDFInfo.UDFTYPE.TRANSPORTABLE_UDF;
     assertEquals(testUdfType, targetUdfType);
@@ -147,11 +145,9 @@ public class CoralSparkTest {
     String udfFunctionName = udfJars.get(0).getFunctionName();
     String targetFunctionName = "default_foo_dali_udf2_GreaterThanHundred";
     assertEquals(udfFunctionName, targetFunctionName);
-    // LIHADOOP-48635: check if CoralSpark can fetch artifactory url from Dali View definition.
     List<String> listOfUriStrings = convertToListOfUriStrings(udfJars.get(0).getArtifactoryUrls());
     String targetArtifactoryUrl = "ivy://com.linkedin:udf:1.0";
     assertTrue(listOfUriStrings.contains(targetArtifactoryUrl));
-    // LIHADOOP-48379: need to check the UDF type
     SparkUDFInfo.UDFTYPE testUdfType = udfJars.get(0).getUdfType();
     SparkUDFInfo.UDFTYPE targetUdfType = SparkUDFInfo.UDFTYPE.HIVE_CUSTOM_UDF;
     assertEquals(testUdfType, targetUdfType);
@@ -299,7 +295,7 @@ public class CoralSparkTest {
     System.out.println(relNodePlan);
     String convertToSparkSql = CoralSpark.create(relNode).getSparkSql();
 
-    /*  [LIHADOOP-43199] the test query is translated to:
+    /*  the test query is translated to:
      *  SELECT named_struct('abc', 123, 'def', 'xyz') named_struc FROM default.bar;
      */
     String targetSql =

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
@@ -73,7 +73,6 @@ public class TestUtils {
 
     run(driver, String.join("\n", "", "CREATE VIEW IF NOT EXISTS foo_view", "AS", "SELECT b AS bcol, sum(c) AS sum_c",
         "FROM foo", "GROUP BY b"));
-    // [LIHADOOP-47172 test date literal in view definition
     run(driver, "DROP VIEW IF EXITS foo_v1");
     run(driver,
         String.join("\n", "", "CREATE VIEW IF NOT EXISTS foo_v1 ", "AS ",

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
@@ -117,7 +117,7 @@ public class RelToTrinoConverter extends RelToSqlConverter {
 
   @Override
   public void addSelect(List<SqlNode> selectList, SqlNode node, RelDataType rowType) {
-    // APA-7366 Override this method from parent class RelToSqlConverter to always add "as"
+    // Override this method from parent class RelToSqlConverter to always add "as"
     // when accessing nested struct.
     // In parent class "as" is skipped for "select a.b as b", here we will keep the "a.b as b"
     SqlNode selectNode = node;

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverterTest.java
@@ -74,7 +74,6 @@ public class RelToTrinoConverterTest {
 
   @Test
   public void testMapStructAccess() {
-    // This test reproduces the bug in APA-6771, APA-7366
     String sql = String.format(
         "SELECT mcol[scol].IFIELD as mapStructAccess, mcol[scol].SFIELD as sField from %s where icol < 5", tableFour);
 


### PR DESCRIPTION
Before open source there are a bunch of Linkedin-specific ticket referenced added in the comments. This PRs remove them as the majority of them have been resolved already. 