### PR TITLE
Change trino-parser dependency to compileOnly (coral issue#205)

### DIFF
--- a/coral-trino/build.gradle
+++ b/coral-trino/build.gradle
@@ -3,8 +3,8 @@ apply from: "$rootDir/gradle/java-publication.gradle"
 dependencies {
   compile deps.'gson'
   compile deps.'javax-annotation'
-  compile deps.'trino-parser'
   compile project(path: ':coral-hive')
+  implementation deps.'trino-parser'
   implementation 'com.github.vertical-blank:sql-formatter:2.0.2'
 
   testCompile deps.'assertj'


### PR DESCRIPTION
A temporary fix to unblock issue coral #205
Shading trino-parser was done, however, it causes some IDEs (IntelliJ in particular) to not recognize trino-parser libraries, which makes the experience contributing to Coral suboptimal. With compileOnly/implementation, issue #205 is unblocked and we are to revisit all shading in Coral in the near future.