### PR TITLE
Force interring extract_union nullablity using Calcite

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -51,6 +51,8 @@ class SchemaUtilities {
   private static final Logger LOG = LoggerFactory.getLogger(SchemaUtilities.class);
   private static final String DALI_ROW_SCHEMA = "dali.row.schema";
 
+  // TODO: 2/2/22 Needs to refactor this into a separate registry class
+  // if the num of functions in this set get bigger
   private static final Set<String> USE_CALCITE_NULLABILITY_FUNCS =
       Collections.unmodifiableSet(new HashSet<>(Arrays.asList("extract_union")));
 

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -7,12 +7,7 @@ package com.linkedin.coral.schema.avro;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.StringJoiner;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -55,6 +50,9 @@ import static org.apache.avro.Schema.Type.NULL;
 class SchemaUtilities {
   private static final Logger LOG = LoggerFactory.getLogger(SchemaUtilities.class);
   private static final String DALI_ROW_SCHEMA = "dali.row.schema";
+
+  private static final Set<String> USE_CALCITE_NULLABILITY_FUNCS =
+      Collections.unmodifiableSet(new HashSet<>(Arrays.asList("extract_union")));
 
   // private constructor for utility class
   private SchemaUtilities() {
@@ -220,6 +218,12 @@ class SchemaUtilities {
   static boolean isFieldNullable(@Nonnull RexCall rexCall, @Nonnull Schema inputSchema) {
     Preconditions.checkNotNull(rexCall);
     Preconditions.checkNotNull(inputSchema);
+
+    // we first filter against these static list of functions, whose nullability should be
+    // determined by calcite rather than avro.schema.literal
+    if (USE_CALCITE_NULLABILITY_FUNCS.contains(rexCall.getOperator().getName().toLowerCase())) {
+      return rexCall.getType().isNullable();
+    }
 
     // the field is non-nullable only if all operands are RexInputRef
     // and corresponding field schema type of RexInputRef index is not UNION

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
@@ -95,6 +95,7 @@ public class TestUtils {
     String baseNullTypeFieldSchema = loadSchema("base-null-type-field.avsc");
     String baseTimestampTypeFieldSchema = loadSchema("base-timestamp-type-field.avsc");
     String baseComplexUnionTypeSchema = loadSchema("base-complex-union-type.avsc");
+    String baseNestedUnionSchema = loadSchema("base-nested-union.avsc");
 
     executeCreateTableQuery("default", "basecomplex", baseComplexSchema);
     executeCreateTableQuery("default", "basecomplexunioncompatible", baseComplexUnionCompatible);
@@ -104,6 +105,7 @@ public class TestUtils {
     executeCreateTableQuery("default", "basenulltypefield", baseNullTypeFieldSchema);
     executeCreateTableQuery("default", "basetimestamptypefield", baseTimestampTypeFieldSchema);
     executeCreateTableQuery("default", "basecomplexuniontype", baseComplexUnionTypeSchema);
+    executeCreateTableQuery("default", "basenestedunion", baseNestedUnionSchema);
     executeCreateTableWithPartitionQuery("default", "basecasepreservation", baseCasePreservation);
     executeCreateTableWithPartitionFieldSchemaQuery("default", "basecomplexfieldschema", baseComplexFieldSchema);
     executeCreateTableWithPartitionQuery("default", "basenestedcomplex", baseNestedComplexSchema);

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -521,6 +521,16 @@ public class ViewToAvroSchemaConverterTests {
     Assert.assertEquals(actualSchema.toString(true), TestUtils.loadSchema("testNullabilityUdf-expected.avsc"));
   }
 
+  @Test
+  public void testNullabliltyExtractUnionUDF() {
+    String sql = "select extract_union(unionCol) as c1 from basenestedunion";
+    ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);
+
+    Schema actual = viewToAvroSchemaConverter.toAvroSchema(sql);
+
+    Assert.assertEquals(actual.toString(true), TestUtils.loadSchema("testNullabilityExtractUnionUDF-expected.avsc"));
+  }
+
   @Test(enabled = false)
   public void testRenameToLowercase() {
     String viewSql = "CREATE VIEW v AS " + "SELECT bc.Id AS id, bc.Array_Col AS array_col " + "FROM basecomplex bc "

--- a/coral-schema/src/test/resources/base-nested-union.avsc
+++ b/coral-schema/src/test/resources/base-nested-union.avsc
@@ -1,0 +1,49 @@
+{
+  "type": "record",
+  "name": "baseNestedUnion",
+  "namespace" : "coral.schema.avro.base.nested.union",
+  "fields": [
+    {
+      "name": "unionCol",
+      "type": [
+        {
+          "type": "record",
+          "name": "r1",
+          "fields": [
+            {
+              "name": "f1",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            }
+          ]
+        },
+        {
+          "type": "record",
+          "name": "r2",
+          "fields": [
+            {
+              "name": "f1",
+              "type": [
+                "null",
+                "int"
+              ],
+              "default": null
+            },
+            {
+              "name": "f2",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            }
+          ]
+        }
+      ],
+      "default": null
+    }
+  ]
+}

--- a/coral-schema/src/test/resources/testNullabilityExtractUnionUDF-expected.avsc
+++ b/coral-schema/src/test/resources/testNullabilityExtractUnionUDF-expected.avsc
@@ -1,0 +1,38 @@
+{
+  "type" : "record",
+  "name" : "baseNestedUnion",
+  "namespace" : "coral.schema.avro.base.nested.union",
+  "fields" : [ {
+    "name" : "c1",
+    "type" : [ {
+      "type" : "record",
+      "name" : "c1",
+      "namespace" : "rel_avro",
+      "fields" : [ {
+        "name" : "tag_0",
+        "type" : [ "null", {
+          "type" : "record",
+          "name" : "tag_0",
+          "fields" : [ {
+            "name" : "f1",
+            "type" : [ "null", "string" ]
+          } ]
+        } ]
+      }, {
+        "name" : "tag_1",
+        "type" : [ "null", {
+          "type" : "record",
+          "name" : "tag_1",
+          "fields" : [ {
+            "name" : "f1",
+            "type" : [ "null", "int" ]
+          }, {
+            "name" : "f2",
+            "type" : [ "null", "string" ]
+          } ]
+        } ]
+      } ]
+    }, "null" ],
+    "doc" : "Field created in view by applying UDF 'extract_union' with argument(s): coral.schema.avro.base.nested.union.baseNestedUnion.unionCol"
+  } ]
+}


### PR DESCRIPTION
This pr is an alternative solution to #226 , which has minimum impact on affecting existing function's nullability but force the nullablilty of `extract_union` to be inferred by calcite.

This will make the extract_union view's Coral inferred schema align with spark's analysis, thus making spark able to read such views instead of throwing exception.

I manually tested this by translating the failed extract_union view using this patch, and the nullability in the schema is correct. It's a bit hard to write a unit test on this one because the Hive environment (1.2.2) that Coral depends on doesn't contain the extract_union UDF in its codebase yet (it's a feature from open source hive 2+), so we wouldn't be able to create a extract_union view in the test Hive environment to begin with.