### PR TITLE
Coral-spark: Remove explicit casting for nullability difference

### DIFF
--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -1026,14 +1026,15 @@ public class ViewToAvroSchemaConverterTests {
 
   @Test
   public void testCaseCallWithNullBranchAndComplexDataTypeBranch() {
-    String viewSql = "CREATE VIEW v AS SELECT CASE WHEN TRUE THEN NULL ELSE split(struct_col.string_field, ' ') END AS col1 FROM basecomplex";
+    String viewSql =
+        "CREATE VIEW v AS SELECT CASE WHEN TRUE THEN NULL ELSE split(struct_col.string_field, ' ') END AS col1 FROM basecomplex";
     TestUtils.executeCreateViewQuery("default", "v", viewSql);
 
     ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);
     Schema actualSchema = viewToAvroSchemaConverter.toAvroSchema("default", "v");
 
     Assert.assertEquals(actualSchema.toString(true),
-            TestUtils.loadSchema("testCaseCallWithNullBranchAndComplexDataTypeBranch-expected.avsc"));
+        TestUtils.loadSchema("testCaseCallWithNullBranchAndComplexDataTypeBranch-expected.avsc"));
   }
 
   // TODO: add more unit tests

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -1024,5 +1024,17 @@ public class ViewToAvroSchemaConverterTests {
     Assert.assertEquals(actualSchema.toString(true), TestUtils.loadSchema("testLowercaseSchema-expected.avsc"));
   }
 
+  @Test
+  public void testCaseCallWithNullBranchAndComplexDataTypeBranch() {
+    String viewSql = "CREATE VIEW v AS SELECT CASE WHEN TRUE THEN NULL ELSE split(struct_col.string_field, ' ') END AS col1 FROM basecomplex";
+    TestUtils.executeCreateViewQuery("default", "v", viewSql);
+
+    ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);
+    Schema actualSchema = viewToAvroSchemaConverter.toAvroSchema("default", "v");
+
+    Assert.assertEquals(actualSchema.toString(true),
+            TestUtils.loadSchema("testCaseCallWithNullBranchAndComplexDataTypeBranch-expected.avsc"));
+  }
+
   // TODO: add more unit tests
 }

--- a/coral-schema/src/test/resources/testCaseCallWithNullBranchAndComplexDataTypeBranch-expected.avsc
+++ b/coral-schema/src/test/resources/testCaseCallWithNullBranchAndComplexDataTypeBranch-expected.avsc
@@ -1,0 +1,13 @@
+{
+  "type" : "record",
+  "name" : "v",
+  "namespace" : "default.v",
+  "fields" : [ {
+    "name" : "col1",
+    "type" : [ "null", {
+      "type" : "array",
+      "items" : "string"
+    } ],
+    "doc" : "Field created in view by applying operator 'CASE' with argument(s): true, value with type VARCHAR(65535) ARRAY, value with type VARCHAR(65535) ARRAY"
+  } ]
+}

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
@@ -34,11 +34,7 @@ import org.apache.calcite.rel.logical.LogicalValues;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.rel.type.RelRecordType;
-import org.apache.calcite.rex.RexBuilder;
-import org.apache.calcite.rex.RexCall;
-import org.apache.calcite.rex.RexLiteral;
-import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.rex.*;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
@@ -208,7 +204,7 @@ class IRRelToSparkRelTransformer {
           convertToZeroBasedArrayIndex(updatedCall).orElseGet(() -> convertToNamedStruct(updatedCall)
               .orElseGet(() -> convertFuzzyUnionGenericProject(updatedCall).orElseGet(() -> convertDaliUDF(updatedCall)
                   .orElseGet(() -> convertBuiltInUDF(updatedCall).orElseGet(() -> fallbackToHiveUdf(updatedCall)
-                      .orElseGet(() -> swapExtractUnionFunction(updatedCall).orElse(updatedCall)))))));
+                      .orElseGet(() -> swapExtractUnionFunction(updatedCall).orElseGet(() -> removeCastToEnsureCorrectNullability(updatedCall).orElse(updatedCall))))))));
 
       return convertToNewNode;
     }
@@ -363,6 +359,29 @@ class IRRelToSparkRelTransformer {
           return Optional.of(rexBuilder.makeCall(
               createUDF("coalesce_struct", CoalesceStructUtility.COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY),
               operandsCopy));
+        }
+      }
+      return Optional.empty();
+    }
+
+    // Calcite entails the nullability of an expression by casting it to the correct nullable type.
+    // However, for complex types like ARRAY<STRING NOT NULL> (element non-nullable, but top-level nullable),
+    // the translated SQL will still be `CAST(XXX) AS ARRAY<STRING>`. Since Spark treats a Cast target type
+    // as always nullable (both inner and outer), it will treat the SQL type as ARRAY<STRING>, this deviates
+    // from the nullability represented in RelNode/Coral-Schema.
+    // To make this work, we remove all the CAST expressions induced by nullability differences, and let Spark's
+    // SQL analyzer derive the nullability for the SQL itself, and as long as Coral-Schema can be an equal or looser
+    // with regard to the Spark analyzer schema, it should make Coral compatible with Spark.
+    private Optional<RexNode> removeCastToEnsureCorrectNullability(RexCall call) {
+      if (call.getOperator().equals(SqlStdOperatorTable.CAST)) {
+        if (RexUtil.isNullLiteral(call, true)) {
+          return Optional.of(rexBuilder.makeNullLiteral(call.getType()));
+        }
+        RelDataType castType = call.getType();
+        RelDataType originalType = call.getOperands().get(0).getType();
+        if (castType.isNullable() && !originalType.isNullable()
+          && rexBuilder.getTypeFactory().createTypeWithNullability(originalType, true).equals(castType)) {
+          return Optional.of(rexBuilder.copy(call.getOperands().get(0)));
         }
       }
       return Optional.empty();

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/IRRelToSparkRelTransformer.java
@@ -200,11 +200,11 @@ class IRRelToSparkRelTransformer {
 
       RexCall updatedCall = (RexCall) super.visitCall(call);
 
-      RexNode convertToNewNode =
-          convertToZeroBasedArrayIndex(updatedCall).orElseGet(() -> convertToNamedStruct(updatedCall)
-              .orElseGet(() -> convertFuzzyUnionGenericProject(updatedCall).orElseGet(() -> convertDaliUDF(updatedCall)
-                  .orElseGet(() -> convertBuiltInUDF(updatedCall).orElseGet(() -> fallbackToHiveUdf(updatedCall)
-                      .orElseGet(() -> swapExtractUnionFunction(updatedCall).orElseGet(() -> removeCastToEnsureCorrectNullability(updatedCall).orElse(updatedCall))))))));
+      RexNode convertToNewNode = convertToZeroBasedArrayIndex(updatedCall).orElseGet(
+          () -> convertToNamedStruct(updatedCall).orElseGet(() -> convertFuzzyUnionGenericProject(updatedCall)
+              .orElseGet(() -> convertDaliUDF(updatedCall).orElseGet(() -> convertBuiltInUDF(updatedCall)
+                  .orElseGet(() -> fallbackToHiveUdf(updatedCall).orElseGet(() -> swapExtractUnionFunction(updatedCall)
+                      .orElseGet(() -> removeCastToEnsureCorrectNullability(updatedCall).orElse(updatedCall))))))));
 
       return convertToNewNode;
     }
@@ -380,7 +380,7 @@ class IRRelToSparkRelTransformer {
         RelDataType castType = call.getType();
         RelDataType originalType = call.getOperands().get(0).getType();
         if (castType.isNullable() && !originalType.isNullable()
-          && rexBuilder.getTypeFactory().createTypeWithNullability(originalType, true).equals(castType)) {
+            && rexBuilder.getTypeFactory().createTypeWithNullability(originalType, true).equals(castType)) {
           return Optional.of(rexBuilder.copy(call.getOperands().get(0)));
         }
       }

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -833,6 +833,16 @@ public class CoralSparkTest {
     assertEquals(expandedSql, targetSql);
   }
 
+  @Test
+  public void testRedundantCastRemovedFromCaseCall() {
+    final String sourceSql = "SELECT CASE WHEN TRUE THEN NULL ELSE split(b, ' ') END AS col1 FROM complex";
+    String expandedSql = getCoralSparkTranslatedSqlWithAliasFromCoralSchema(sourceSql);
+
+    String targetSql = "SELECT CASE WHEN TRUE THEN NULL ELSE split(b, ' ') END col1\n" +
+            "FROM default.complex";
+    assertEquals(expandedSql, targetSql);
+  }
+
   private static String getCoralSparkTranslatedSqlWithAliasFromCoralSchema(String db, String view) {
     RelNode relNode = TestUtils.toRelNode(db, view);
     Schema schema = TestUtils.getAvroSchemaForView(db, view, false);

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -838,8 +838,7 @@ public class CoralSparkTest {
     final String sourceSql = "SELECT CASE WHEN TRUE THEN NULL ELSE split(b, ' ') END AS col1 FROM complex";
     String expandedSql = getCoralSparkTranslatedSqlWithAliasFromCoralSchema(sourceSql);
 
-    String targetSql = "SELECT CASE WHEN TRUE THEN NULL ELSE split(b, ' ') END col1\n" +
-            "FROM default.complex";
+    String targetSql = "SELECT CASE WHEN TRUE THEN NULL ELSE split(b, ' ') END col1\n" + "FROM default.complex";
     assertEquals(expandedSql, targetSql);
   }
 


### PR DESCRIPTION
Previously, for a CASE expression: `CASE WHEN TRUE THEN NULL ELSE split(b, ' ') END` , Coral spark sql will generate `CASE WHEN TRUE IS CAST(NULL AS ARRAY<STRING>) THEN NULL ELSE CAST(split(b, ' ')) AS ARRAY<STRING>) END`.

In spark3, it treats target SQL type names in the CAST as all nullable, it means, for the above nested type of `ARRAY<STRING>` , its nullable at all levels: `ARRAY<STRING:nullable>:nullable`. This is actually different from the Calcite RelNode nullability: `ARRAY<STRING:non-nullable>:nullable`, which is entailed in RelNode and Coral-schema, but lost when the RelNode is converted to SparkSql (because spark sql type names can't contain nullable info).

With this fix, we basically remove those CAST wrappers when generating the sparkSQL, and the resulting SQL will always  be compatible with both Spark sql analyzer and coral-schema with regard to nullability.

The affected view is tested with the patch in spark3 and it succeeds.