### PR TITLE
Support schema converting of union for fixed and bytes

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -582,6 +582,9 @@ class SchemaUtilities {
       if (ImmutableSet.of(ENUM, STRING).equals(types)) {
         return Schema.create(STRING);
       }
+      if (ImmutableSet.of(FIXED, BYTES).equals(types)) {
+        return Schema.create(BYTES);
+      }
     }
 
     throw new RuntimeException("Found two incompatible schemas for LogicalUnion operator. Left schema is: "

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
@@ -87,6 +87,8 @@ public class TestUtils {
     String baseComplexSchema = loadSchema("base-complex.avsc");
     String baseComplexUnionCompatible = loadSchema("base-complex-union-compatible.avsc");
     String baseEnumSchema = loadSchema("base-enum.avsc");
+    String baseBytes = loadSchema("base-bytes.avsc");
+    String baseFixed = loadSchema("base-fixed.avsc");
     String baseLateralViewSchema = loadSchema("base-lateralview.avsc");
     String baseNullabilitySchema = loadSchema("base-nullability.avsc");
     String baseCasePreservation = loadSchema("base-casepreservation.avsc");
@@ -102,6 +104,8 @@ public class TestUtils {
     executeCreateTableQuery("default", "basecomplex", baseComplexSchema);
     executeCreateTableQuery("default", "basecomplexunioncompatible", baseComplexUnionCompatible);
     executeCreateTableQuery("default", "baseenum", baseEnumSchema);
+    executeCreateTableQuery("default", "basebytes", baseBytes);
+    executeCreateTableQuery("default", "basefixed", baseFixed);
     executeCreateTableQuery("default", "baselateralview", baseLateralViewSchema);
     executeCreateTableQuery("default", "basenullability", baseNullabilitySchema);
     executeCreateTableQuery("default", "basenulltypefield", baseNullTypeFieldSchema);

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -987,6 +987,7 @@ public class ViewToAvroSchemaConverterTests {
   public void testUnionFixedAndBytes() {
     String viewSql = "CREATE VIEW v AS SELECT b1.Fixed_field as c1 FROM basefixed b1" + " UNION ALL "
         + "SELECT b2.Bytes_field as c1 FROM basebytes b2";
+
     TestUtils.executeCreateViewQuery("default", "v", viewSql);
 
     ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -984,6 +984,18 @@ public class ViewToAvroSchemaConverterTests {
   }
 
   @Test
+  public void testUnionFixedAndBytes() {
+    String viewSql = "CREATE VIEW v AS SELECT b1.Fixed_field as c1 FROM basefixed b1" + " UNION ALL "
+        + "SELECT b2.Bytes_field as c1 FROM basebytes b2";
+    TestUtils.executeCreateViewQuery("default", "v", viewSql);
+
+    ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);
+    Schema actualSchema = viewToAvroSchemaConverter.toAvroSchema("default", "v");
+
+    Assert.assertEquals(actualSchema.toString(true), TestUtils.loadSchema("testUnionFixedAndBytes-expected.avsc"));
+  }
+
+  @Test
   public void testProjectUdfReturnedStruct() {
     String viewSql = "CREATE VIEW foo_udf_return_struct "
         + "tblproperties('functions' = 'FuncIsEven:com.linkedin.coral.hive.hive2rel.CoralTestUDFReturnStruct') " + "AS "

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -985,8 +985,8 @@ public class ViewToAvroSchemaConverterTests {
 
   @Test
   public void testUnionFixedAndBytes() {
-    String viewSql = "CREATE VIEW v AS SELECT b1.Fixed_field as c1 FROM basefixed b1" + " UNION ALL "
-        + "SELECT b2.Bytes_field as c1 FROM basebytes b2";
+    String viewSql = "CREATE VIEW v AS SELECT b1.Fixed_field AS c1 FROM basefixed b1" + " UNION ALL "
+        + "SELECT b2.Bytes_field AS c1 FROM basebytes b2";
 
     TestUtils.executeCreateViewQuery("default", "v", viewSql);
 

--- a/coral-schema/src/test/resources/base-bytes.avsc
+++ b/coral-schema/src/test/resources/base-bytes.avsc
@@ -1,0 +1,12 @@
+{
+  "type" : "record",
+  "name" : "basebytes",
+  "namespace" : "coral.schema.avro.base.bytes",
+  "fields" : [ {
+    "name" : "Bytes_field",
+    "type" : [ "null", {
+      "type" : "bytes",
+      "name": "bytes_field"
+    } ]
+  } ]
+}

--- a/coral-schema/src/test/resources/base-fixed.avsc
+++ b/coral-schema/src/test/resources/base-fixed.avsc
@@ -1,0 +1,13 @@
+{
+  "type" : "record",
+  "name" : "basefixed",
+  "namespace" : "coral.schema.avro.base.fixed",
+  "fields" : [ {
+    "name" : "Fixed_field",
+    "type" : [ "null", {
+      "type" : "fixed",
+      "size": 16,
+      "name": "fixed_field"
+    } ]
+  } ]
+}

--- a/coral-schema/src/test/resources/testUnionFixedAndBytes-expected.avsc
+++ b/coral-schema/src/test/resources/testUnionFixedAndBytes-expected.avsc
@@ -1,0 +1,9 @@
+{
+  "type" : "record",
+  "name" : "v",
+  "namespace" : "default.v",
+  "fields" : [ {
+    "name" : "c1",
+    "type" : [ "null", "bytes" ]
+  } ]
+}


### PR DESCRIPTION
From [Avro Spec](https://avro.apache.org/docs/current/spec.html),  bytes is a sequence of 8-bit unsigned bytes and fixed is a containing a fixed-size number of bytes, so we can support the union of Bytes and Fixed column and the return type will be bytes.
 
Without this PR, we will see the following error message during union of fixed and bytes column

`Exception in thread "main" java.lang.RuntimeException: Found two incompatible schemas for LogicalUnion operator. Left schema is: "bytes". Right schema is: fixed`

