### PR TITLE
UDF: Add additional UDF mapping to handle Trino naming discrepancies

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -590,6 +590,11 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
       return typeFactory.createArrayType(typeFactory.createMapType(typeFactory.createSqlType(SqlTypeName.VARCHAR),
           typeFactory.createSqlType(SqlTypeName.VARCHAR)), -1);
     }, or(ARRAY, STRING));
+    createAddUserDefinedFunction("com.linkedin.stdudfs.hive.daliudfs.UrnExtractorFunctionWrapper", opBinding -> {
+      RelDataTypeFactory typeFactory = opBinding.getTypeFactory();
+      return typeFactory.createArrayType(typeFactory.createMapType(typeFactory.createSqlType(SqlTypeName.VARCHAR),
+          typeFactory.createSqlType(SqlTypeName.VARCHAR)), -1);
+    }, or(ARRAY, STRING));
     createAddUserDefinedFunction("com.linkedin.udfs.standard.hive.ObfuscateMemberIdNumeric", BIGINT,
         family(SqlTypeFamily.ANY, SqlTypeFamily.STRING));
     createAddUserDefinedFunction("com.linkedin.udfs.standard.hive.ObfuscateMemberIdNumericInt", BIGINT,

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CalciteTrinoUDFMap.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CalciteTrinoUDFMap.java
@@ -82,9 +82,8 @@ public class CalciteTrinoUDFMap {
         null);
 
     // DALI functions
-    // Most "com.linkedin..." UDFs follow convention of having UDF names mapped from their class name by converting
-    // the classname to LOWER_UNDERSCORE. For example: For class name IsGuestMemberId, the conventional udf name would
-    // be is_guest_member_id.
+    // Most "com.linkedin..." UDFs follow convention of having UDF names mapped from camel-cased name to snake-cased name.
+    // For example: For class name IsGuestMemberId, the conventional udf name would be is_guest_member_id.
     // While this convention fits most UDFs it doesn't fit all. With the following mapping we override the conventional
     // UDF name mapping behavior to a hardcoded one.
     // For example instead of UserAgentParser getting mapped to user_agent_parser, we mapped it here to useragentparser
@@ -94,9 +93,14 @@ public class CalciteTrinoUDFMap {
     createUDFMapEntry(UDF_MAP, daliToCalciteOp("com.linkedin.stdudfs.parsing.hive.Ip2Str"), 3, "ip2str");
     createUDFMapEntry(UDF_MAP, daliToCalciteOp("com.linkedin.stdudfs.parsing.hive.UserAgentParser"), 2,
         "useragentparser");
+
     createUDFMapEntry(UDF_MAP, daliToCalciteOp("com.linkedin.stdudfs.lookup.hive.BrowserLookup"), 3, "browserlookup");
     createUDFMapEntry(UDF_MAP, daliToCalciteOp("com.linkedin.jobs.udf.hive.ConvertIndustryCode"), 1,
         "converttoindustryv1");
+    createUDFMapEntry(UDF_MAP, daliToCalciteOp("com.linkedin.stdudfs.urnextractor.hive.UrnExtractorFunctionWrapper"), 1,
+        "urn_extractor");
+    createUDFMapEntry(UDF_MAP, daliToCalciteOp("com.linkedin.stdudfs.hive.daliudfs.UrnExtractorFunctionWrapper"), 1,
+        "urn_extractor");
 
     addDaliUDFs();
   }


### PR DESCRIPTION
Add a hive udf registration, as well as the mapping rule to a Trino udf to fill in the gap of default rules of UDF naming conversion, which is from camel use to snake case. 