### PR TITLE
Coral-Schema: Respect column names provided by Hive for unnamed columns

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
@@ -202,9 +202,8 @@ public class RelToAvroSchemaConverter {
       Queue<String> suggestedFieldNames = new LinkedList<>();
 
       for (int i = 0; i < logicalProject.getChildExps().size(); ++i) {
-        final RexNode rexNode = logicalProject.getChildExps().get(i);
         final String fieldName = logicalProject.getRowType().getFieldList().get(i).getName();
-        if (rexNode instanceof RexLiteral && fieldName.toLowerCase().startsWith("expr$")) {
+        if (fieldName.startsWith("EXPR$")) {
           // we should respect the column names provided by Hive here for unnamed columns
           // i.e. EXPR$0 -> _c0
           suggestedFieldNames.offer("_c" + fieldName.substring(5));

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -943,7 +943,7 @@ public class ViewToAvroSchemaConverterTests {
 
   @Test
   public void testUnnamedColumnSchemaName() {
-    String viewSql = "CREATE VIEW foo_unnamed_column " + "AS " + "SELECT 1, 'foo' FROM basecomplex bc";
+    String viewSql = "CREATE VIEW foo_unnamed_column " + "AS " + "SELECT 1 + 1, 'foo' FROM basecomplex bc";
 
     TestUtils.executeCreateViewQuery("default", "foo_unnamed_column", viewSql);
 

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -941,5 +941,16 @@ public class ViewToAvroSchemaConverterTests {
         TestUtils.loadSchema("testProjectUdfReturnedStruct-expected.avsc"));
   }
 
+  @Test
+  public void testUnnamedColumnSchemaName() {
+    String viewSql = "CREATE VIEW foo_unnamed_column " + "AS " + "SELECT 1, 'foo' FROM basecomplex bc";
+
+    TestUtils.executeCreateViewQuery("default", "foo_unnamed_column", viewSql);
+
+    ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);
+    Schema actualSchema = viewToAvroSchemaConverter.toAvroSchema("default", "foo_unnamed_column");
+
+    Assert.assertEquals(actualSchema.toString(true), TestUtils.loadSchema("testUnnamedColumnSchemaName-expected.avsc"));
+  }
   // TODO: add more unit tests
 }

--- a/coral-schema/src/test/resources/docTestResources/testSelectWithLiterals-expected-with-doc.avsc
+++ b/coral-schema/src/test/resources/docTestResources/testSelectWithLiterals-expected-with-doc.avsc
@@ -11,7 +11,7 @@
     "type" : [ "null", "int" ],
     "doc" : "Field created from view literal with value: 100"
   }, {
-    "name" : "EXPR_2",
+    "name" : "_c2",
     "type" : [ "null", "int" ],
     "doc" : "Field created from view literal with value: 200"
   }, {

--- a/coral-schema/src/test/resources/testAggregate-expected.avsc
+++ b/coral-schema/src/test/resources/testAggregate-expected.avsc
@@ -6,11 +6,11 @@
     "name" : "Id_View_Col",
     "type" : "int"
   }, {
-    "name" : "EXPR_1",
+    "name" : "_c1",
     "type" : [ "null", "long" ],
     "doc" : "Field created in view by applying aggregate function of type: COUNT"
   }, {
-    "name" : "EXPR_2",
+    "name" : "_c2",
     "type" : [ "null", "int" ],
     "doc" : "Field created in view by applying operator '+' with argument(s): 1, 1"
   }, {

--- a/coral-schema/src/test/resources/testNullabilitySqlOperator-expected.avsc
+++ b/coral-schema/src/test/resources/testNullabilitySqlOperator-expected.avsc
@@ -3,43 +3,43 @@
   "name" : "v",
   "namespace" : "default.v",
   "fields" : [ {
-    "name" : "EXPR_0",
+    "name" : "_c0",
     "type" : [ "null", "int" ],
     "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.nullability.basenullability.Id, coral.schema.avro.base.nullability.basenullability.Int_Field_1"
   }, {
-    "name" : "EXPR_1",
+    "name" : "_c1",
     "type" : "int",
     "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.nullability.basenullability.Id, coral.schema.avro.base.nullability.basenullability.Int_Field_2"
   }, {
-    "name" : "EXPR_2",
+    "name" : "_c2",
     "type" : [ "null", "int" ],
     "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.nullability.basenullability.Int_Field_1, coral.schema.avro.base.nullability.basenullability.Int_Field_1"
   }, {
-    "name" : "EXPR_3",
+    "name" : "_c3",
     "type" : [ "null", "int" ],
     "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.nullability.basenullability.Int_Field_1, 1"
   }, {
-    "name" : "EXPR_4",
+    "name" : "_c4",
     "type" : [ "null", "int" ],
     "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.nullability.basenullability.Int_Field_2, 1"
   }, {
-    "name" : "EXPR_5",
+    "name" : "_c5",
     "type" : [ "null", "double" ],
     "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.nullability.basenullability.Double_Field_1, coral.schema.avro.base.nullability.basenullability.Double_Field_1"
   }, {
-    "name" : "EXPR_6",
+    "name" : "_c6",
     "type" : "double",
     "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.nullability.basenullability.Double_Field_2, coral.schema.avro.base.nullability.basenullability.Double_Field_2"
   }, {
-    "name" : "EXPR_7",
+    "name" : "_c7",
     "type" : [ "null", "double" ],
     "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.nullability.basenullability.Double_Field_1, coral.schema.avro.base.nullability.basenullability.Double_Field_2"
   }, {
-    "name" : "EXPR_8",
+    "name" : "_c8",
     "type" : [ "null", "boolean" ],
     "doc" : "Field created in view by applying operator 'NOT' with argument(s): coral.schema.avro.base.nullability.basenullability.Bool_Field_1"
   }, {
-    "name" : "EXPR_9",
+    "name" : "_c9",
     "type" : "boolean",
     "doc" : "Field created in view by applying operator 'NOT' with argument(s): coral.schema.avro.base.nullability.basenullability.Bool_Field_2"
   } ]

--- a/coral-schema/src/test/resources/testNullabilityUdf-expected.avsc
+++ b/coral-schema/src/test/resources/testNullabilityUdf-expected.avsc
@@ -3,79 +3,79 @@
   "name" : "foo_dali_udf_nullability",
   "namespace" : "default.foo_dali_udf_nullability",
   "fields" : [ {
-    "name" : "EXPR_0",
+    "name" : "_c0",
     "type" : [ "null", "boolean" ],
     "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF1' with argument(s): coral.schema.avro.base.nullability.basenullability.Int_Field_1"
   }, {
-    "name" : "EXPR_1",
+    "name" : "_c1",
     "type" : "boolean",
     "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF1' with argument(s): coral.schema.avro.base.nullability.basenullability.Int_Field_2"
   }, {
-    "name" : "EXPR_2",
+    "name" : "_c2",
     "type" : [ "null", "boolean" ],
     "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF2' with argument(s): coral.schema.avro.base.nullability.basenullability.Int_Field_1"
   }, {
-    "name" : "EXPR_3",
+    "name" : "_c3",
     "type" : "boolean",
     "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF2' with argument(s): coral.schema.avro.base.nullability.basenullability.Int_Field_2"
   }, {
-    "name" : "EXPR_4",
+    "name" : "_c4",
     "type" : [ "null", "int" ],
     "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF3' with argument(s): coral.schema.avro.base.nullability.basenullability.Int_Field_1"
   }, {
-    "name" : "EXPR_5",
+    "name" : "_c5",
     "type" : "int",
     "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF3' with argument(s): coral.schema.avro.base.nullability.basenullability.Int_Field_2"
   }, {
-    "name" : "EXPR_6",
+    "name" : "_c6",
     "type" : [ "null", "boolean" ],
     "doc" : "Field created in view by applying operator 'AND' with argument(s): value with type BOOLEAN, value with type BOOLEAN"
   }, {
-    "name" : "EXPR_7",
+    "name" : "_c7",
     "type" : [ "null", "boolean" ],
     "doc" : "Field created in view by applying operator 'OR' with argument(s): value with type BOOLEAN, value with type BOOLEAN"
   }, {
-    "name" : "EXPR_8",
+    "name" : "_c8",
     "type" : [ "null", "int" ],
     "doc" : "Field created in view by applying operator '+' with argument(s): value with type INTEGER, coral.schema.avro.base.nullability.basenullability.Id"
   }, {
-    "name" : "EXPR_9",
+    "name" : "_c9",
     "type" : "int",
     "doc" : "Field created in view by applying operator '+' with argument(s): value with type INTEGER, coral.schema.avro.base.nullability.basenullability.Id"
   }, {
-    "name" : "EXPR_10",
+    "name" : "_c10",
     "type" : [ "null", "string" ],
     "doc" : "Field created in view by applying UDF 'concat' with argument(s): coral.schema.avro.base.nullability.basenullability.String_Field_1, coral.schema.avro.base.nullability.basenullability.String_Field_1"
   }, {
-    "name" : "EXPR_11",
+    "name" : "_c11",
     "type" : "string",
     "doc" : "Field created in view by applying UDF 'concat' with argument(s): coral.schema.avro.base.nullability.basenullability.String_Field_2, coral.schema.avro.base.nullability.basenullability.String_Field_2"
   }, {
-    "name" : "EXPR_12",
+    "name" : "_c12",
     "type" : [ "null", "string" ],
     "doc" : "Field created in view by applying UDF 'concat' with argument(s): coral.schema.avro.base.nullability.basenullability.String_Field_1, coral.schema.avro.base.nullability.basenullability.String_Field_2"
   }, {
-    "name" : "EXPR_13",
+    "name" : "_c13",
     "type" : [ "null", "int" ],
     "doc" : "Field created in view by applying operator '+' with argument(s): value with type INTEGER, 1"
   }, {
-    "name" : "EXPR_14",
+    "name" : "_c14",
     "type" : [ "null", "int" ],
     "doc" : "Field created in view by applying operator '+' with argument(s): value with type INTEGER, 1"
   }, {
-    "name" : "EXPR_15",
+    "name" : "_c15",
     "type" : "int",
     "doc" : "Field created in view by applying operator '+' with argument(s): value with type INTEGER, coral.schema.avro.base.nullability.basenullability.Id"
   }, {
-    "name" : "EXPR_16",
+    "name" : "_c16",
     "type" : [ "null", "int" ],
     "doc" : "Field created in view by applying operator '+' with argument(s): value with type INTEGER, coral.schema.avro.base.nullability.basenullability.Id"
   }, {
-    "name" : "EXPR_17",
+    "name" : "_c17",
     "type" : "int",
     "doc" : "Field created in view by applying operator '+' with argument(s): value with type INTEGER, coral.schema.avro.base.nullability.basenullability.Id"
   }, {
-    "name" : "EXPR_18",
+    "name" : "_c18",
     "type" : "int",
     "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.nullability.basenullability.Id, value with type INTEGER"
   } ]

--- a/coral-schema/src/test/resources/testRexCallAggregateMultiple-expected.avsc
+++ b/coral-schema/src/test/resources/testRexCallAggregateMultiple-expected.avsc
@@ -14,11 +14,11 @@
     "type" : [ "null", "int" ],
     "doc" : "Field created in view by applying operator '*' with argument(s): 33, value with type BIGINT"
   }, {
-    "name" : "EXPR_3",
+    "name" : "_c3",
     "type" : [ "null", "long" ],
     "doc" : "Field created in view by applying aggregate function of type: COUNT"
   }, {
-    "name" : "EXPR_4",
+    "name" : "_c4",
     "type" : [ "null", "long" ],
     "doc" : "Field created in view by applying aggregate function of type: COUNT"
   } ]

--- a/coral-schema/src/test/resources/testSelectWithLiterals-expected.avsc
+++ b/coral-schema/src/test/resources/testSelectWithLiterals-expected.avsc
@@ -10,7 +10,7 @@
     "type" : [ "null", "int" ],
     "doc" : "Field created from view literal with value: 100"
   }, {
-    "name" : "EXPR_2",
+    "name" : "_c2",
     "type" : [ "null", "int" ],
     "doc" : "Field created from view literal with value: 200"
   }, {

--- a/coral-schema/src/test/resources/testSelectWithMultipleLiterals-expected.avsc
+++ b/coral-schema/src/test/resources/testSelectWithMultipleLiterals-expected.avsc
@@ -3,11 +3,11 @@
   "name" : "v",
   "namespace" : "default.v",
   "fields" : [ {
-    "name" : "EXPR_0",
+    "name" : "_c0",
     "type" : [ "null", "int" ],
     "doc" : "Field created from view literal with value: 200"
   }, {
-    "name" : "EXPR_1",
+    "name" : "_c1",
     "type" : [ "null", "int" ],
     "doc" : "Field created from view literal with value: 1"
   }, {
@@ -18,19 +18,19 @@
     "type" : [ "null", "int" ],
     "doc" : "Field created from view literal with value: 100"
   }, {
-    "name" : "EXPR_4",
+    "name" : "_c4",
     "type" : [ "null", "int" ],
     "doc" : "Field created from view literal with value: 200"
   }, {
-    "name" : "EXPR_5",
+    "name" : "_c5",
     "type" : [ "null", "int" ],
     "doc" : "Field created from view literal with value: 1"
   }, {
-    "name" : "EXPR_6",
+    "name" : "_c6",
     "type" : [ "null", "int" ],
     "doc" : "Field created from view literal with value: 1"
   }, {
-    "name" : "EXPR_7",
+    "name" : "_c7",
     "type" : [ "null", "int" ],
     "doc" : "Field created from view literal with value: 1"
   }, {

--- a/coral-schema/src/test/resources/testUdfWithOperator-expected.avsc
+++ b/coral-schema/src/test/resources/testUdfWithOperator-expected.avsc
@@ -6,35 +6,35 @@
     "name" : "Id_Viewc_Col",
     "type" : "int"
   }, {
-    "name" : "EXPR_1",
+    "name" : "_c1",
     "type" : "boolean",
     "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF1' with argument(s): coral.schema.avro.base.complex.basecomplex.Id"
   }, {
-    "name" : "EXPR_2",
+    "name" : "_c2",
     "type" : "boolean",
     "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF2' with argument(s): coral.schema.avro.base.complex.basecomplex.Id"
   }, {
-    "name" : "EXPR_3",
+    "name" : "_c3",
     "type" : "int",
     "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDF3' with argument(s): coral.schema.avro.base.complex.basecomplex.Id"
   }, {
-    "name" : "EXPR_4",
+    "name" : "_c4",
     "type" : [ "null", "int" ],
     "doc" : "Field created in view by applying operator '+' with argument(s): 1, 1"
   }, {
-    "name" : "EXPR_5",
+    "name" : "_c5",
     "type" : [ "null", "int" ],
     "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.complex.basecomplex.Id, 1"
   }, {
-    "name" : "EXPR_6",
+    "name" : "_c6",
     "type" : [ "null", "int" ],
     "doc" : "Field created in view by applying operator '+' with argument(s): value with type INTEGER, 1"
   }, {
-    "name" : "EXPR_7",
+    "name" : "_c7",
     "type" : [ "null", "int" ],
     "doc" : "Field created in view by applying operator '+' with argument(s): value with type INTEGER, 1"
   }, {
-    "name" : "EXPR_8",
+    "name" : "_c8",
     "type" : "int",
     "doc" : "Field created in view by applying operator '+' with argument(s): coral.schema.avro.base.complex.basecomplex.Id, value with type INTEGER"
   } ]

--- a/coral-schema/src/test/resources/testUnnamedColumnSchemaName-expected.avsc
+++ b/coral-schema/src/test/resources/testUnnamedColumnSchemaName-expected.avsc
@@ -1,0 +1,14 @@
+{
+  "type" : "record",
+  "name" : "foo_unnamed_column",
+  "namespace" : "default.foo_unnamed_column",
+  "fields" : [ {
+    "name" : "_c0",
+    "type" : [ "null", "int" ],
+    "doc" : "Field created from view literal with value: 1"
+  }, {
+    "name" : "_c1",
+    "type" : [ "null", "string" ],
+    "doc" : "Field created from view literal with value: \"foo\""
+  } ]
+}

--- a/coral-schema/src/test/resources/testUnnamedColumnSchemaName-expected.avsc
+++ b/coral-schema/src/test/resources/testUnnamedColumnSchemaName-expected.avsc
@@ -5,7 +5,7 @@
   "fields" : [ {
     "name" : "_c0",
     "type" : [ "null", "int" ],
-    "doc" : "Field created from view literal with value: 1"
+    "doc" : "Field created in view by applying operator '+' with argument(s): 1, 1"
   }, {
     "name" : "_c1",
     "type" : [ "null", "string" ],


### PR DESCRIPTION
### Summary
This PR is to solve #212 
For unnamed columns, we should convert the name to the one provided by Hive. i.e. `EXPR$0 -> _c0`

### Tests
1. Unit tests
2. i-test