### PR TITLE
Coral-Schema: Add support for LogicalValues

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
@@ -197,8 +197,10 @@ public class RelToAvroSchemaConverter {
 
     @Override
     public RelNode visit(LogicalValues logicalValues) {
-      // TODO: implement this method
-      return super.visit(logicalValues);
+      RelNode relNode = super.visit(logicalValues);
+      schemaMap.put(logicalValues,
+          RelDataTypeToAvroType.relDataTypeToAvroTypeNonNullable(logicalValues.getRowType(), "literalvalue"));
+      return relNode;
     }
 
     @Override

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -1024,5 +1024,12 @@ public class ViewToAvroSchemaConverterTests {
     Assert.assertEquals(actualSchema.toString(true), TestUtils.loadSchema("testLowercaseSchema-expected.avsc"));
   }
 
+  @Test
+  public void testSelectWithoutBaseTable() {
+    final ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);
+    final Schema actualSchema = viewToAvroSchemaConverter.toAvroSchema("SELECT 1 intCol");
+
+    Assert.assertEquals(actualSchema.toString(true), TestUtils.loadSchema("testSelectWithoutBaseTable-expected.avsc"));
+  }
   // TODO: add more unit tests
 }

--- a/coral-schema/src/test/resources/testSelectWithoutBaseTable-expected.avsc
+++ b/coral-schema/src/test/resources/testSelectWithoutBaseTable-expected.avsc
@@ -1,0 +1,10 @@
+{
+  "type" : "record",
+  "name" : "literalvalue",
+  "namespace" : "rel_avro",
+  "fields" : [ {
+    "name" : "intCol",
+    "type" : [ "null", "int" ],
+    "doc" : "Field created from view literal with value: 1"
+  } ]
+}


### PR DESCRIPTION
I encountered the following exception while querying a simple view `SELECT 1 intCol` on Spark shell:
```
Caused by: java.lang.NullPointerException
	at com.linkedin.coral.schema.avro.RelToAvroSchemaConverter$SchemaRelShuttle.visit(RelToAvroSchemaConverter.java:224)
	at coral_dali.org.apache.calcite.rel.logical.LogicalProject.accept(LogicalProject.java:121)
	at com.linkedin.coral.schema.avro.RelToAvroSchemaConverter.convert(RelToAvroSchemaConverter.java:127)
	at com.linkedin.coral.schema.avro.ViewToAvroSchemaConverter.inferAvroSchema(ViewToAvroSchemaConverter.java:199)
	at com.linkedin.coral.schema.avro.ViewToAvroSchemaConverter.toAvroSchema(ViewToAvroSchemaConverter.java:102)
``` 
It happened because there is no handling for `LogicalValues` when there is no base table. Adding the support for LogicalValues fixes this issue.

Tests:
1. Unit test
2. Tested on Spark shell, the affected view can be queried well