### PR TITLE
Increase maxRetries for gradle-nexus.publish-plugin

### DIFF
--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -1,4 +1,3 @@
-import java.time.Duration
 //Plugin jars are added to the buildscript classpath in the root build.gradle file
 apply plugin: "org.shipkit.shipkit-auto-version" //https://github.com/shipkit/shipkit-auto-version
 
@@ -31,6 +30,5 @@ nexusPublishing {
   }
   transitionCheckOptions {
     maxRetries.set(100)
-    delayBetween.set(Duration.ofSeconds(10))
   }
 }

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -1,3 +1,4 @@
+import java.time.Duration
 //Plugin jars are added to the buildscript classpath in the root build.gradle file
 apply plugin: "org.shipkit.shipkit-auto-version" //https://github.com/shipkit/shipkit-auto-version
 
@@ -27,5 +28,9 @@ nexusPublishing {
         password = System.getenv("SONATYPE_PWD")
       }
     }
+  }
+  transitionCheckOptions {
+    maxRetries.set(100)
+    delayBetween.set(Duration.ofSeconds(5))
   }
 }

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -31,6 +31,6 @@ nexusPublishing {
   }
   transitionCheckOptions {
     maxRetries.set(100)
-    delayBetween.set(Duration.ofSeconds(5))
+    delayBetween.set(Duration.ofSeconds(10))
   }
 }


### PR DESCRIPTION
The default value of `maxRetries` is 60 (https://github.com/gradle-nexus/publish-plugin/pull/135/files), we increase it to 100, which may help to avoid the releasing issue like https://github.com/linkedin/coral/runs/4549508308