### PR TITLE
Cast current_timestamp to timestamp

### DIFF
--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -143,7 +143,7 @@ public class HiveToTrinoConverterTest {
         { "test", "map_array_view", "SELECT MAP (ARRAY['key1', 'key2'], ARRAY['value1', 'value2']) AS \"simple_map_col\", "
             + "MAP (ARRAY['key1', 'key2'], ARRAY[MAP (ARRAY['a', 'c'], ARRAY['b', 'd']), MAP (ARRAY['a', 'c'], ARRAY['b', 'd'])]) AS \"nested_map_col\"\nFROM \"test\".\"tablea\"" },
 
-        { "test", "current_date_and_timestamp_view", "SELECT CURRENT_TIMESTAMP, TRIM(CAST(CURRENT_TIMESTAMP AS VARCHAR(65535))) AS \"ct\", CURRENT_DATE, CURRENT_DATE AS \"cd\", \"a\"\nFROM \"test\".\"tablea\"" },
+        { "test", "current_date_and_timestamp_view", "SELECT CAST(CURRENT_TIMESTAMP AS TIMESTAMP(3)), TRIM(CAST(CAST(CURRENT_TIMESTAMP AS TIMESTAMP(3)) AS VARCHAR(65535))) AS \"ct\", CURRENT_DATE, CURRENT_DATE AS \"cd\", \"a\"\nFROM \"test\".\"tablea\"" },
 
         { "test", "date_function_view", "SELECT \"date\"('2021-01-02') AS \"a\"\n" + "FROM \"test\".\"tablea\"" },
 

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverterTest.java
@@ -471,8 +471,8 @@ public class RelToTrinoConverterTest {
   @Test
   public void testCurrentTimestamp() {
     String sql = "SELECT current_timestamp";
-    String expected =
-        formatSql("SELECT CURRENT_TIMESTAMP AS \"CURRENT_TIMESTAMP\"\nFROM (VALUES  (0)) AS \"t\" (\"ZERO\")");
+    String expected = formatSql(
+        "SELECT CAST(CURRENT_TIMESTAMP AS TIMESTAMP(3)) AS \"CURRENT_TIMESTAMP\"\nFROM (VALUES  (0)) AS \"t\" (\"ZERO\")");
     testConversion(sql, expected);
   }
 

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
@@ -144,8 +144,8 @@ public class TestUtils {
       String replacement = null;
       String alias = m.group(1);
       if (alias.equalsIgnoreCase("integer") || alias.equalsIgnoreCase("double") || alias.equalsIgnoreCase("boolean")
-          || alias.equalsIgnoreCase("varchar") || alias.equalsIgnoreCase("real")
-          || alias.equalsIgnoreCase("varbinary")) {
+          || alias.equalsIgnoreCase("varchar") || alias.equalsIgnoreCase("real") || alias.equalsIgnoreCase("varbinary")
+          || alias.equalsIgnoreCase("timestamp")) {
         replacement = "AS " + alias.toUpperCase();
       } else {
         replacement = "AS \"" + m.group(1).toUpperCase() + "\"";


### PR DESCRIPTION
### Summary
This PR fixes https://github.com/trinodb/trino/issues/5688

Hive's `current_timestamp` returns `TIMESTAMP` while Trino's `current_timestamp` returns `TIMESTAMP WITH TIME ZONE`, which cannot be coerced into `TIMESTAMP` type. This fix adds the cast `CAST(current_timestamp AS TIMESTAMP(3))`

If this seems like the right way to fix it, we could consider supporting current_timestamp(n) for completeness of the intermediate representation

### Testing
Update unit test in RelToTrino and HiveToTrino

Added/ran Trino unit tests locally for correctness (not equality of results)