### PR TITLE
Add sonatype settings and apply spotless check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath "io.github.gradle-nexus:publish-plugin:1.0.0"
+    classpath "io.github.gradle-nexus:publish-plugin:1.1.0"
     classpath "org.shipkit:shipkit-auto-version:1.1.1"
     classpath "org.shipkit:shipkit-changelog:1.1.10"
   }

--- a/coral-common/src/main/java/com/linkedin/coral/common/FuzzyUnionSqlRewriter.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/FuzzyUnionSqlRewriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/HiveDbSchema.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/HiveDbSchema.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/HiveMetastoreClient.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/HiveMetastoreClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/HiveMscAdapter.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/HiveMscAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/HiveSchema.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/HiveSchema.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/HiveSchemaUtils.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/HiveSchemaUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/HiveTable.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/HiveTable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/HiveTypeSystem.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/HiveTypeSystem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/HiveViewTable.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/HiveViewTable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/LocalMetastoreHiveDbSchema.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/LocalMetastoreHiveDbSchema.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/LocalMetastoreHiveSchema.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/LocalMetastoreHiveSchema.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/LocalMetastoreHiveTable.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/LocalMetastoreHiveTable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2020-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/ToRelConverter.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/ToRelConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/TypeConverter.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/TypeConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/calcite/CalciteUtil.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/calcite/CalciteUtil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2021-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/functions/Function.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/functions/Function.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionFieldReferenceOperator.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionFieldReferenceOperator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionRegistry.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionRegistry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionReturnTypes.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionReturnTypes.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/functions/GenericProjectFunction.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/functions/GenericProjectFunction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/functions/OperandTypeInference.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/functions/OperandTypeInference.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/functions/SameOperandTypeExceptFirstOperandChecker.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/functions/SameOperandTypeExceptFirstOperandChecker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/functions/UnknownSqlFunctionException.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/functions/UnknownSqlFunctionException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/DaliOperatorTable.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/DaliOperatorTable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveConvertletTable.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveConvertletTable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveRelBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveRelBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2021-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveSqlConformance.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveSqlConformance.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2021-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveSqlToRelConverter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveSqlToRelConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveSqlValidator.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveSqlValidator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveViewExpander.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveViewExpander.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/ArtifactsResolver.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/ArtifactsResolver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2020-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveExplodeOperator.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveExplodeOperator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveFunction.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveFunction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveFunctionResolver.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveFunctionResolver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveGenericUDFReturnTypeInference.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveGenericUDFReturnTypeInference.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2020-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HivePosExplodeOperator.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HivePosExplodeOperator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveReflectOperator.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveReflectOperator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/VersionedSqlUserDefinedFunction.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/VersionedSqlUserDefinedFunction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/AbstractASTVisitor.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/AbstractASTVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/UnexpectedASTChildCountException.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/UnexpectedASTChildCountException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/UnhandledASTTokenException.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/UnhandledASTTokenException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/parser/ASTErrorNode.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/parser/ASTErrorNode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/parser/ASTNode.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/parser/ASTNode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/parser/CoralParseDriver.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/parser/CoralParseDriver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2021-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/parser/ParseDriver.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/parser/ParseDriver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/parser/ParseException.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/parser/ParseException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/rel/HiveUncollect.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/rel/HiveUncollect.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/test/java/com/linkedin/coral/common/ToRelConverterTestUtils.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/common/ToRelConverterTestUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveMetastoreClientProvider.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveMetastoreClientProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveOperatorsTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveOperatorsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveSchemaTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveSchemaTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveTableTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveTableTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/LateralViewTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/LateralViewTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/NamedStructTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/NamedStructTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/TestUtils.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/TestUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtilityTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtilityTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-pig/src/main/java/com/linkedin/coral/pig/rel2pig/RelToPigBuilder.java
+++ b/coral-pig/src/main/java/com/linkedin/coral/pig/rel2pig/RelToPigBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-pig/src/main/java/com/linkedin/coral/pig/rel2pig/RelToPigLatinConverter.java
+++ b/coral-pig/src/main/java/com/linkedin/coral/pig/rel2pig/RelToPigLatinConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-pig/src/main/java/com/linkedin/coral/pig/rel2pig/rel/PigLogicalAggregate.java
+++ b/coral-pig/src/main/java/com/linkedin/coral/pig/rel2pig/rel/PigLogicalAggregate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-pig/src/main/java/com/linkedin/coral/pig/rel2pig/rel/functions/PigBuiltinFunction.java
+++ b/coral-pig/src/main/java/com/linkedin/coral/pig/rel2pig/rel/functions/PigBuiltinFunction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-pig/src/main/java/com/linkedin/coral/pig/rel2pig/rel/operators/PigBinaryOperator.java
+++ b/coral-pig/src/main/java/com/linkedin/coral/pig/rel2pig/rel/operators/PigBinaryOperator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-pig/src/main/java/com/linkedin/coral/pig/rel2pig/rel/operators/PigPrefixOperator.java
+++ b/coral-pig/src/main/java/com/linkedin/coral/pig/rel2pig/rel/operators/PigPrefixOperator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-pig/src/main/java/com/linkedin/coral/pig/rel2pig/rel/operators/PigSpecialOperator.java
+++ b/coral-pig/src/main/java/com/linkedin/coral/pig/rel2pig/rel/operators/PigSpecialOperator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-pig/src/test/java/com/linkedin/coral/pig/rel2pig/CalcitePigUDFTest.java
+++ b/coral-pig/src/test/java/com/linkedin/coral/pig/rel2pig/CalcitePigUDFTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-pig/src/test/java/com/linkedin/coral/pig/rel2pig/RelToPigLatinConverterTest.java
+++ b/coral-pig/src/test/java/com/linkedin/coral/pig/rel2pig/RelToPigLatinConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-pig/src/test/java/com/linkedin/coral/pig/rel2pig/TestUtils.java
+++ b/coral-pig/src/test/java/com/linkedin/coral/pig/rel2pig/TestUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/AvroSchemaVisitor.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/AvroSchemaVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2021-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvro.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvro.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2021-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/TypeInfoToAvroSchemaConverter.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/TypeInfoToAvroSchemaConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverter.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/test/java/com/linkedin/coral/hive/hive2rel/CoralTestUDFReturnStruct.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/hive/hive2rel/CoralTestUDFReturnStruct.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2021-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroTypeTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroTypeTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2020-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark-plan/src/main/java/com/linkedin/coral/sparkplan/SparkPlanToIRRelConverter.java
+++ b/coral-spark-plan/src/main/java/com/linkedin/coral/sparkplan/SparkPlanToIRRelConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2020-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark-plan/src/test/java/com/linkedin/coral/sparkplan/SparkPlanToIRRelConverterTest.java
+++ b/coral-spark-plan/src/test/java/com/linkedin/coral/sparkplan/SparkPlanToIRRelConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2020-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark-plan/src/test/java/com/linkedin/coral/sparkplan/TestUtils.java
+++ b/coral-spark-plan/src/test/java/com/linkedin/coral/sparkplan/TestUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2020-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/BuiltinUDFMap.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/BuiltinUDFMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/CoralSpark.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/CoralSpark.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/SparkRelToSparkSqlConverter.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/SparkRelToSparkSqlConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/SparkSqlRewriter.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/SparkSqlRewriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/TransportableUDFMap.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/TransportableUDFMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/UnsupportedHiveUDFsInSpark.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/UnsupportedHiveUDFsInSpark.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/containers/SparkRelInfo.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/containers/SparkRelInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/containers/SparkUDFInfo.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/containers/SparkUDFInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/dialect/SparkSqlDialect.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/dialect/SparkSqlDialect.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/functions/SqlLateralJoin.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/functions/SqlLateralJoin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/functions/SqlLateralViewAsOperator.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/functions/SqlLateralViewAsOperator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark/src/spark3test/java/com.linkedin.coral.spark/TransportableUDFMapTest.java
+++ b/coral-spark/src/spark3test/java/com.linkedin.coral.spark/TransportableUDFMapTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark/src/sparktest/java/com.linkedin.coral.spark/TransportableUDFMapTest.java
+++ b/coral-spark/src/sparktest/java/com.linkedin.coral.spark/TransportableUDFMapTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/FuzzyUnionViewTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/FuzzyUnionViewTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/utils/RelDataTypeToSparkDataTypeStringConverterTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/utils/RelDataTypeToSparkDataTypeStringConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/Calcite2TrinoUDFConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/Calcite2TrinoUDFConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CalciteTrinoUDFMap.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CalciteTrinoUDFMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CoralTrinoConfigKeys.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CoralTrinoConfigKeys.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2021-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoSqlDialect.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoSqlDialect.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoTryCastFunction.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoTryCastFunction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/UDFTransformer.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/UDFTransformer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/functions/GenericProjectToTrinoConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/functions/GenericProjectToTrinoConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/functions/GenericTemplateFunction.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/functions/GenericTemplateFunction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/functions/RelDataTypeToTrinoTypeStringConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/functions/RelDataTypeToTrinoTypeStringConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/functions/TrinoKeywordsConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/functions/TrinoKeywordsConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2020-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/trino2rel/CalciteSqlFormatter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/trino2rel/CalciteSqlFormatter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2021-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/trino2rel/ParseTreeBuilder.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/trino2rel/ParseTreeBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2021-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/trino2rel/ParserVisitorContext.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/trino2rel/ParserVisitorContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2021-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/trino2rel/PrestoParserDriver.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/trino2rel/PrestoParserDriver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2021-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/trino2rel/UnhandledASTNodeException.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/trino2rel/UnhandledASTNodeException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2021-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/UDFTransformerTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/UDFTransformerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/functions/RelDataTypeToTrinoTypeStringConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/functions/RelDataTypeToTrinoTypeStringConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/trino2rel/ParseTreeBuilderTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/trino2rel/ParseTreeBuilderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2021-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -25,6 +25,8 @@ nexusPublishing {
       sonatype {
         username = System.getenv("SONATYPE_USER")
         password = System.getenv("SONATYPE_PWD")
+        nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+        snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
       }
     }
   }


### PR DESCRIPTION
According to the [doc](https://github.com/gradle-nexus/publish-plugin):
```
Important. Users registered in Sonatype after 24 February 2021 need to customize the following URLs:

nexusPublishing {
    repositories {
        sonatype {  //only for users registered in Sonatype after 24 Feb 2021
            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
        }
    }
}
```
we need to add these settings for release.