### PR TITLE
Add return type inference for isb.GetProfileSections

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -527,8 +527,17 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
         FunctionReturnTypes.STRING, STRING);
     createAddUserDefinedFunction("com.linkedin.etg.business.common.udfs.MapD365OptionSet", FunctionReturnTypes.STRING,
         STRING_STRING_STRING);
-    createAddUserDefinedFunction("isb.GetProfileSections", FunctionReturnTypes.arrayOfType(SqlTypeName.ANY),
-        or(family(SqlTypeFamily.MAP, SqlTypeFamily.ARRAY), family(SqlTypeFamily.MAP)));
+
+    SqlReturnTypeInference getProfileSectionsReturnTypeInference = opBinding -> {
+      int numArgs = opBinding.getOperandCount();
+      Preconditions.checkState(numArgs == 2, "UDF isb.GetProfileSections must take 2 arguments.");
+      RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
+      RelDataType retType = opBinding.getOperandType(0).getValueType();
+      return typeFactory.createArrayType(retType, -1);
+    };
+    createAddUserDefinedFunction("isb.GetProfileSections", getProfileSectionsReturnTypeInference,
+        family(SqlTypeFamily.MAP, SqlTypeFamily.ARRAY));
+
     createAddUserDefinedFunction("com.linkedin.recruiter.udf.GetEventOriginUDF", FunctionReturnTypes.STRING,
         or(STRING_STRING_STRING,
             family(SqlTypeFamily.STRING, SqlTypeFamily.STRING, SqlTypeFamily.STRING, SqlTypeFamily.STRING)));


### PR DESCRIPTION
Fix the return type inference of `isb.GetProfileSections` by explicitly define its `SqlReturnTypeInference` logic in the `StaticHiveFunctionRegistry`.

Verified the fix works by validating the output avro schema of such a UDF transformation result in the correct output avro schema.