### PR TITLE
Coral-Trino: Fix incompatible issue after renaming PrestoParserDriver to TrinoParserDriver

### DIFF
--- a/coral-trino/src/main/java/com/linkedin/coral/trino/trino2rel/TrinoToRelConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/trino2rel/TrinoToRelConverter.java
@@ -84,7 +84,7 @@ public class TrinoToRelConverter extends ToRelConverter {
   @Override
   protected SqlNode toSqlNode(String sql, Table trinoView) {
     String trimmedSql = trimParenthesis(sql.toUpperCase());
-    SqlNode parsedSqlNode = PrestoParserDriver.parse(trimmedSql).accept(parseTreeBuilder, parserVisitorContext);
+    SqlNode parsedSqlNode = TrinoParserDriver.parse(trimmedSql).accept(parseTreeBuilder, parserVisitorContext);
     SqlNode convertedSqlNode = parsedSqlNode.accept(new Trino2CoralOperatorConverter());
     return convertedSqlNode;
   }


### PR DESCRIPTION
#224 and #236 are not compatible, this PR is to fix it.
It's better to rerun the CI build test before merging any PR in the future, given the test wouldn't run again by itself once another PR is merged.