### PR TITLE
Coral-Spark: Register generic_project UDF

### DIFF
--- a/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
@@ -313,6 +313,10 @@ class IRRelToSparkRelTransformer {
      */
     private Optional<RexNode> convertFuzzyUnionGenericProject(RexCall call) {
       if (call.getOperator() instanceof GenericProjectFunction) {
+        // Register generic_project UDF
+        sparkUDFInfos.add(new SparkUDFInfo("com.linkedin.genericprojectudf.GenericProject", "generic_project",
+            ImmutableList.of(URI.create("ivy://com.linkedin.GenericProject:GenericProject-impl:0.0.2")),
+            SparkUDFInfo.UDFTYPE.HIVE_CUSTOM_UDF));
         RelDataType expectedRelDataType = call.getType();
         String expectedRelDataTypeString = RelDataTypeToHiveTypeStringConverter.convertRelDataType(expectedRelDataType);
 


### PR DESCRIPTION
We need to register `generic_project` UDF if it's used in Spark SQL, otherwise Spark will throw the following exception because it can't recognize `generic_project`:
```
org.apache.spark.sql.AnalysisException: Undefined function: 'generic_project'. This function is neither a registered temporary function nor a permanent function registered in the database 'default'.; line 1 pos 7
```

Tested on gateway with Spark3, the affected view can be queried with this PR.

