### PR TITLE
Coral-Spark: Deduplicate sparkUDFInfoList

### DIFF
--- a/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.calcite.rel.RelNode;
@@ -85,7 +86,7 @@ class IRRelToSparkRelTransformer {
    *
    */
   static SparkRelInfo transform(RelNode calciteNode) {
-    List<SparkUDFInfo> sparkUDFInfos = new ArrayList<>();
+    Set<SparkUDFInfo> sparkUDFInfos = new HashSet<>();
     RelShuttle converter = new RelShuttleImpl() {
       @Override
       public RelNode visit(LogicalProject project) {
@@ -166,8 +167,7 @@ class IRRelToSparkRelTransformer {
         return new SparkRexConverter(node.getCluster().getRexBuilder(), sparkUDFInfos);
       }
     };
-    // Deduplicate sparkUDFInfos to avoid registering the same UDF many times in Spark
-    return new SparkRelInfo(calciteNode.accept(converter), new ArrayList<>(new HashSet<>(sparkUDFInfos)));
+    return new SparkRelInfo(calciteNode.accept(converter), new ArrayList<>(sparkUDFInfos));
   }
 
   /**
@@ -179,10 +179,10 @@ class IRRelToSparkRelTransformer {
    */
   private static class SparkRexConverter extends RexShuttle {
     private final RexBuilder rexBuilder;
-    private final List<SparkUDFInfo> sparkUDFInfos;
+    private final Set<SparkUDFInfo> sparkUDFInfos;
     private static final Logger LOG = LoggerFactory.getLogger(SparkRexConverter.class);
 
-    SparkRexConverter(RexBuilder rexBuilder, List<SparkUDFInfo> sparkUDFInfos) {
+    SparkRexConverter(RexBuilder rexBuilder, Set<SparkUDFInfo> sparkUDFInfos) {
       this.sparkUDFInfos = sparkUDFInfos;
       this.rexBuilder = rexBuilder;
     }

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
@@ -8,6 +8,7 @@ package com.linkedin.coral.spark;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -165,7 +166,8 @@ class IRRelToSparkRelTransformer {
         return new SparkRexConverter(node.getCluster().getRexBuilder(), sparkUDFInfos);
       }
     };
-    return new SparkRelInfo(calciteNode.accept(converter), sparkUDFInfos);
+    // Deduplicate sparkUDFInfos to avoid registering the same UDF many times in Spark
+    return new SparkRelInfo(calciteNode.accept(converter), new ArrayList<>(new HashSet<>(sparkUDFInfos)));
   }
 
   /**

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/containers/SparkUDFInfo.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/containers/SparkUDFInfo.java
@@ -7,6 +7,7 @@ package com.linkedin.coral.spark.containers;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Objects;
 
 
 /**
@@ -93,5 +94,23 @@ public class SparkUDFInfo {
   public String toString() {
     return "SparkUDFInfo{" + "className='" + className + '\'' + ", functionName='" + functionName + '\''
         + ", artifactoryUrls='" + artifactoryUrls + '\'' + ", udfType='" + udfType + '\'' + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SparkUDFInfo that = (SparkUDFInfo) o;
+    return Objects.equals(className, that.className) && Objects.equals(functionName, that.functionName)
+        && Objects.equals(artifactoryUrls, that.artifactoryUrls) && udfType == that.udfType;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(className, functionName, artifactoryUrls, udfType);
   }
 }

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -719,4 +719,12 @@ public class CoralSparkTest {
     String targetSql = "SELECT c[1] c1\n" + "FROM default.complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
+
+  @Test
+  public void testDeduplicateUdf() {
+    RelNode relNode = TestUtils.toRelNode("default", "foo_duplicate_udf");
+    CoralSpark coralSpark = CoralSpark.create(relNode);
+    List<SparkUDFInfo> udfJars = coralSpark.getSparkUDFInfoList();
+    assertEquals(1, udfJars.size());
+  }
 }

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
@@ -68,6 +68,8 @@ public class TestUtils {
         "CREATE FUNCTION default_foo_dali_udf5_UnsupportedUDF as 'com.linkedin.coral.hive.hive2rel.CoralTestUnsupportedUDF'");
     run(driver,
         "create function default_foo_lateral_udtf_CountOfRow as 'com.linkedin.coral.hive.hive2rel.CoralTestUDTF'");
+    run(driver,
+        "create function default_foo_duplicate_udf_LessThanHundred as 'com.linkedin.coral.hive.hive2rel.CoralTestUDF'");
 
     run(driver, String.join("\n", "", "CREATE VIEW IF NOT EXISTS foo_view", "AS", "SELECT b AS bcol, sum(c) AS sum_c",
         "FROM foo", "GROUP BY b"));
@@ -205,6 +207,13 @@ public class TestUtils {
     run(driver, "CREATE TABLE IF NOT EXISTS nested_union(a uniontype<int, struct<a:uniontype<int, double>, b:int>>)");
 
     run(driver, "CREATE VIEW IF NOT EXISTS view_expand_array_index AS SELECT c[1] c1 FROM default.complex");
+
+    run(driver,
+        String.join("\n", "", "CREATE VIEW IF NOT EXISTS foo_duplicate_udf",
+            "tblproperties('functions' = 'LessThanHundred:com.linkedin.coral.hive.hive2rel.CoralTestUDF',",
+            "              'dependencies' = 'ivy://com.linkedin:udf:1.0')", "AS",
+            "SELECT default_foo_duplicate_udf_LessThanHundred(a), default_foo_duplicate_udf_LessThanHundred(a)",
+            "FROM foo"));
   }
 
   public static RelNode toRelNode(String db, String view) {


### PR DESCRIPTION
### Summary
This PR deduplicates `sparkUDFInfoList` to avoid registering the same UDF many times in Spark. Didn't choose to use `Set` in `CoralSpark` and `SparkRelInfo` directly because it needs modifications from Spark side.

### Tests
1. Unit test
2. i-test