### PR TITLE
Coral-Schema: Correct nullability determination in coral-schema

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
@@ -15,7 +15,9 @@ import com.google.common.base.Preconditions;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.sql.type.SqlTypeTransforms;
 
 
 /**
@@ -50,22 +52,24 @@ public class CoalesceStructUtility {
    * def coalesce_struct(struct:struct_tr) : struct_ex = {...}
    * def coalesce_struct(struct:struct_tr, ordinal: int): field_at_ordinal = {...}
    *
+   * We want to make the inferred return type of this UDF always nullable.
    */
-  public static final SqlReturnTypeInference COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY = opBinding -> {
-    int numArgs = opBinding.getOperandCount();
-    RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
-    Preconditions.checkState(numArgs == 1 || numArgs == 2);
-    RelDataType coalescedDataType = coalesce(opBinding.getOperandType(0), typeFactory);
-    // 1-arg case
-    if (numArgs == 1) {
-      return coalescedDataType;
-    }
-    // 2-arg case
-    else {
-      int ordinal = opBinding.getOperandLiteralValue(1, Integer.class);
-      return coalescedDataType.getFieldList().get(ordinal).getType();
-    }
-  };
+  public static final SqlReturnTypeInference COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY =
+      ReturnTypes.cascade(opBinding -> {
+        int numArgs = opBinding.getOperandCount();
+        RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
+        Preconditions.checkState(numArgs == 1 || numArgs == 2);
+        RelDataType coalescedDataType = coalesce(opBinding.getOperandType(0), typeFactory);
+        // 1-arg case
+        if (numArgs == 1) {
+          return coalescedDataType;
+        }
+        // 2-arg case
+        else {
+          int ordinal = opBinding.getOperandLiteralValue(1, Integer.class);
+          return coalescedDataType.getFieldList().get(ordinal).getType();
+        }
+      }, SqlTypeTransforms.FORCE_NULLABLE);
   private static final String TRINO_PREFIX = "field";
   private static final String HIVE_EXTRACT_UNION_PREFIX = "tag_";
 

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
@@ -424,10 +424,10 @@ public class RelToAvroSchemaConverter {
        * For SqlUserDefinedFunction and SqlOperator RexCall, no need to handle it recursively
        * and only return type of udf or sql operator is relevant
        */
-      RelDataType fieldType = rexCall.getType();
-      boolean isNullable = SchemaUtilities.isFieldNullable(rexCall, inputSchema);
+      RelDataType inferredType = rexCall.getType();
+      boolean isNullable = inferredType.isNullable();
 
-      appendField(fieldType, isNullable,
+      appendField(inferredType, isNullable,
           SchemaUtilities.generateDocumentationForFunctionCall(rexCall, inputSchema, inputNode));
 
       return rexCall;
@@ -468,7 +468,7 @@ public class RelToAvroSchemaConverter {
         String newFieldName = SchemaUtilities.getFieldName(oldFieldName, suggestNewFieldName);
 
         RelDataType fieldType = rexFieldAccess.getType();
-        boolean isNullable = SchemaUtilities.isFieldNullable((RexCall) referenceExpr, inputSchema);
+        boolean isNullable = fieldType.isNullable();
         // TODO: add field documentation
         SchemaUtilities.appendField(newFieldName, fieldType, null, fieldAssembler, isNullable);
       } else {

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -217,32 +217,6 @@ class SchemaUtilities {
     }
   }
 
-  static boolean isFieldNullable(@Nonnull RexCall rexCall, @Nonnull Schema inputSchema) {
-    Preconditions.checkNotNull(rexCall);
-    Preconditions.checkNotNull(inputSchema);
-
-    // the field is non-nullable only if all operands are RexInputRef
-    // and corresponding field schema type of RexInputRef index is not UNION
-    List<RexNode> operands = rexCall.getOperands();
-    for (RexNode operand : operands) {
-      if (operand instanceof RexInputRef) {
-        Schema.Field field = inputSchema.getFields().get(((RexInputRef) operand).getIndex());
-        if (Schema.Type.UNION.equals(field.schema().getType())) {
-          return true;
-        }
-      } else if (operand instanceof RexCall) {
-        boolean isNullable = isFieldNullable((RexCall) operand, inputSchema);
-        if (isNullable) {
-          return true;
-        }
-      } else {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
   static void appendField(@Nonnull String fieldName, @Nonnull Schema.Field field,
       @Nonnull SchemaBuilder.FieldAssembler<Schema> fieldAssembler) {
     Preconditions.checkNotNull(fieldName);

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
@@ -70,11 +70,11 @@ public class TestUtils {
   public static void registerUdfs() {
     // add the following 3 test UDF to StaticHiveFunctionRegistry for testing purpose.
     StaticHiveFunctionRegistry.createAddUserDefinedFunction("com.linkedin.coral.hive.hive2rel.CoralTestUDF1",
-        ReturnTypes.BOOLEAN, family(SqlTypeFamily.INTEGER));
+        ReturnTypes.BOOLEAN_NULLABLE, family(SqlTypeFamily.INTEGER));
     StaticHiveFunctionRegistry.createAddUserDefinedFunction("com.linkedin.coral.hive.hive2rel.CoralTestUDF2",
-        ReturnTypes.BOOLEAN, family(SqlTypeFamily.INTEGER));
+        ReturnTypes.BOOLEAN_NULLABLE, family(SqlTypeFamily.INTEGER));
     StaticHiveFunctionRegistry.createAddUserDefinedFunction("com.linkedin.coral.hive.hive2rel.CoralTestUDF3",
-        ReturnTypes.INTEGER, family(SqlTypeFamily.INTEGER));
+        ReturnTypes.INTEGER_NULLABLE, family(SqlTypeFamily.INTEGER));
     StaticHiveFunctionRegistry.createAddUserDefinedTableFunction("com.linkedin.coral.hive.hive2rel.CoralTestUDTF",
         ImmutableList.of("col1"), ImmutableList.of(SqlTypeName.INTEGER), family(SqlTypeFamily.INTEGER));
     StaticHiveFunctionRegistry.createAddUserDefinedFunction(


### PR DESCRIPTION
During investigation of a extract_union view coral-schema schema conversion issue, I found a bigger problem in the nullability determination logic in the existing coral-schema module codebase.

The correct determination of the nullability should be using the `RelDataType`'s builtin `isNullable` method, this means, for example, to determine the nullability of a UDF's return type, we should use the UDF's `SqlReturnTypeInference` which when called on the given operands will return the inferred return `RelDataType` which contains the nullability information.

Coral-schema needs to return the correct nullability information to work with engines that have strict nullability checks like spark3.

The unit test failures are expected, because the code change covers the logic change in the main code but the framework and unit tests setup needs more changes to pass all tests.