### PR TITLE
Fix force lowercase is ignored for alias in coral schema conversion

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
@@ -273,7 +273,8 @@ public class RelToAvroSchemaConverter {
       Schema inputSchema1 = schemaMap.get(logicalUnion.getInput(0));
       Schema inputSchema2 = schemaMap.get(logicalUnion.getInput(1));
 
-      Schema mergedSchema = SchemaUtilities.mergeUnionRecordSchema(inputSchema1, inputSchema2, strictMode);
+      Schema mergedSchema =
+          SchemaUtilities.mergeUnionRecordSchema(inputSchema1, inputSchema2, strictMode, forceLowercase);
 
       schemaMap.put(logicalUnion, mergedSchema);
 
@@ -374,7 +375,7 @@ public class RelToAvroSchemaConverter {
         throw new RuntimeException("Cannot find table " + dbName + "." + tableName + " in Hive metastore");
       }
 
-      Schema tableSchema = SchemaUtilities.getAvroSchemaForTable(baseTable, strictMode, forceLowercase);
+      Schema tableSchema = SchemaUtilities.getAvroSchemaForTable(baseTable, strictMode);
 
       return tableSchema;
     }

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -88,10 +88,9 @@ class SchemaUtilities {
    *
    * @param table
    * @param strictMode if set to true, we do not fall back to Hive schema
-   * @param forceLowercase if set to true, the schema returned is converted to lowercase
    * @return Avro schema for table including partition columns
    */
-  static Schema getAvroSchemaForTable(@Nonnull final Table table, boolean strictMode, boolean forceLowercase) {
+  static Schema getAvroSchemaForTable(@Nonnull final Table table, boolean strictMode) {
     Preconditions.checkNotNull(table);
     Schema resultTableSchema;
     Schema originalTableSchema = SchemaUtilities.getCasePreservedSchemaForTable(table);
@@ -125,8 +124,7 @@ class SchemaUtilities {
       }
     }
 
-    // Return lowercased schema if forceLowercase is set to True
-    return forceLowercase ? ToLowercaseSchemaVisitor.visit(resultTableSchema) : resultTableSchema;
+    return resultTableSchema;
   }
 
   static Schema convertHiveSchemaToAvro(@Nonnull final Table table) {
@@ -451,12 +449,19 @@ class SchemaUtilities {
    * @param rightSchema Right schema to be merged
    * @param strictMode If set to true, namespaces are required to be same.
    *                   If set to false, we don't check namespaces.
-   *
+   * @param forceLowercase If set to true, cast schema to lowercase
    * @return Merged schema if the input schemas can be merged
    */
-  static Schema mergeUnionRecordSchema(@Nonnull Schema leftSchema, @Nonnull Schema rightSchema, boolean strictMode) {
+  static Schema mergeUnionRecordSchema(@Nonnull Schema leftSchema, @Nonnull Schema rightSchema, boolean strictMode,
+      boolean forceLowercase) {
     Preconditions.checkNotNull(leftSchema);
     Preconditions.checkNotNull(rightSchema);
+    // TODO: we should investigate simplify casing transformations
+    if (forceLowercase) {
+      leftSchema = ToLowercaseSchemaVisitor.visit(leftSchema);
+      rightSchema = ToLowercaseSchemaVisitor.visit(rightSchema);
+    }
+
     if (leftSchema.toString(true).equals(rightSchema.toString(true))) {
       return leftSchema;
     }
@@ -558,7 +563,7 @@ class SchemaUtilities {
           }
           break;
         case RECORD:
-          return mergeUnionRecordSchema(leftSchema, rightSchema, strictMode);
+          return mergeUnionRecordSchema(leftSchema, rightSchema, strictMode, false);
         case MAP:
           Schema valueType = getUnionFieldSchema(leftSchema.getValueType(), rightSchema.getValueType(), strictMode);
           return Schema.createMap(valueType);

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverter.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverter.java
@@ -192,10 +192,14 @@ public class ViewToAvroSchemaConverter {
 
     if (!tableOrView.getTableType().equals("VIRTUAL_VIEW")) {
       // It's base table, just retrieve the avro schema from Hive metastore
-      return SchemaUtilities.getAvroSchemaForTable(tableOrView, strictMode, forceLowercase);
+      Schema schema = SchemaUtilities.getAvroSchemaForTable(tableOrView, strictMode);
+      return forceLowercase ? ToLowercaseSchemaVisitor.visit(schema) : schema;
     } else {
       RelNode relNode = hiveToRelConverter.convertView(dbName, tableOrViewName);
       Schema schema = relToAvroSchemaConverter.convert(relNode, strictMode, forceLowercase);
+      if (forceLowercase) {
+        schema = ToLowercaseSchemaVisitor.visit(schema);
+      }
       Schema avroSchema = schema;
 
       // In flex mode, we assign a new set of namespace

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -976,5 +976,16 @@ public class ViewToAvroSchemaConverterTests {
         TestUtils.loadSchema("testProjectUdfReturnedStruct-expected.avsc"));
   }
 
+  @Test
+  public void testLowercaseSchema() {
+    String viewSql = "CREATE VIEW v AS SELECT id as Id FROM basecomplex";
+    TestUtils.executeCreateViewQuery("default", "v", viewSql);
+
+    ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);
+    Schema actualSchema = viewToAvroSchemaConverter.toAvroSchema("default", "v", false, true);
+
+    Assert.assertEquals(actualSchema.toString(true), TestUtils.loadSchema("testLowercaseSchema-expected.avsc"));
+  }
+
   // TODO: add more unit tests
 }

--- a/coral-schema/src/test/resources/testLowercaseSchema-expected.avsc
+++ b/coral-schema/src/test/resources/testLowercaseSchema-expected.avsc
@@ -1,0 +1,9 @@
+{
+  "type" : "record",
+  "name" : "v",
+  "namespace" : "default.v",
+  "fields" : [ {
+    "name" : "id",
+    "type" : "int"
+  } ]
+}


### PR DESCRIPTION
This is a similar issue to https://github.com/linkedin/coral/issues/249, in this case, the scheme alias is upper case, even if `forcelowercase` flag is true, the output schema is still upper case.

For the test case below
```
  @Test
  public void testLowercase() {
    String viewSql = "CREATE VIEW v AS SELECT id as ID FROM basecomplex";
    TestUtils.executeCreateViewQuery("default", "v", viewSql);

    ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);

    // the last flag is forceLowercase, it is set to true
    Schema actualSchema = viewToAvroSchemaConverter.toAvroSchema("default", "v", false, true); 

    System.out.println(actualSchema);
  }
```
the output will be 
```
{"type":"record","name":"v","namespace":"default.v","fields":[{"name":"Id","type":"int"}]}
```
after this PR, the output will be (the column name is lowercase, as expected)
```
{"type":"record","name":"v","namespace":"default.v","fields":[{"name":"id","type":"int"}]}
```


This PR is removing the `forcelowercase` being used inside [RelToAvroSchemaConverter.java](https://github.com/770120041/coral/commit/425cc2faa552451923dce8b428fb78df9a588635#diff-a2e05f91f268adfd9edbe9dda395197fad075217aaac529dbee5d794a8f6866c), and cast the schema to lowercase in [ViewToAvroSchemaConverter.java](https://github.com/770120041/coral/commit/425cc2faa552451923dce8b428fb78df9a588635#diff-29d8b6a6932537360d80a64e0114c5da3e86b43a3f7f30c3e2b70cfc22dc581b) for both table and views. The test case is added in [ViewToAvroSchemaConverterTests.java](https://github.com/linkedin/coral/compare/master...770120041:lowercase-schema#diff-e1845c8c382ec1780c233a2385d55e8ae52a31699084c02a2a8216ce43b16322)
