### PR TITLE
Coral-Schema: Add ToNullableSchemaVisitor and apply that on `dali.row.schema`

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -44,7 +44,7 @@ import com.linkedin.coral.com.google.common.base.Strings;
 import com.linkedin.coral.schema.avro.exceptions.SchemaNotFoundException;
 
 import static com.linkedin.coral.schema.avro.AvroSerdeUtils.*;
-import static org.apache.avro.Schema.Type.NULL;
+import static org.apache.avro.Schema.Type.*;
 
 
 class SchemaUtilities {
@@ -586,6 +586,16 @@ class SchemaUtilities {
   static Schema makeNullable(Schema schema) {
     if (schema.getType() == NULL || isNullableType(schema)) {
       return schema;
+    } else if (schema.getType() == UNION) {
+      for (Schema innerSchema : schema.getTypes()) {
+        if (innerSchema.getType() == NULL) {
+          return schema;
+        }
+      }
+      final List<Schema> types = new ArrayList<>();
+      types.add(Schema.create(NULL));
+      types.addAll(schema.getTypes());
+      return Schema.createUnion(types);
     } else {
       return Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), schema));
     }

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -166,15 +166,14 @@ class SchemaUtilities {
         schemaStr = schemaStr.replaceAll("\n", "\\\\n");
         // Given schemas stored in `dali.row.schema` are all non-nullable, we need to convert them to be nullable to be compatible with Spark
         schema = ToNullableSchemaVisitor.visit(new Schema.Parser().parse(schemaStr));
-        schemaStr = schema.toString();
       }
     } else {
       schema = new Schema.Parser().parse(schemaStr);
     }
 
-    if (!Strings.isNullOrEmpty(schemaStr)) {
+    if (schema != null) {
       LOG.info("Schema found for table {}", getCompleteName(table));
-      LOG.debug("Schema is {}", schemaStr);
+      LOG.debug("Schema is {}", schema.toString(true));
       return schema;
     } else {
       LOG.warn("Cannot determine avro schema for table {}", getCompleteName(table));

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/ToNullableSchemaVisitor.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/ToNullableSchemaVisitor.java
@@ -16,7 +16,7 @@ import org.codehaus.jackson.JsonNode;
 
 
 /**
- * Converts all the fields to be nullable for a given schema
+ * Converts all the fields (including nested fields) to be nullable for a given schema
  */
 public class ToNullableSchemaVisitor extends AvroSchemaVisitor<Schema> {
   public static Schema visit(Schema schema) {

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/ToNullableSchemaVisitor.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/ToNullableSchemaVisitor.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2022 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.schema.avro;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.Lists;
+
+import org.apache.avro.Schema;
+import org.codehaus.jackson.JsonNode;
+
+
+/**
+ * Converts all the fields to be nullable for a given schema
+ */
+public class ToNullableSchemaVisitor extends AvroSchemaVisitor<Schema> {
+  public static Schema visit(Schema schema) {
+    return SchemaUtilities.makeNonNullable(AvroSchemaVisitor.visit(schema, new ToNullableSchemaVisitor()));
+  }
+
+  @Override
+  public Schema record(Schema record, List<String> names, List<Schema> fields) {
+    Schema nullableSchema =
+        Schema.createRecord(record.getName(), record.getDoc(), record.getNamespace(), record.isError());
+
+    List<Schema.Field> nullableFields = Lists.newArrayListWithExpectedSize(fields.size());
+    for (int i = 0; i < fields.size(); i++) {
+      nullableFields.add(nullableField(record.getFields().get(i), fields.get(i)));
+    }
+
+    nullableSchema.setFields(nullableFields);
+    SchemaUtilities.replicateSchemaProps(record, nullableSchema);
+
+    return SchemaUtilities.makeNullable(nullableSchema);
+  }
+
+  @Override
+  public Schema union(Schema union, List<Schema> options) {
+    List<Schema> unionOptions = new ArrayList<>(options);
+    return Schema.createUnion(unionOptions);
+  }
+
+  @Override
+  public Schema array(Schema array, Schema element) {
+    return Schema.createArray(element);
+  }
+
+  @Override
+  public Schema map(Schema map, Schema value) {
+    return Schema.createMap(value);
+  }
+
+  @Override
+  public Schema primitive(Schema primitive) {
+    return primitive;
+  }
+
+  private Schema.Field nullableField(Schema.Field field, Schema schema) {
+    Schema.Field nullableField = new Schema.Field(field.name(), SchemaUtilities.makeNullable(schema), field.doc(),
+        field.defaultValue(), field.order());
+
+    for (Map.Entry<String, JsonNode> prop : field.getJsonProps().entrySet()) {
+      nullableField.addProp(prop.getKey(), prop.getValue());
+    }
+
+    return nullableField;
+  }
+}

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
@@ -80,4 +80,12 @@ public class SchemaUtilitiesTests {
     Assert.assertEquals(outputSchema.toString(true),
         TestUtils.loadSchema("testForceLowercaseSchemaTrue-expected.avsc"));
   }
+
+  @Test
+  public void testToNullableSchema() {
+    Schema inputSchema = new Schema.Parser().parse(TestUtils.loadSchema("base-complex-non-nullable.avsc"));
+    Schema outputSchema = ToNullableSchemaVisitor.visit(inputSchema);
+
+    Assert.assertEquals(outputSchema.toString(true), TestUtils.loadSchema("testToNullableSchema-expected.avsc"));
+  }
 }

--- a/coral-schema/src/test/resources/base-complex-non-nullable.avsc
+++ b/coral-schema/src/test/resources/base-complex-non-nullable.avsc
@@ -6,6 +6,12 @@
     "name" : "Id",
     "type" : "int"
   }, {
+    "name" : "Nullable_Union_Col",
+    "type" : [ "null", "int", "string" ]
+  }, {
+    "name" : "Non_Nullable_Union_Col",
+    "type" : [ "int", "string" ]
+  }, {
     "name" : "Array_Col",
     "type" : {
       "type" : "array",

--- a/coral-schema/src/test/resources/base-complex-non-nullable.avsc
+++ b/coral-schema/src/test/resources/base-complex-non-nullable.avsc
@@ -1,0 +1,73 @@
+{
+  "type" : "record",
+  "name" : "basecomplexnonnullable",
+  "namespace" : "coral.schema.avro.base.complex.nonnullable",
+  "fields" : [ {
+    "name" : "Id",
+    "type" : "int"
+  }, {
+    "name" : "Array_Col",
+    "type" : {
+      "type" : "array",
+      "items" : "string"
+    }
+  }, {
+    "name" : "Map_Col",
+    "type" : {
+      "type" : "map",
+      "values" : "string"
+    }
+  }, {
+    "name" : "Struct_Col",
+    "type" : {
+      "type" : "record",
+      "name" : "Struct_col",
+      "namespace" : "coral.schema.avro.base.complex.nonnullable.basecomplexnonnullable",
+      "fields" : [ {
+        "name" : "Bool_Field",
+        "type" : "boolean"
+      }, {
+        "name" : "Int_Field",
+        "type" : "int"
+      }, {
+        "name" : "Bigint_Field",
+        "type" : "long"
+      }, {
+        "name" : "Float_Field",
+        "type" : "float"
+      }, {
+        "name" : "Double_Field",
+        "type" : "double"
+      }, {
+        "name" : "Date_String_Field",
+        "type" : "string"
+      }, {
+        "name" : "String_Field",
+        "type" : "string"
+      }, {
+        "name" : "Array_Col",
+        "type" : {
+          "type" : "array",
+          "items" : {
+            "type" : "record",
+            "name" : "Struct_col",
+            "namespace" : "coral.schema.avro.base.complex.nonnullable.basecomplexnonnullable.basecomplexnonnullable",
+            "fields" : [ {
+              "name" : "key",
+              "type" : "string"
+            }, {
+              "name" : "value",
+              "type" : "string"
+            } ]
+          }
+        }
+      }, {
+        "name" : "Map_Col",
+        "type" : {
+          "type" : "map",
+          "values" : "string"
+        }
+      } ]
+    }
+  } ]
+}

--- a/coral-schema/src/test/resources/testToNullableSchema-expected.avsc
+++ b/coral-schema/src/test/resources/testToNullableSchema-expected.avsc
@@ -6,6 +6,12 @@
     "name" : "Id",
     "type" : [ "null", "int" ]
   }, {
+    "name" : "Nullable_Union_Col",
+    "type" : [ "null", "int", "string" ]
+  }, {
+    "name" : "Non_Nullable_Union_Col",
+    "type" : [ "null", "int", "string" ]
+  }, {
     "name" : "Array_Col",
     "type" : [ "null", {
       "type" : "array",

--- a/coral-schema/src/test/resources/testToNullableSchema-expected.avsc
+++ b/coral-schema/src/test/resources/testToNullableSchema-expected.avsc
@@ -1,0 +1,73 @@
+{
+  "type" : "record",
+  "name" : "basecomplexnonnullable",
+  "namespace" : "coral.schema.avro.base.complex.nonnullable",
+  "fields" : [ {
+    "name" : "Id",
+    "type" : [ "null", "int" ]
+  }, {
+    "name" : "Array_Col",
+    "type" : [ "null", {
+      "type" : "array",
+      "items" : "string"
+    } ]
+  }, {
+    "name" : "Map_Col",
+    "type" : [ "null", {
+      "type" : "map",
+      "values" : "string"
+    } ]
+  }, {
+    "name" : "Struct_Col",
+    "type" : [ "null", {
+      "type" : "record",
+      "name" : "Struct_col",
+      "namespace" : "coral.schema.avro.base.complex.nonnullable.basecomplexnonnullable",
+      "fields" : [ {
+        "name" : "Bool_Field",
+        "type" : [ "null", "boolean" ]
+      }, {
+        "name" : "Int_Field",
+        "type" : [ "null", "int" ]
+      }, {
+        "name" : "Bigint_Field",
+        "type" : [ "null", "long" ]
+      }, {
+        "name" : "Float_Field",
+        "type" : [ "null", "float" ]
+      }, {
+        "name" : "Double_Field",
+        "type" : [ "null", "double" ]
+      }, {
+        "name" : "Date_String_Field",
+        "type" : [ "null", "string" ]
+      }, {
+        "name" : "String_Field",
+        "type" : [ "null", "string" ]
+      }, {
+        "name" : "Array_Col",
+        "type" : [ "null", {
+          "type" : "array",
+          "items" : [ "null", {
+            "type" : "record",
+            "name" : "Struct_col",
+            "namespace" : "coral.schema.avro.base.complex.nonnullable.basecomplexnonnullable.basecomplexnonnullable",
+            "fields" : [ {
+              "name" : "key",
+              "type" : [ "null", "string" ]
+            }, {
+              "name" : "value",
+              "type" : [ "null", "string" ]
+            } ]
+          } ]
+        } ]
+      }, {
+        "name" : "Map_Col",
+        "type" : [ "null", {
+          "type" : "map",
+          "values" : "string"
+        } ]
+      } ]
+    } ]
+  } ]
+}


### PR DESCRIPTION
**Summary**
This PR adds `ToNullableSchemaVisitor` which converts all the fields (including nested fields) to be nullable, and applies it to the schema stored in `dail.row.schema` given Spark expects all nullable schema.

**Tests**
1. Unit test
2. Integration test, no regression after verification
3. Tested on the affected views, can be queried on gateway with this PR