### PR TITLE
Bump com.diffplug.spotless to 5.9.0 to fix a transient issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
 }
 
 plugins {
-  id "com.diffplug.spotless" version "5.8.2"
+  id "com.diffplug.spotless" version "5.9.0"
 }
 
 apply from: "gradle/shipkit.gradle"


### PR DESCRIPTION
I met a transient issue similar to https://github.com/diffplug/spotless/issues/741 several times while building locally, bumping the version can fix it according to the discussion.