### PR TITLE
Use compileOnly for trino-parser shading

### DIFF
--- a/shading/coral-trino-parser/build.gradle
+++ b/shading/coral-trino-parser/build.gradle
@@ -7,7 +7,7 @@ plugins {
 apply from: "$rootDir/gradle/java-publication.gradle"
 
 dependencies {
-  implementation 'io.trino:trino-parser:355'
+  compileOnly 'io.trino:trino-parser:355'
 }
 
 task relocateShadowJar(type: ConfigureShadowRelocation) {
@@ -16,6 +16,9 @@ task relocateShadowJar(type: ConfigureShadowRelocation) {
 }
 
 shadowJar {
+  configurations = [
+    project.configurations.compileOnly
+  ]
   dependsOn(relocateShadowJar)
 }
 


### PR DESCRIPTION
Tested it by publishing to local maven and integrating with Trino.