### PR TITLE
Coral-Spark: Handle select star case for AddExplicitAlias

### DIFF
--- a/coral-spark/src/main/java/com/linkedin/coral/spark/CoralSpark.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/CoralSpark.java
@@ -120,14 +120,13 @@ public class CoralSpark {
     // Create temporary objects r and rewritten to make debugging easier
     SqlImplementor.Result r = rel2sql.visitChild(0, sparkRelNode);
     SqlNode rewritten = r.asStatement().accept(new SparkSqlRewriter());
-    SqlNode ret = rewritten;
     // Use a second pass visit to add explicit alias names,
     // only do this when it's not a select star case,
     // since for select star we don't need to add any explicit aliases
     if (rewritten.getKind() == SqlKind.SELECT && ((SqlSelect) rewritten).getSelectList() != null) {
-      ret = rewritten.accept(new AddExplicitAlias(aliases));
+      rewritten = rewritten.accept(new AddExplicitAlias(aliases));
     }
-    return ret.toSqlString(SparkSqlDialect.INSTANCE).getSql();
+    return rewritten.toSqlString(SparkSqlDialect.INSTANCE).getSql();
   }
 
   /**

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/CoralSpark.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/CoralSpark.java
@@ -15,11 +15,11 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.rel2sql.SqlImplementor;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlSelect;
 
 import com.linkedin.coral.spark.containers.SparkRelInfo;
 import com.linkedin.coral.spark.containers.SparkUDFInfo;
 import com.linkedin.coral.spark.dialect.SparkSqlDialect;
-import org.apache.calcite.sql.SqlSelect;
 
 
 /**

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -815,6 +815,15 @@ public class CoralSparkTest {
     assertEquals(expandedSql, targetSql);
   }
 
+  @Test
+  public void testSelectStar() {
+    String sourceSql = "SELECT * FROM default.basecomplex";
+    String expandedSql = getCoralSparkTranslatedSqlWithAliasFromCoralSchema(sourceSql);
+
+    String targetSql = "SELECT *\n" + "FROM default.basecomplex";
+    assertEquals(expandedSql, targetSql);
+  }
+
   private static String getCoralSparkTranslatedSqlWithAliasFromCoralSchema(String db, String view) {
     RelNode relNode = TestUtils.toRelNode(db, view);
     Schema schema = TestUtils.getAvroSchemaForView(db, view, false);


### PR DESCRIPTION
in pr #250 I miss handling the special case of select star queries, for select star queries, we don't want to explicitly add any aliases and should just return select star as is.

The select star special case is distinguished by the `SqlSelect`'s `selectList` being `null`. If we don't explicitly handle this case, line https://github.com/linkedin/coral/blob/efc84d80b93844ba17715946eee65c87dc8e8cdb/coral-spark/src/main/java/com/linkedin/coral/spark/AddExplicitAlias.java#L42 will throw an NPE.

I also add a unit test case for this special case.