### PR TITLE
Support schema enum union with different number of symbols and enum u…

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -554,19 +554,11 @@ class SchemaUtilities {
           }
           break;
         case ENUM:
-          if (leftSchema.getEnumSymbols().size() == rightSchema.getEnumSymbols().size()) {
-            return leftSchema;
-          }
-          // Check if the symbols of one Enum is a strict subset of the other
-          final ImmutableSet<String> leftSchemaSymbols = ImmutableSet.copyOf(leftSchema.getEnumSymbols());
-          final ImmutableSet<String> rightSchemaSymbols = ImmutableSet.copyOf(rightSchema.getEnumSymbols());
-          if (leftSchemaSymbols.containsAll(rightSchemaSymbols)) {
-            return leftSchema;
-          }
-          if (rightSchemaSymbols.containsAll(leftSchemaSymbols)) {
-            return rightSchema;
-          }
-          break;
+          // Union symbols of two Enum
+          ImmutableSet<String> schemaSymbols = ImmutableSet.<String> builder().addAll(leftSchema.getEnumSymbols())
+              .addAll(rightSchema.getEnumSymbols()).build();
+          return Schema.createEnum(leftSchema.getName(), leftSchema.getDoc(), leftSchema.getNamespace(),
+              schemaSymbols.asList());
         case RECORD:
           return mergeUnionRecordSchema(leftSchema, rightSchema, strictMode);
         case MAP:

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -949,6 +949,30 @@ public class ViewToAvroSchemaConverterTests {
   }
 
   @Test
+  public void testEnumUnionEnum() {
+    String viewSql = "CREATE VIEW v AS SELECT b1.Enum_Top_Col AS c1 FROM baseenum b1"
+        + " UNION ALL SELECT b2.Enum_Second_Col AS c1 FROM baseenum b2";
+    TestUtils.executeCreateViewQuery("default", "v", viewSql);
+
+    ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);
+    Schema actualSchema = viewToAvroSchemaConverter.toAvroSchema("default", "v");
+
+    Assert.assertEquals(actualSchema.toString(true), TestUtils.loadSchema("testEnumUnionEnum-expected.avsc"));
+  }
+
+  @Test
+  public void testEnumUnionString() {
+    String viewSql = "CREATE VIEW v AS SELECT b1.Enum_Top_Col AS c1 FROM baseenum b1"
+        + " UNION ALL SELECT b2.Struct_Col.String_Field AS c1 FROM basecomplex b2";
+    TestUtils.executeCreateViewQuery("default", "v", viewSql);
+
+    ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);
+    Schema actualSchema = viewToAvroSchemaConverter.toAvroSchema("default", "v");
+
+    Assert.assertEquals(actualSchema.toString(true), TestUtils.loadSchema("testEnumUnionString-expected.avsc"));
+  }
+
+  @Test
   public void testComplexUnionType() {
     String viewSql = "CREATE VIEW v AS SELECT * FROM basecomplexuniontype";
     TestUtils.executeCreateViewQuery("default", "v", viewSql);

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -950,8 +950,8 @@ public class ViewToAvroSchemaConverterTests {
 
   @Test
   public void testEnumUnionEnum() {
-    String viewSql = "CREATE VIEW v AS SELECT b1.Enum_Top_Col AS c1 FROM baseenum b1"
-        + " UNION ALL SELECT b2.Enum_Second_Col AS c1 FROM baseenum b2";
+    String viewSql = "CREATE VIEW v AS SELECT b1.Enum_Second_Col AS c1 FROM baseenum b1"
+        + " UNION ALL SELECT b2.Enum_Third_Col AS c1 FROM baseenum b2";
     TestUtils.executeCreateViewQuery("default", "v", viewSql);
 
     ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);

--- a/coral-schema/src/test/resources/base-enum.avsc
+++ b/coral-schema/src/test/resources/base-enum.avsc
@@ -27,6 +27,13 @@
       "symbols" : [ "Spark", "Pig", "Hive", "MR" ]
     }
   }, {
+    "name" : "Enum_Second_Col",
+    "type" : {
+      "type" : "enum",
+      "name" : "Enum_Second_col",
+      "symbols" : [ "Spark", "Pig", "Hive", "MR", "Avro" ]
+    }
+  }, {
     "name" : "Struct_Col",
     "type" : [ "null", {
       "type" : "record",

--- a/coral-schema/src/test/resources/base-enum.avsc
+++ b/coral-schema/src/test/resources/base-enum.avsc
@@ -34,6 +34,13 @@
       "symbols" : [ "Spark", "Pig", "Hive", "MR", "Avro" ]
     }
   }, {
+      "name" : "Enum_Third_Col",
+      "type" : {
+        "type" : "enum",
+        "name" : "Enum_Third_Col",
+        "symbols" : [ "Option1", "Option2", "Option3", "Option4" ]
+      }
+    },{
     "name" : "Struct_Col",
     "type" : [ "null", {
       "type" : "record",

--- a/coral-schema/src/test/resources/testEnumUnionEnum-expected.avsc
+++ b/coral-schema/src/test/resources/testEnumUnionEnum-expected.avsc
@@ -1,0 +1,14 @@
+{
+  "type" : "record",
+  "name" : "v",
+  "namespace" : "default.v",
+  "fields" : [ {
+    "name" : "c1",
+    "type" : {
+      "type" : "enum",
+      "name" : "Enum_Second_col",
+      "namespace" : "default.v.v",
+      "symbols" : [ "Spark", "Pig", "Hive", "MR", "Avro" ]
+    }
+  } ]
+}

--- a/coral-schema/src/test/resources/testEnumUnionEnum-expected.avsc
+++ b/coral-schema/src/test/resources/testEnumUnionEnum-expected.avsc
@@ -8,7 +8,7 @@
       "type" : "enum",
       "name" : "Enum_Second_col",
       "namespace" : "default.v.v",
-      "symbols" : [ "Spark", "Pig", "Hive", "MR", "Avro" ]
+      "symbols" : [ "Spark", "Pig", "Hive", "MR", "Avro", "Option1", "Option2", "Option3", "Option4" ]
     }
   } ]
 }

--- a/coral-schema/src/test/resources/testEnumUnionString-expected.avsc
+++ b/coral-schema/src/test/resources/testEnumUnionString-expected.avsc
@@ -1,0 +1,9 @@
+{
+  "type" : "record",
+  "name" : "v",
+  "namespace" : "default.v",
+  "fields" : [ {
+    "name" : "c1",
+    "type" : [ "null", "string" ]
+  } ]
+}


### PR DESCRIPTION
This is similar to this [PR](https://github.com/linkedin/coral/pull/280). We should support the union of `enum` and `string` type, and the union of  enums with different number of symbols but the symbols of one enum is a strict subset of the other.