### PR TITLE
Correct nullability information for certain functions to unblock a vi…

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -198,7 +198,8 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
     createAddUserDefinedFunction("base64", FunctionReturnTypes.STRING, BINARY);
     createAddUserDefinedFunction("character_length", ReturnTypes.INTEGER, STRING);
     createAddUserDefinedFunction("chr", FunctionReturnTypes.STRING, NUMERIC);
-    createAddUserDefinedFunction("concat", cascade(FunctionReturnTypes.STRING, SqlTypeTransforms.TO_NULLABLE), SAME_VARIADIC);
+    createAddUserDefinedFunction("concat", cascade(FunctionReturnTypes.STRING, SqlTypeTransforms.TO_NULLABLE),
+        SAME_VARIADIC);
     // [CORAL-24] Tried setting this to
     // or(family(SqlTypeFamily.STRING, SqlTypeFamily.ARRAY),
     // and(variadic(SqlOperandCountRanges.from(2)), repeat(SqlOperandCountRanges.from(2), STRING)))
@@ -400,7 +401,7 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
         FunctionReturnTypes.STRING, STRING_STRING);
     createAddUserDefinedFunction("com.linkedin.dali.udf.maplookup.hive.MapLookup",
         cascade(FunctionReturnTypes.STRING, SqlTypeTransforms.FORCE_NULLABLE),
-            family(SqlTypeFamily.MAP, SqlTypeFamily.STRING, SqlTypeFamily.STRING));
+        family(SqlTypeFamily.MAP, SqlTypeFamily.STRING, SqlTypeFamily.STRING));
     createAddUserDefinedFunction("com.linkedin.dali.udf.monarch.UrnGenerator", FunctionReturnTypes.STRING, VARIADIC);
     createAddUserDefinedFunction("com.linkedin.dali.udf.genericlookup.hive.GenericLookup", FunctionReturnTypes.STRING,
         or(family(SqlTypeFamily.STRING, SqlTypeFamily.STRING, SqlTypeFamily.STRING, SqlTypeFamily.ANY,
@@ -547,7 +548,7 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
     createAddUserDefinedFunction("com.linkedin.stdudfs.daliudfs.hive.IsGuestMemberId", ReturnTypes.BOOLEAN, NUMERIC);
     createAddUserDefinedFunction("com.linkedin.stdudfs.daliudfs.hive.MapLookup",
         cascade(FunctionReturnTypes.STRING, SqlTypeTransforms.FORCE_NULLABLE),
-            family(SqlTypeFamily.MAP, SqlTypeFamily.STRING, SqlTypeFamily.STRING));
+        family(SqlTypeFamily.MAP, SqlTypeFamily.STRING, SqlTypeFamily.STRING));
     createAddUserDefinedFunction("com.linkedin.stdudfs.daliudfs.hive.PortalLookup", FunctionReturnTypes.STRING,
         STRING_STRING);
     createAddUserDefinedFunction("com.linkedin.stdudfs.daliudfs.hive.Sanitize", FunctionReturnTypes.STRING, STRING);

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -23,14 +23,7 @@ import org.apache.calcite.sql.SqlOperandCountRange;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
-import org.apache.calcite.sql.type.ReturnTypes;
-import org.apache.calcite.sql.type.SameOperandTypeChecker;
-import org.apache.calcite.sql.type.SqlOperandCountRanges;
-import org.apache.calcite.sql.type.SqlOperandTypeChecker;
-import org.apache.calcite.sql.type.SqlOperandTypeInference;
-import org.apache.calcite.sql.type.SqlReturnTypeInference;
-import org.apache.calcite.sql.type.SqlTypeFamily;
-import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.*;
 import org.apache.calcite.sql.validate.SqlUserDefinedFunction;
 
 import com.linkedin.coral.com.google.common.collect.HashMultimap;
@@ -205,7 +198,7 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
     createAddUserDefinedFunction("base64", FunctionReturnTypes.STRING, BINARY);
     createAddUserDefinedFunction("character_length", ReturnTypes.INTEGER, STRING);
     createAddUserDefinedFunction("chr", FunctionReturnTypes.STRING, NUMERIC);
-    createAddUserDefinedFunction("concat", FunctionReturnTypes.STRING, SAME_VARIADIC);
+    createAddUserDefinedFunction("concat", cascade(FunctionReturnTypes.STRING, SqlTypeTransforms.TO_NULLABLE), SAME_VARIADIC);
     // [CORAL-24] Tried setting this to
     // or(family(SqlTypeFamily.STRING, SqlTypeFamily.ARRAY),
     // and(variadic(SqlOperandCountRanges.from(2)), repeat(SqlOperandCountRanges.from(2), STRING)))
@@ -405,8 +398,9 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
         STRING_STRING_STRING);
     createAddUserDefinedFunction("com.linkedin.dali.udf.useragentparser.hive.UserAgentParser",
         FunctionReturnTypes.STRING, STRING_STRING);
-    createAddUserDefinedFunction("com.linkedin.dali.udf.maplookup.hive.MapLookup", FunctionReturnTypes.STRING,
-        family(SqlTypeFamily.MAP, SqlTypeFamily.STRING, SqlTypeFamily.STRING));
+    createAddUserDefinedFunction("com.linkedin.dali.udf.maplookup.hive.MapLookup",
+        cascade(FunctionReturnTypes.STRING, SqlTypeTransforms.FORCE_NULLABLE),
+            family(SqlTypeFamily.MAP, SqlTypeFamily.STRING, SqlTypeFamily.STRING));
     createAddUserDefinedFunction("com.linkedin.dali.udf.monarch.UrnGenerator", FunctionReturnTypes.STRING, VARIADIC);
     createAddUserDefinedFunction("com.linkedin.dali.udf.genericlookup.hive.GenericLookup", FunctionReturnTypes.STRING,
         or(family(SqlTypeFamily.STRING, SqlTypeFamily.STRING, SqlTypeFamily.STRING, SqlTypeFamily.ANY,
@@ -551,8 +545,9 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
         NUMERIC);
     createAddUserDefinedFunction("com.linkedin.stdudfs.stringudfs.hive.InitCap", FunctionReturnTypes.STRING, STRING);
     createAddUserDefinedFunction("com.linkedin.stdudfs.daliudfs.hive.IsGuestMemberId", ReturnTypes.BOOLEAN, NUMERIC);
-    createAddUserDefinedFunction("com.linkedin.stdudfs.daliudfs.hive.MapLookup", FunctionReturnTypes.STRING,
-        family(SqlTypeFamily.MAP, SqlTypeFamily.STRING, SqlTypeFamily.STRING));
+    createAddUserDefinedFunction("com.linkedin.stdudfs.daliudfs.hive.MapLookup",
+        cascade(FunctionReturnTypes.STRING, SqlTypeTransforms.FORCE_NULLABLE),
+            family(SqlTypeFamily.MAP, SqlTypeFamily.STRING, SqlTypeFamily.STRING));
     createAddUserDefinedFunction("com.linkedin.stdudfs.daliudfs.hive.PortalLookup", FunctionReturnTypes.STRING,
         STRING_STRING);
     createAddUserDefinedFunction("com.linkedin.stdudfs.daliudfs.hive.Sanitize", FunctionReturnTypes.STRING, STRING);


### PR DESCRIPTION
…ew for spark3

Previously a production view failed in translation in spark3, due to the fact that the view defines a `named_struct` logic: 
```
NAMED_STRUCT(
    'objectUrn', CONCAT('xxx', company_id),
    ...
```

which the `company_id` itself is from another projection:

```
    mapLookup(
      trackinginfo,
      'xxx',
      'xxx''
    ) AS company_id
```

Coral derives the `objectUrn` to be non-nullable, which is incorrect against spark3's derivation, and it makes the view fails in spark3.

I found out that the `named_struct` relevant code logic in `HiveNamedStructFunction` , and it uses the return type inference logics defined in `StaticHiveFunctionRegistry` to derive type information (including nullability). So this patch will fix the nullability to be correct.