### PR TITLE
Translate to Trino properly `regexp_extract` function

### DIFF
--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CalciteTrinoUDFMap.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CalciteTrinoUDFMap.java
@@ -62,8 +62,7 @@ public class CalciteTrinoUDFMap {
     createUDFMapEntry(UDF_MAP, hiveToCalciteOp("hex"), 1, "to_hex");
     createUDFMapEntry(UDF_MAP, hiveToCalciteOp("unhex"), 1, "from_hex");
     createUDFMapEntry(UDF_MAP, hiveToCalciteOp("array_contains"), 2, "contains");
-    createUDFMapEntry(UDF_MAP, hiveToCalciteOp("regexp_extract"), 3, "regexp_extract",
-        "[{\"input\": 1}, {\"op\": \"hive_pattern_to_trino\", \"operands\":[{\"input\": 2}]}, {\"input\": 3}]", null);
+    createUDFMapEntry(UDF_MAP, hiveToCalciteOp("regexp_extract"), 3, "regexp_extract");
     createUDFMapEntry(UDF_MAP, hiveToCalciteOp("instr"), 2, "strpos");
     createRuntimeUDFMapEntry(UDF_MAP, hiveToCalciteOp("decode"), 2,
         "[{\"regex\":\"(?i)('utf-8')\", \"input\":2, \"name\":\"from_utf8\"}]", "[{\"input\":1}]", null);

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/UDFTransformer.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/UDFTransformer.java
@@ -144,9 +144,6 @@ public class UDFTransformer {
         writer.endFunCall(frame);
       }
     });
-    OP_MAP.put("hive_pattern_to_trino",
-        new SqlUserDefinedFunction(new SqlIdentifier("hive_pattern_to_trino", SqlParserPos.ZERO),
-            FunctionReturnTypes.STRING, null, OperandTypes.STRING, null, null));
   }
 
   public static final String OPERATOR = "op";

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -709,4 +709,15 @@ public class HiveToTrinoConverterTest {
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
+
+  @Test
+  public void testRegexpExtractFunction() {
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+
+    RelNode relNode = hiveToRelConverter.convertSql("SELECT regexp_extract('1abc 2b 14m', '(\\d+)([a-z]+)', 2)");
+    String targetSql =
+        "SELECT \"regexp_extract\"('1abc 2b 14m', '(\\d+)([a-z]+)', 2)\n" + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
 }


### PR DESCRIPTION
Fixes: #266

Context: 

`regexp_extract` function in Hive https://www.revisitclass.com/hadoop/regexp_extract-function-in-hive-with-examples/
`regexp_extract` function in Trino https://trino.io/docs/current/functions/regexp.html#regexp_extract

Trino signature matches Hive's signature for `regexp_extract` function.

Remove from the code the unused reference `hive_pattern_to_trino`.