### PR TITLE
Coral-Spark: Convert back for LATERAL VIEW OUTER EXPLODE

### DIFF
--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -218,8 +218,8 @@ public class CoralSparkTest {
     System.out.println(relNodePlan);
     String convertToSparkSql = CoralSpark.create(relNode).getSparkSql();
 
-    String targetSql = "SELECT complex.a, t0.ccol\n"
-        + "FROM default.complex LATERAL VIEW OUTER EXPLODE(if(complex.c IS NOT NULL AND size(complex.c) > 0, complex.c, ARRAY (NULL))) t0 AS ccol";
+    String targetSql =
+        "SELECT complex.a, t0.ccol\n" + "FROM default.complex LATERAL VIEW OUTER EXPLODE(complex.c) t0 AS ccol";
     assertEquals(convertToSparkSql, targetSql);
   }
 
@@ -245,8 +245,8 @@ public class CoralSparkTest {
   public void testLateralViewMapOuter() {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT a, t.ccol1, t.ccol2", "FROM complex",
         "LATERAL VIEW OUTER explode(complex.m) t as ccol1, ccol2"));
-    String targetSql = String.join("\n", "SELECT complex.a, t0.ccol1, t0.ccol2",
-        "FROM default.complex LATERAL VIEW OUTER EXPLODE(if(complex.m IS NOT NULL AND size(complex.m) > 0, complex.m, MAP (NULL, NULL))) t0 AS ccol1, ccol2");
+    String targetSql = "SELECT complex.a, t0.ccol1, t0.ccol2\n"
+        + "FROM default.complex LATERAL VIEW OUTER EXPLODE(complex.m) t0 AS ccol1, ccol2";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -537,8 +537,8 @@ public class CoralSparkTest {
     RelNode relNode = TestUtils
         .toRelNode("SELECT arr.alias FROM foo tmp LATERAL VIEW OUTER POSEXPLODE(ARRAY('a', 'b')) arr AS pos, alias");
 
-    String targetSql = "SELECT t0.alias\n"
-        + "FROM default.foo LATERAL VIEW OUTER POSEXPLODE(if(ARRAY ('a', 'b') IS NOT NULL AND size(ARRAY ('a', 'b')) > 0, ARRAY ('a', 'b'), ARRAY (NULL))) t0 AS pos, alias";
+    String targetSql =
+        "SELECT t0.alias\n" + "FROM default.foo LATERAL VIEW OUTER POSEXPLODE(ARRAY ('a', 'b')) t0 AS pos, alias";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 


### PR DESCRIPTION
### Summary
Given Spark supports `LATERAL VIEW OUTER EXPLODE` itself, we don't need to transform `unnest(b)` to `unnest(if(b is null or cardinality(b) = 0, ARRAY(null)/MAP(null, null), b))` in https://github.com/linkedin/coral/blob/3e388ab839e199270fe81189be14fc0bf9312dce/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java#L223-L243.
But we don't want to remove this part of code given it's still useful for Trino translation and any other engines which don't support `LATERAL VIEW OUTER EXPLODE`, so we can convert it back in Coral-Spark.

i.e. this PR converts
```
LATERAL VIEW OUTER EXPLODE(if(array_struct_table.as IS NOT NULL AND size(array_struct_table.as) > 0,
array_struct_table.as, ARRAY (NULL))) t0 AS exploded_results a
```
back to 
```
LATERAL VIEW OUTER EXPLODE(array_struct_table.as) t0 AS exploded_results a
```
We need to do this conversion because if `array_struct_table.as` is an array of struct, query using previous translated Spark SQL will fail with the exception like:
```
java.lang.ClassCastException: org.apache.spark.sql.types.NullType$ cannot be cast to org.apache.spark.sql.types.StructType
```

### Tests
1. Modified unit tests
2. Test on affected production views with Spark-shell
3. i-test