### PR TITLE
Coral-Trino: Modify TrinoKeywordsConverter.RESERVED_KEYWORDS from Map to Set

### DIFF
--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/functions/TrinoKeywordsConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/functions/TrinoKeywordsConverter.java
@@ -5,9 +5,9 @@
  */
 package com.linkedin.coral.trino.rel2trino.functions;
 
-import java.util.Map;
+import java.util.Set;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 
 /**
@@ -19,30 +19,13 @@ public final class TrinoKeywordsConverter {
 
   }
 
-  /**
-   * Map of Trino Reserved Keywords with the mark to distinguish if the word is reserved SQL:2016 keyword ONLY
-   */
-  public static final Map<String, Boolean> RESERVED_KEYWORDS = ImmutableMap.<String, Boolean> builder()
-      .put("ALTER", Boolean.FALSE).put("AND", Boolean.FALSE).put("AS", Boolean.FALSE).put("BETWEEN", Boolean.FALSE)
-      .put("BY", Boolean.FALSE).put("CASE", Boolean.FALSE).put("CAST", Boolean.FALSE).put("CONSTRAINT", Boolean.FALSE)
-      .put("CREATE", Boolean.FALSE).put("CROSS", Boolean.FALSE).put("CUBE", Boolean.TRUE)
-      .put("CURRENT_DATE", Boolean.FALSE).put("CURRENT_TIME", Boolean.FALSE).put("CURRENT_TIMESTAMP", Boolean.FALSE)
-      .put("CURRENT_USER", Boolean.TRUE).put("DEALLOCATE", Boolean.FALSE).put("DELETE", Boolean.FALSE)
-      .put("DESCRIBE", Boolean.FALSE).put("DISTINCT", Boolean.FALSE).put("DROP", Boolean.FALSE)
-      .put("ELSE", Boolean.FALSE).put("END", Boolean.FALSE).put("ESCAPE", Boolean.FALSE).put("EXCEPT", Boolean.FALSE)
-      .put("EXECUTE", Boolean.FALSE).put("EXISTS", Boolean.FALSE).put("EXTRACT", Boolean.FALSE)
-      .put("FALSE", Boolean.FALSE).put("FOR", Boolean.FALSE).put("FROM", Boolean.FALSE).put("FULL", Boolean.FALSE)
-      .put("GROUP", Boolean.FALSE).put("GROUPING", Boolean.TRUE).put("HAVING", Boolean.FALSE).put("IN", Boolean.FALSE)
-      .put("INNER", Boolean.FALSE).put("INSERT", Boolean.FALSE).put("INTERSECT", Boolean.FALSE)
-      .put("INTO", Boolean.FALSE).put("IS", Boolean.FALSE).put("JOIN", Boolean.FALSE).put("LEFT", Boolean.FALSE)
-      .put("LIKE", Boolean.FALSE).put("LOCALTIME", Boolean.TRUE).put("LOCALTIMESTAMP", Boolean.TRUE)
-      .put("NATURAL", Boolean.FALSE).put("NORMALIZE", Boolean.TRUE).put("NOT", Boolean.FALSE).put("NULL", Boolean.FALSE)
-      .put("ON", Boolean.FALSE).put("OR", Boolean.FALSE).put("ORDER", Boolean.FALSE).put("OUTER", Boolean.FALSE)
-      .put("PREPARE", Boolean.FALSE).put("RECURSIVE", Boolean.TRUE).put("RIGHT", Boolean.FALSE)
-      .put("ROLLUP", Boolean.TRUE).put("SELECT", Boolean.FALSE).put("TABLE", Boolean.FALSE).put("THEN", Boolean.FALSE)
-      .put("TRUE", Boolean.FALSE).put("UESCAPE", Boolean.TRUE).put("UNION", Boolean.FALSE).put("UNNEST", Boolean.TRUE)
-      .put("USING", Boolean.FALSE).put("VALUES", Boolean.FALSE).put("WHEN", Boolean.FALSE).put("WHERE", Boolean.FALSE)
-      .put("WITH", Boolean.FALSE).build();
+  private static final Set<String> RESERVED_KEYWORDS = ImmutableSet.of("ALTER", "AND", "AS", "BETWEEN", "BY", "CASE",
+      "CAST", "CONSTRAINT", "CREATE", "CROSS", "CUBE", "CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP",
+      "CURRENT_USER", "DEALLOCATE", "DELETE", "DESCRIBE", "DISTINCT", "DROP", "ELSE", "END", "ESCAPE", "EXCEPT",
+      "EXECUTE", "EXISTS", "EXTRACT", "FALSE", "FOR", "FROM", "FULL", "GROUP", "GROUPING", "HAVING", "IN", "INNER",
+      "INSERT", "INTERSECT", "INTO", "IS", "JOIN", "LEFT", "LIKE", "LOCALTIME", "LOCALTIMESTAMP", "NATURAL",
+      "NORMALIZE", "NOT", "NULL", "ON", "OR", "ORDER", "OUTER", "PREPARE", "RECURSIVE", "RIGHT", "ROLLUP", "SELECT",
+      "TABLE", "THEN", "TRUE", "UESCAPE", "UNION", "UNNEST", "USING", "VALUES", "WHEN", "WHERE", "WITH");
 
   /**
    * Quote the value iif it is a reserved Trino keyword
@@ -52,7 +35,7 @@ public final class TrinoKeywordsConverter {
    * @return if the value is a reserved keyword, a double quote will be added as a return value
    */
   public static String quoteReservedKeyword(String value) {
-    if (RESERVED_KEYWORDS.containsKey(value.toUpperCase())) {
+    if (RESERVED_KEYWORDS.contains(value.toUpperCase())) {
       return quoteWordIfNotQuoted(value);
     } else {
       return value;


### PR DESCRIPTION
Previously, we used a map for `TrinoKeywordsConverter.RESERVED_KEYWORDS`, whose value is not used at all.
This PR is to modify it from map to set to clean the code.