### PR TITLE
Register some UDFs

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -433,6 +433,11 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
         STRING_STRING);
     createAddUserDefinedFunction("com.linkedin.dali.view.udf.entityhandles.PhoneNumberNormalizer",
         FunctionReturnTypes.STRING, STRING_STRING_STRING);
+    createAddUserDefinedFunction("com.linkedin.dali.views.feed.udf.GenerateDecoratedFeedUpdateData",
+        FunctionReturnTypes.arrayOfType(SqlTypeName.ANY),
+        family(SqlTypeFamily.STRING, SqlTypeFamily.MAP, SqlTypeFamily.MAP));
+    createAddUserDefinedFunction("com.linkedin.dali.views.feed.udf.UnifiedResultsToFeedUpdates",
+        FunctionReturnTypes.arrayOfType(SqlTypeName.ANY), family(SqlTypeFamily.ARRAY));
     createAddUserDefinedFunction("com.linkedin.dali.views.job.udf.GetUUID", FunctionReturnTypes.STRING, BINARY);
     createAddUserDefinedFunction("com.linkedin.dali.views.premium.udf.GetOrderUrn", FunctionReturnTypes.STRING,
         family(SqlTypeFamily.MAP, SqlTypeFamily.STRING));
@@ -527,6 +532,8 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
         FunctionReturnTypes.STRING, STRING);
     createAddUserDefinedFunction("com.linkedin.etg.business.common.udfs.MapD365OptionSet", FunctionReturnTypes.STRING,
         STRING_STRING_STRING);
+    createAddUserDefinedFunction("isb.GetProfileSections", FunctionReturnTypes.arrayOfType(SqlTypeName.ANY),
+        or(family(SqlTypeFamily.MAP, SqlTypeFamily.ARRAY), family(SqlTypeFamily.MAP)));
 
     // The following UDFs are already defined using Transport UDF.
     // The class name is the corresponding Hive UDF.
@@ -572,7 +579,7 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
       RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
       return typeFactory.createArrayType(typeFactory.createMapType(typeFactory.createSqlType(SqlTypeName.VARCHAR),
           typeFactory.createSqlType(SqlTypeName.VARCHAR)), -1);
-    }, STRING);
+    }, or(ARRAY, STRING));
     createAddUserDefinedFunction("com.linkedin.udfs.standard.hive.ObfuscateMemberIdNumeric", BIGINT,
         family(SqlTypeFamily.ANY, SqlTypeFamily.STRING));
     createAddUserDefinedFunction("com.linkedin.udfs.standard.hive.ObfuscateMemberIdNumericInt", BIGINT,

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -440,6 +440,8 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
         family(SqlTypeFamily.MAP));
     createAddUserDefinedFunction("com.linkedin.dali.views.premium.udf.GetFamily", FunctionReturnTypes.STRING,
         family(SqlTypeFamily.MAP));
+    createAddUserDefinedFunction("com.linkedin.dali.views.premium.udf.GetPriceUrnList",
+        FunctionReturnTypes.arrayOfType(SqlTypeName.VARCHAR), family(SqlTypeFamily.MAP));
 
     final SqlReturnTypeInference hitInfo = FunctionReturnTypes.rowOfInference(
         ImmutableList.of("secondarysearchresultinfo", "entityawaresuggestioninfo"),
@@ -566,6 +568,11 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
         STRING_STRING_STRING);
     createAddUserDefinedFunction("com.linkedin.stdudfs.daliudfs.hive.IsTestMemberId", ReturnTypes.BOOLEAN,
         family(SqlTypeFamily.NUMERIC, SqlTypeFamily.STRING));
+    createAddUserDefinedFunction("com.linkedin.stdudfs.urnextractor.hive.UrnExtractorFunctionWrapper", opBinding -> {
+      RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
+      return typeFactory.createArrayType(typeFactory.createMapType(typeFactory.createSqlType(SqlTypeName.VARCHAR),
+          typeFactory.createSqlType(SqlTypeName.VARCHAR)), -1);
+    }, STRING);
     createAddUserDefinedFunction("com.linkedin.udfs.standard.hive.ObfuscateMemberIdNumeric", BIGINT,
         family(SqlTypeFamily.ANY, SqlTypeFamily.STRING));
     createAddUserDefinedFunction("com.linkedin.udfs.standard.hive.ObfuscateMemberIdNumericInt", BIGINT,


### PR DESCRIPTION
`ArtifactsResolver` takes very long to resolve these UDFs dynamically due to the issues like:
```
	impossible to acquire lock for com.fasterxml.jackson.core#jackson-annotations;2.7.8

22/06/14 19:44:09 WARN functions.ArtifactsResolver: Unable to fetch dependencies: [unresolved dependency: com.fasterxml.jackson.core#jackson-annotations;2.7.8: configuration not found in com.fasterxml.jackson.core#jackson-annotations;2.7.8: 'master'. It was required from com.fasterxml.jackson.core#jackson-databind;2.7.8 compile]
```
This PR registers these UDFs manually to mitigate this issue.

Tested on the affected production views, which can be translated well in normal time with this PR.