### PR TITLE
Coral-Hive: Add UDF name in the log of ArtifactsResolver

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/ArtifactsResolver.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/ArtifactsResolver.java
@@ -58,11 +58,11 @@ public class ArtifactsResolver {
    * "group:name:version@extension"
    * "group:name:version"
    */
-  public List<File> resolve(String dependencySpecString) {
+  public List<File> resolve(String udfClassName, String dependencySpecString) {
     List<File> uris = new ArrayList<>();
     try {
       _ivyInstance.pushContext();
-      final ResolveReport report = getDependencies(createDependencySpec(dependencySpecString));
+      final ResolveReport report = getDependencies(udfClassName, createDependencySpec(dependencySpecString));
       for (ArtifactDownloadReport adr : report.getAllArtifactsReports()) {
         if (adr.getLocalFile() != null) {
           uris.add(adr.getLocalFile());
@@ -105,7 +105,7 @@ public class ArtifactsResolver {
     return dependencySpec;
   }
 
-  private ResolveReport getDependencies(DependencySpec dependencySpec) {
+  private ResolveReport getDependencies(String udfClassName, DependencySpec dependencySpec) {
     final long millis = System.currentTimeMillis();
     final DefaultModuleDescriptor md = DefaultModuleDescriptor
         .newDefaultInstance(ModuleRevisionId.newInstance("caller", "all-caller", "working-" + millis));
@@ -128,11 +128,12 @@ public class ArtifactsResolver {
     try {
       final ResolveReport report = _ivyInstance.resolve(md, resolveOptions);
       if (report.hasError()) {
-        LOG.warn("Unable to fetch dependencies: " + report.getAllProblemMessages());
+        LOG.warn(
+            String.format("Unable to fetch dependencies for UDF %s: %s", udfClassName, report.getAllProblemMessages()));
       }
       return report;
     } catch (ParseException | IOException e) {
-      throw new RuntimeException("Unable to fetch dependencies", e);
+      throw new RuntimeException(String.format("Unable to fetch dependencies for UDF %s", udfClassName), e);
     }
   }
 

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveGenericUDFReturnTypeInference.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveGenericUDFReturnTypeInference.java
@@ -93,9 +93,9 @@ public class HiveGenericUDFReturnTypeInference implements SqlReturnTypeInference
 
   private URLClassLoader getUdfClassLoader() {
     if (_udfClassLoader == null) {
-      URL[] urls =
-          _udfDependencies.stream().flatMap(udfDependency -> _artifactsResolver.resolve(udfDependency).stream())
-              .map(file -> url(file.toURI())).toArray(URL[]::new);
+      URL[] urls = _udfDependencies.stream()
+          .flatMap(udfDependency -> _artifactsResolver.resolve(_udfClassName, udfDependency).stream())
+          .map(file -> url(file.toURI())).toArray(URL[]::new);
 
       _udfClassLoader = new URLClassLoader(urls, ClassLoader.getSystemClassLoader());
     }


### PR DESCRIPTION
Sometimes, the translation on some views takes very long due to the issues like:
```
	impossible to acquire lock for com.fasterxml.jackson.core#jackson-annotations;2.7.8

22/06/05 10:23:49 WARN functions.ArtifactsResolver: Unable to fetch dependencies: [unresolved dependency: com.fasterxml.jackson.core#jackson-annotations;2.7.8: configuration not found in com.fasterxml.jackson.core#jackson-annotations;2.7.8: 'master'. It was required from com.fasterxml.jackson.core#jackson-databind;2.7.8 compile]
```
This PR adds the UDF name to the log for debugging. We may register the affected UDFs to `StaticHiveFunctionRegistry` for such an issue.