### PR TITLE
coral-schema: return partition column as nullable

### DIFF
--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/CoralTestUDTF.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/CoralTestUDTF.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/HiveSchemaWithPartnerVisitor.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/HiveSchemaWithPartnerVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2021-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -386,7 +386,7 @@ class SchemaUtilities {
     }
 
     Schema partitionColumnsSchema =
-        convertFieldSchemaToAvroSchema("partitionCols", "partitionCols", false, tableOrView.getPartitionKeys());
+        convertFieldSchemaToAvroSchema("partitionCols", "partitionCols", true, tableOrView.getPartitionKeys());
 
     List<Schema.Field> fieldsWithPartitionColumns = cloneFieldList(schema.getFields());
     fieldsWithPartitionColumns.addAll(cloneFieldList(partitionColumnsSchema.getFields(), true));

--- a/coral-schema/src/test/java/com/linkedin/coral/hive/hive2rel/CoralTestUDTF.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/hive/hive2rel/CoralTestUDTF.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2020-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/test/resources/testBaseTableWithPartiton-expected.avsc
+++ b/coral-schema/src/test/resources/testBaseTableWithPartiton-expected.avsc
@@ -32,7 +32,8 @@
     } ]
   }, {
     "name" : "datepartition",
-    "type" : "string",
-    "doc" : "This is the partition column. Partition columns, if present in the schema, should also be projected in the data."
+    "type" : [ "null", "string" ],
+    "doc" : "This is the partition column. Partition columns, if present in the schema, should also be projected in the data.",
+    "default" : null
   } ]
 }

--- a/coral-schema/src/test/resources/testSelectStarFromNestComplex-expected.avsc
+++ b/coral-schema/src/test/resources/testSelectStarFromNestComplex-expected.avsc
@@ -148,7 +148,8 @@
     "default" : null
   }, {
     "name" : "datepartition",
-    "type" : "string",
-    "doc" : "This is the partition column. Partition columns, if present in the schema, should also be projected in the data."
+    "type" : [ "null", "string" ],
+    "doc" : "This is the partition column. Partition columns, if present in the schema, should also be projected in the data.",
+    "default" : null
   } ]
 }

--- a/coral-schema/src/test/resources/testSelectStarWithPartition.avsc
+++ b/coral-schema/src/test/resources/testSelectStarWithPartition.avsc
@@ -32,7 +32,8 @@
     } ]
   }, {
     "name" : "datepartition",
-    "type" : "string",
-    "doc" : "This is the partition column. Partition columns, if present in the schema, should also be projected in the data."
+    "type" : [ "null", "string" ],
+    "doc" : "This is the partition column. Partition columns, if present in the schema, should also be projected in the data.",
+    "default" : null
   } ]
 }

--- a/coral-schema/src/test/resources/testUnionPreserveNamespace.avsc
+++ b/coral-schema/src/test/resources/testUnionPreserveNamespace.avsc
@@ -32,7 +32,8 @@
     } ]
   }, {
     "name" : "datepartition",
-    "type" : "string",
-    "doc" : "This is the partition column. Partition columns, if present in the schema, should also be projected in the data."
+    "type" : [ "null", "string" ],
+    "doc" : "This is the partition column. Partition columns, if present in the schema, should also be projected in the data.",
+    "default" : null
   } ]
 }

--- a/coral-spark/src/test/java/com/linkedin/coral/hive/hive2rel/CoralTestUDTF.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/hive/hive2rel/CoralTestUDTF.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/functions/TrinoArrayTransformFunction.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/functions/TrinoArrayTransformFunction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */


### PR DESCRIPTION
This PR makes coral schema return partition column as nullable

1. Modified unit tests
2. itests (no regression)