### PR TITLE
Coral-Spark | Coral-Hive : Statically register coalesce_struct UDF in Coral-Spark

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
@@ -26,25 +26,6 @@ import org.apache.calcite.sql.type.SqlReturnTypeInference;
 public class CoalesceStructUtility {
 
   /**
-   * The semantics for the extract_union is now pass-through: Assuming the engine's reader could deal with
-   * union type and explode it into a struct, this extract_union UDF's return type will simply follow exploded struct's
-   * schema based on how many arguments passed by users.
-   */
-  public static final SqlReturnTypeInference EXTRACT_UNION_FUNCTION_RETURN_STRATEGY = opBinding -> {
-    int numArgs = opBinding.getOperandCount();
-    Preconditions.checkState(numArgs == 1 || numArgs == 2);
-    // 1-arg case
-    if (numArgs == 1) {
-      return opBinding.getOperandType(0);
-    }
-    // 2-arg case
-    else {
-      int ordinal = opBinding.getOperandLiteralValue(1, Integer.class);
-      return opBinding.getOperandType(0).getFieldList().get(ordinal).getType();
-    }
-  };
-
-  /**
    * Represents the return type for the coalesce_struct UDF that is built for bridging the schema difference
    * between extract_union UDF's processed schema of union field in Coral IR (let's call it struct_ex) and
    * Trino's schema when deserializing union field from its reader.

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -373,9 +373,8 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
 
     createAddUserDefinedFunction("array_contains", ReturnTypes.BOOLEAN, family(SqlTypeFamily.ARRAY, SqlTypeFamily.ANY));
     createAddUserDefinedFunction("sort_array", ARG0, ARRAY);
-    createAddUserDefinedFunction("extract_union", EXTRACT_UNION_FUNCTION_RETURN_STRATEGY,
-        or(ANY, family(SqlTypeFamily.ANY, SqlTypeFamily.INTEGER)));
-    createAddUserDefinedFunction("coalesce_struct", COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY,
+
+    createAddUserDefinedFunction("extract_union", COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY,
         or(ANY, family(SqlTypeFamily.ANY, SqlTypeFamily.INTEGER)));
 
     // LinkedIn UDFs: Dali stores mapping from UDF name to the implementing Java class as table properties

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -376,6 +376,8 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
 
     createAddUserDefinedFunction("extract_union", COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY,
         or(ANY, family(SqlTypeFamily.ANY, SqlTypeFamily.INTEGER)));
+    createAddUserDefinedFunction("coalesce_struct", COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY,
+        or(ANY, family(SqlTypeFamily.ANY, SqlTypeFamily.INTEGER)));
 
     // LinkedIn UDFs: Dali stores mapping from UDF name to the implementing Java class as table properties
     // in the HCatalog. So, an UDF implementation may be referred by different names by different views.

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
@@ -341,6 +341,12 @@ class IRRelToSparkRelTransformer {
      */
     private Optional<RexNode> swapExtractUnionFunction(RexCall call) {
       if (call.getOperator().getName().equalsIgnoreCase("extract_union")) {
+        // When there's necessity to register coalesce_struct UDF
+        sparkUDFInfos.add(new SparkUDFInfo("com.linkedin.coalescestruct.GenericUDFCoalesceStruct",
+            "coalesce_struct",
+            ImmutableList.of(URI.create("ivy://com.linkedin.coalesce-struct:coalesce-struct-impl:0.0.1")),
+            SparkUDFInfo.UDFTYPE.HIVE_CUSTOM_UDF));
+
         // one arg case: extract_union(field_name)
         if (call.getOperands().size() == 1) {
           return Optional.of(rexBuilder.makeCall(

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
@@ -341,7 +341,7 @@ class IRRelToSparkRelTransformer {
      */
     private Optional<RexNode> swapExtractUnionFunction(RexCall call) {
       if (call.getOperator().getName().equalsIgnoreCase("extract_union")) {
-        // When there's necessity to register coalesce_struct UDF
+        // Only when there's a necessity to register coalesce_struct UDF
         sparkUDFInfos.add(new SparkUDFInfo("com.linkedin.coalescestruct.GenericUDFCoalesceStruct",
             "coalesce_struct",
             ImmutableList.of(URI.create("ivy://com.linkedin.coalesce-struct:coalesce-struct-impl:0.0.1")),

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
@@ -342,8 +342,7 @@ class IRRelToSparkRelTransformer {
     private Optional<RexNode> swapExtractUnionFunction(RexCall call) {
       if (call.getOperator().getName().equalsIgnoreCase("extract_union")) {
         // Only when there's a necessity to register coalesce_struct UDF
-        sparkUDFInfos.add(new SparkUDFInfo("com.linkedin.coalescestruct.GenericUDFCoalesceStruct",
-            "coalesce_struct",
+        sparkUDFInfos.add(new SparkUDFInfo("com.linkedin.coalescestruct.GenericUDFCoalesceStruct", "coalesce_struct",
             ImmutableList.of(URI.create("ivy://com.linkedin.coalesce-struct:coalesce-struct-impl:0.0.1")),
             SparkUDFInfo.UDFTYPE.HIVE_CUSTOM_UDF));
 


### PR DESCRIPTION
This PR statically register `coalesce_struct` UDF in Coral-Spark. The jar containing UDF will be downloaded in `org.apache.spark.sql.hive.HiveExternalCatalog#restoreTableMetadata` where the `view` is handled. 

~~This patch is created for early feedback, the integration test within properly environment is in-progress~~ 

This PR additionally contains an one-liner fix for the issue we discovered during the tests. Briefly, given the decision to swap `extract_union` to `coalesce_struct` to preserve the original output schema of `extract_union` HiveUDF, we need to ensure the `RelDataType` of a node in AST `extract_union(union)` to be its original output schema, which is `[tag_0, tag_1, ... , tag_N]`. To achieve that, the registration of `extract_union` needs to be modified to return `COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY` instead of `EXTRACT_UNION_FUNCTION_RETURN_STRATEGY`. 

