### PR TITLE
Simplify build.gradle files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,4 +74,5 @@ subprojects {
   }
 
   apply from: "${rootDir}/gradle/dependencies.gradle"
+  apply from: "$rootDir/gradle/java-publication.gradle"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -74,5 +74,5 @@ subprojects {
   }
 
   apply from: "${rootDir}/gradle/dependencies.gradle"
-  apply from: "$rootDir/gradle/java-publication.gradle"
+  apply from: "${rootDir}/gradle/java-publication.gradle"
 }

--- a/coral-common/build.gradle
+++ b/coral-common/build.gradle
@@ -1,5 +1,3 @@
-apply from: "$rootDir/gradle/java-publication.gradle"
-
 dependencies {
   compile('com.linkedin.calcite:calcite-core:1.21.0.151') {
     artifact {
@@ -18,8 +16,4 @@ dependencies {
   }
 
   compile deps.'hadoop'.'hadoop-common'
-}
-
-artifacts {
-  archives jar, javadocJar, sourcesJar
 }

--- a/coral-hive/build.gradle
+++ b/coral-hive/build.gradle
@@ -1,4 +1,3 @@
-apply from: "$rootDir/gradle/java-publication.gradle"
 apply plugin: 'antlr'
 
 dependencies {
@@ -29,11 +28,6 @@ generateGrammarSource {
     '-lib',
     'src/main/antlr/imports'
   ]}
-
-artifacts {
-  archives jar, javadocJar, sourcesJar
-}
-
 
 task customFatJar(type: Jar) {
   manifest {

--- a/coral-pig/build.gradle
+++ b/coral-pig/build.gradle
@@ -1,5 +1,3 @@
-apply from: "$rootDir/gradle/java-publication.gradle"
-
 dependencies {
   compile deps.'javax-annotation'
   // NOTE: jline is needed as testCompile for PigUnit tests because it is missing from Pig runtime
@@ -27,8 +25,4 @@ dependencies {
 
   testCompile deps.'hadoop'.'hadoop-mapreduce-client-common'
   testCompile deps.'kryo'
-}
-
-artifacts {
-  archives jar, javadocJar, sourcesJar
 }

--- a/coral-schema/build.gradle
+++ b/coral-schema/build.gradle
@@ -1,5 +1,3 @@
-apply from: "$rootDir/gradle/java-publication.gradle"
-
 dependencies {
   compile deps.'slf4j-api'
   compile deps.'slf4j-log4j12'
@@ -18,8 +16,4 @@ dependencies {
 
   testCompile deps.'hadoop'.'hadoop-mapreduce-client-core'
   testCompile deps.'kryo'
-}
-
-artifacts {
-  archives jar, javadocJar, sourcesJar
 }

--- a/coral-spark-plan/build.gradle
+++ b/coral-spark-plan/build.gradle
@@ -1,5 +1,3 @@
-apply from: "$rootDir/gradle/java-publication.gradle"
-
 dependencies {
   compile deps.'gson'
   compile deps.'slf4j-api'
@@ -16,8 +14,4 @@ dependencies {
 
   testCompile deps.'hadoop'.'hadoop-mapreduce-client-core'
   testCompile deps.'kryo'
-}
-
-artifacts {
-  archives jar, javadocJar, sourcesJar
 }

--- a/coral-spark/build.gradle
+++ b/coral-spark/build.gradle
@@ -1,4 +1,3 @@
-apply from: "$rootDir/gradle/java-publication.gradle"
 apply from: "spark_itest.gradle"
 
 dependencies {
@@ -20,8 +19,4 @@ dependencies {
   }
   testCompile deps.'hadoop'.'hadoop-mapreduce-client-core'
   testCompile deps.'kryo'
-}
-
-artifacts {
-  archives jar, javadocJar, sourcesJar
 }

--- a/coral-trino/build.gradle
+++ b/coral-trino/build.gradle
@@ -1,5 +1,3 @@
-apply from: "$rootDir/gradle/java-publication.gradle"
-
 dependencies {
   compile deps.'gson'
   compile deps.'javax-annotation'
@@ -20,8 +18,4 @@ dependencies {
 
   testCompile deps.'hadoop'.'hadoop-mapreduce-client-common'
   testCompile deps.'kryo'
-}
-
-artifacts {
-  archives jar, javadocJar, sourcesJar
 }

--- a/gradle/java-publication.gradle
+++ b/gradle/java-publication.gradle
@@ -22,8 +22,7 @@ jar {
 }
 
 artifacts {
-  archives sourcesJar
-  archives javadocJar
+  archives jar, javadocJar, sourcesJar
 }
 
 apply plugin: "maven-publish" //https://docs.gradle.org/current/userguide/publishing_maven.html

--- a/shading/coral-trino-parser/build.gradle
+++ b/shading/coral-trino-parser/build.gradle
@@ -1,6 +1,5 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 apply plugin: "com.github.johnrengelman.shadow"
-apply from: "$rootDir/gradle/java-publication.gradle"
 
 dependencies {
   compileOnly 'io.trino:trino-parser:355'


### PR DESCRIPTION
This PR is to simplify `build.gradle` files, it ensures all the `build.gradle` files in normal submodules only contain dependency information.

Tested by building Coral.