### PR TITLE
Update gson to version 2.9.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -3,7 +3,7 @@ def versions = [
   'assertj': '3.19.0',
   'jsr305': '3.0.2',
   'jline': '0.9.94',
-  'gson': '2.8.1',
+  'gson': '2.9.0',
   'slf4j': '1.7.25',
   'kryo': '2.22',
   'testing': '6.4',


### PR DESCRIPTION
This PR is to solve #272, 2.9.0 is the newest version of gson.

Tested by building it.