### PR TITLE
Move `DaliOperatorTable` to Coral-Common and rename it

### DIFF
--- a/coral-common/src/main/java/com/linkedin/coral/common/functions/CoralOperatorTable.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/functions/CoralOperatorTable.java
@@ -3,7 +3,7 @@
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
-package com.linkedin.coral.hive.hive2rel;
+package com.linkedin.coral.common.functions;
 
 import java.util.Collection;
 import java.util.List;
@@ -19,26 +19,23 @@ import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.validate.SqlNameMatcher;
 import org.apache.calcite.util.Util;
 
-import com.linkedin.coral.common.functions.Function;
-import com.linkedin.coral.hive.hive2rel.functions.HiveFunctionResolver;
-
 
 /**
- * Class to resolve Dali function names in SQL definition based on
+ * Class to resolve Coral operator names in SQL definition based on
  * the mapping stored in table parameters in the metastore.
  */
-public class DaliOperatorTable implements SqlOperatorTable {
+public class CoralOperatorTable implements SqlOperatorTable {
   // TODO: support injection framework to inject same function resolver here and ParseTreeBuilder.
   // For now, we create another instance since the function registry is simple.
-  private final HiveFunctionResolver funcResolver;
+  private final FunctionResolver funcResolver;
 
-  public DaliOperatorTable(HiveFunctionResolver funcResolver) {
+  public CoralOperatorTable(FunctionResolver funcResolver) {
     this.funcResolver = funcResolver;
   }
 
   /**
-   * Resolves functions names to corresponding Calcite UDF. HiveFunctionResolver ensures that
-   * {@code sqlIdentifier} has function name or corresponding class name for Dali functions. All function registry
+   * Resolves operator names to corresponding Calcite operator. FunctionResolver ensures that
+   * {@code sqlIdentifier} has operator name or corresponding class name for Coral operator. All registry
    * lookups performed by this class are case-insensitive.
    *
    * Calcite invokes this function multiple times during analysis phase to validate SqlCall operators. This is

--- a/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionResolver.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionResolver.java
@@ -9,7 +9,7 @@ import java.util.Collection;
 
 
 /**
- * Class to resolve hive function names in SQL to Function.
+ * Class to resolve function names in SQL to Function.
  */
 public abstract class FunctionResolver {
 
@@ -24,7 +24,5 @@ public abstract class FunctionResolver {
    * @param functionName function name to resolve
    * @return list of matching Functions or empty list if there is no match
    */
-  public Collection<Function> resolve(String functionName) {
-    return registry.lookup(functionName);
-  }
+  public abstract Collection<Function> resolve(String functionName);
 }

--- a/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionResolver.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionResolver.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.common.functions;
+
+import java.util.Collection;
+
+
+/**
+ * Class to resolve hive function names in SQL to Function.
+ */
+public abstract class FunctionResolver {
+
+  protected final FunctionRegistry registry;
+
+  protected FunctionResolver(FunctionRegistry registry) {
+    this.registry = registry;
+  }
+
+  /**
+   * Resolves function to concrete operator case-insensitively.
+   * @param functionName function name to resolve
+   * @return list of matching Functions or empty list if there is no match
+   */
+  public Collection<Function> resolve(String functionName) {
+    return registry.lookup(functionName);
+  }
+}

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverter.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hive.metastore.api.Table;
 
 import com.linkedin.coral.common.HiveMetastoreClient;
 import com.linkedin.coral.common.ToRelConverter;
+import com.linkedin.coral.common.functions.CoralOperatorTable;
 import com.linkedin.coral.hive.hive2rel.functions.HiveFunctionResolver;
 import com.linkedin.coral.hive.hive2rel.functions.StaticHiveFunctionRegistry;
 import com.linkedin.coral.hive.hive2rel.parsetree.ParseTreeBuilder;
@@ -75,7 +76,7 @@ public class HiveToRelConverter extends ToRelConverter {
 
   @Override
   protected SqlOperatorTable getOperatorTable() {
-    return ChainedSqlOperatorTable.of(SqlStdOperatorTable.instance(), new DaliOperatorTable(functionResolver));
+    return ChainedSqlOperatorTable.of(SqlStdOperatorTable.instance(), new CoralOperatorTable(functionResolver));
   }
 
   @Override

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveFunctionResolver.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveFunctionResolver.java
@@ -144,7 +144,7 @@ public class HiveFunctionResolver extends FunctionResolver {
    */
   @Override
   public Collection<Function> resolve(String functionName) {
-    Collection<Function> staticLookup = super.resolve(functionName);
+    Collection<Function> staticLookup = registry.lookup(functionName);
     if (!staticLookup.isEmpty()) {
       return staticLookup;
     } else {

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveFunctionResolver.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveFunctionResolver.java
@@ -33,6 +33,7 @@ import com.linkedin.coral.com.google.common.collect.ImmutableList;
 import com.linkedin.coral.common.HiveTable;
 import com.linkedin.coral.common.functions.Function;
 import com.linkedin.coral.common.functions.FunctionRegistry;
+import com.linkedin.coral.common.functions.FunctionResolver;
 import com.linkedin.coral.common.functions.UnknownSqlFunctionException;
 
 import static com.google.common.base.Preconditions.*;
@@ -43,14 +44,13 @@ import static org.apache.calcite.sql.type.OperandTypes.*;
 /**
  * Class to resolve hive function names in SQL to Function.
  */
-public class HiveFunctionResolver {
+public class HiveFunctionResolver extends FunctionResolver {
 
-  public final FunctionRegistry registry;
   private final ConcurrentHashMap<String, Function> dynamicFunctionRegistry;
   private final List<SqlOperator> operators;
 
   public HiveFunctionResolver(FunctionRegistry registry, ConcurrentHashMap<String, Function> dynamicRegistry) {
-    this.registry = registry;
+    super(registry);
     this.dynamicFunctionRegistry = dynamicRegistry;
     this.operators = new ArrayList<>(SqlStdOperatorTable.instance().getOperatorList());
     operators.add(HiveRLikeOperator.REGEXP);
@@ -142,8 +142,9 @@ public class HiveFunctionResolver {
    * @param functionName function name to resolve
    * @return list of matching Functions or empty list if there is no match
    */
+  @Override
   public Collection<Function> resolve(String functionName) {
-    Collection<Function> staticLookup = registry.lookup(functionName);
+    Collection<Function> staticLookup = super.resolve(functionName);
     if (!staticLookup.isEmpty()) {
       return staticLookup;
     } else {

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/trino2rel/TrinoToRelConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/trino2rel/TrinoToRelConverter.java
@@ -51,7 +51,7 @@ public class TrinoToRelConverter extends ToRelConverter {
   private final FunctionResolver functionResolver = new FunctionResolver(new StaticHiveFunctionRegistry()) {
     @Override
     public Collection<Function> resolve(String functionName) {
-      return super.resolve(functionName);
+      return registry.lookup(functionName);
     }
   };
   private final


### PR DESCRIPTION
This PR is for #235.
`DaliOperatorTable` registers legal operators for Calcite to validate and convert the input SqlNode.
Given we convert other types of operators (like Trino operators) to Hive (Coral) operators in SqlNode phase, we use `DaliOperatorTable` for both Coral-Hive hive2rel, Coral-Trino trino2rel and all the future inputs, therefore, it makes more sense to move `DaliOperatorTable` to Coral-Common. 
To move it, we need to create an abstract class `FunctionResolver` to be used in `CoralOperatorTable`.
cc: @wmoustafa 

Tested by building and i-itest.