### PR TITLE
Make nested type returned by coalesce UDF all nullable

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
@@ -116,18 +116,21 @@ public class CoalesceStructUtility {
       convertedTypes.add(coalesce(originalTypes.get(i), typeFactory));
     }
 
-    return typeFactory.createStructType(convertedTypes, convertedNames);
+    RelDataType structType = typeFactory.createStructType(convertedTypes, convertedNames);
+    return typeFactory.createTypeWithNullability(structType, true);
   }
 
   private static RelDataType coalesceMap(RelDataType inputNode, RelDataTypeFactory typeFactory) {
     RelDataType coalescedKeyType = coalesce(inputNode.getKeyType(), typeFactory);
     RelDataType coalescedValueType = coalesce(inputNode.getValueType(), typeFactory);
-    return typeFactory.createMapType(coalescedKeyType, coalescedValueType);
+    RelDataType mapType = typeFactory.createMapType(coalescedKeyType, coalescedValueType);
+    return typeFactory.createTypeWithNullability(mapType, true);
   }
 
   private static RelDataType coalesceCollection(RelDataType inputNode, RelDataTypeFactory typeFactory) {
     RelDataType coalescedComponentType = coalesce(inputNode.getComponentType(), typeFactory);
-    return typeFactory.createArrayType(coalescedComponentType, -1);
+    RelDataType arrayType = typeFactory.createArrayType(coalescedComponentType, -1);
+    return typeFactory.createTypeWithNullability(arrayType, true);
   }
 
   /**


### PR DESCRIPTION
We should return all nested type as nullable since Hive types are all nullable by default.

We should also enhance the unit tests to do equality check using `getFullTypeString`, which includes the information of nullability of the type.