### PR TITLE
Coral-Spark: Maintain alias even if alias is the same as field name

### DIFF
--- a/coral-spark/src/main/java/com/linkedin/coral/spark/SparkRelToSparkSqlConverter.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/SparkRelToSparkSqlConverter.java
@@ -36,6 +36,7 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlMultisetValueConstructor;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.validate.SqlValidatorUtil;
 
 import com.linkedin.coral.com.google.common.collect.ImmutableList;
 import com.linkedin.coral.hive.hive2rel.functions.HiveExplodeOperator;
@@ -43,7 +44,6 @@ import com.linkedin.coral.hive.hive2rel.functions.HivePosExplodeOperator;
 import com.linkedin.coral.spark.dialect.SparkSqlDialect;
 import com.linkedin.coral.spark.functions.SqlLateralJoin;
 import com.linkedin.coral.spark.functions.SqlLateralViewAsOperator;
-import org.apache.calcite.sql.validate.SqlValidatorUtil;
 
 
 /**
@@ -215,8 +215,7 @@ public class SparkRelToSparkSqlConverter extends RelToSqlConverter {
    * will be correctly analyzed by spark3 sql analyzer.
    */
   @Override
-  public void addSelect(List<SqlNode> selectList, SqlNode node,
-                                  RelDataType rowType) {
+  public void addSelect(List<SqlNode> selectList, SqlNode node, RelDataType rowType) {
     String name = rowType.getFieldNames().get(selectList.size());
     String alias = SqlValidatorUtil.getAlias(node, -1);
     final String lowerName = name.toLowerCase(Locale.ROOT);

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/utils/SparkSqlValidatorUtil.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/utils/SparkSqlValidatorUtil.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.spark.utils;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.util.Util;
+
+
+public class SparkSqlValidatorUtil {
+  // refer to SqlValidatorUtil.getAlias from Calcite
+  // the only customization is to use the custom deriveAliasFromOrdinal
+  public static String getAlias(SqlNode node, int ordinal) {
+    switch (node.getKind()) {
+      case AS:
+        // E.g. "1 + 2 as foo" --> "foo"
+        return ((SqlCall) node).operand(1).toString();
+
+      case OVER:
+        // E.g. "bids over w" --> "bids"
+        return getAlias(((SqlCall) node).operand(0), ordinal);
+
+      case IDENTIFIER:
+        // E.g. "foo.bar" --> "bar"
+        return Util.last(((SqlIdentifier) node).names);
+
+      default:
+        if (ordinal < 0) {
+          return null;
+        } else {
+          return deriveAliasFromOrdinal(ordinal);
+        }
+    }
+  }
+
+  // refer to SqlUtil.deriveAliasFromOrdinal from Calcite
+  // the customization is to use '_' instead of '$'
+  public static String deriveAliasFromOrdinal(int ordinal) {
+    // Use a '_' separator to align with current Coral-Schema output names
+    return "EXPR_" + ordinal;
+  }
+}

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -739,4 +739,16 @@ public class CoralSparkTest {
     String expandedSql = coralSpark.getSparkSql();
     assertEquals(expandedSql, targetSql);
   }
+
+  @Test
+  public void testNestedFieldProjectionWithSameNameAlias() {
+    String sourceSql = "SELECT complex.s.name as name FROM default.complex";
+    RelNode relNode = TestUtils.toRelNode(sourceSql);
+    CoralSpark coralSpark = CoralSpark.create(relNode);
+    String expandedSql = coralSpark.getSparkSql();
+
+    String targetSql = "SELECT s.name name\n" +
+            "FROM default.complex";
+    assertEquals(expandedSql, targetSql);
+  }
 }

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -747,8 +747,7 @@ public class CoralSparkTest {
     CoralSpark coralSpark = CoralSpark.create(relNode);
     String expandedSql = coralSpark.getSparkSql();
 
-    String targetSql = "SELECT s.name name\n" +
-            "FROM default.complex";
+    String targetSql = "SELECT s.name name\n" + "FROM default.complex";
     assertEquals(expandedSql, targetSql);
   }
 }

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -750,4 +750,27 @@ public class CoralSparkTest {
     String targetSql = "SELECT s.name name\n" + "FROM default.complex";
     assertEquals(expandedSql, targetSql);
   }
+
+  @Test
+  public void testProjectionOfFunctionCall() {
+    String sourceSql = "SELECT LOWER(complex.s.name) AS name FROM default.complex";
+    RelNode relNode = TestUtils.toRelNode(sourceSql);
+    CoralSpark coralSpark = CoralSpark.create(relNode);
+    String expandedSql = coralSpark.getSparkSql();
+
+    String targetSql = "SELECT LOWER(s.name) EXPR_0\n" + "FROM default.complex";
+    assertEquals(expandedSql, targetSql);
+  }
+
+  @Test
+  public void testProjectionOfCastCall() {
+    String sourceSql = "SELECT CAST(complex.a AS STRING) AS name FROM default.complex";
+    RelNode relNode = TestUtils.toRelNode(sourceSql);
+    CoralSpark coralSpark = CoralSpark.create(relNode);
+    String expandedSql = coralSpark.getSparkSql();
+    System.out.println(expandedSql);
+
+    String targetSql = "SELECT CAST(a AS STRING) EXPR_0\n" + "FROM default.complex";
+    assertEquals(expandedSql, targetSql);
+  }
 }


### PR DESCRIPTION
We noticed that for view like:
  `select foo.bar as bar from t as v`
the previous coral-spark translated spark sql statement will drop the alias because the last part of the field name and the alias is the same, it will generate:
  `select foo.bar from t` for `v`'s definition.

However, when then if user try to in spark3 query the `v` with:
  `select bar from v`
spark3's sql analyzer will fail because it doesn't understand `bar` from the view, since it only understands the full name `foo.bar`, because the alias is dropped.

This change makes the `RelToSqlConverter` maintain the alias all the time. I also chose to override the super method instead of directly changing the method in place inside calcite, to minimize the effect only to the Rel -> sparkSQL part.

The test failures are expected, as I actually want to use the test case failures to showcase the impact on translating other views, since this change will add all column alias even the view definition doesn't specify `as alias` for a certain projection. (this is by the limitation that Calcite doesn't really remember if there's an alias in its `RelNode` IR representation). But overall, I don't think this effect will cause any spark2/3 regressions but I'm open for discussion.