### PR TITLE
coral-schema: Handle NULL type schema in setupNestedNamespace

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -691,6 +691,7 @@ class SchemaUtilities {
     Preconditions.checkNotNull(namespace);
 
     switch (schema.getType()) {
+      case NULL:
       case BOOLEAN:
       case BYTES:
       case DOUBLE:

--- a/coral-schema/src/test/resources/base-complex-union-type.avsc
+++ b/coral-schema/src/test/resources/base-complex-union-type.avsc
@@ -4,6 +4,6 @@
   "namespace" : "coral.schema.avro.base.complex.union.type",
   "fields" : [ {
     "name" : "unionCol",
-    "type" : [ "int", "string" ]
+    "type" : [ "null", "int", "string" ]
   } ]
 }

--- a/coral-schema/src/test/resources/testComplexUnionType-expected.avsc
+++ b/coral-schema/src/test/resources/testComplexUnionType-expected.avsc
@@ -4,6 +4,6 @@
   "namespace" : "default.v",
   "fields" : [ {
     "name" : "unionCol",
-    "type" : [ "int", "string" ]
+    "type" : [ "null", "int", "string" ]
   } ]
 }


### PR DESCRIPTION
This patch fixes the bug where the `setupNestedNamespace` method failed to handle `NULL` primitive type in Avro, which makes it fail to handle complex union view RelNode to Avro schema conversion in `ViewToAvroSchemaConverterTests.testComplexUnionType()`.