### PR TITLE
Coral-Trino: Handle casting from varbinary/binary to varchar

### DIFF
--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/Calcite2TrinoUDFConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/Calcite2TrinoUDFConverter.java
@@ -428,8 +428,8 @@ public class Calcite2TrinoUDFConverter {
 
       // Trino doesn't allow casting varbinary/binary to varchar, we need to use the built-in function `from_utf8`
       // to replace the cast, i.e. CAST(binary AS VARCHAR) -> from_utf8(binary)
-      if (call.getType().getSqlTypeName() == VARCHAR && (leftOperand.getType().getSqlTypeName() == VARBINARY)
-          || leftOperand.getType().getSqlTypeName() == BINARY) {
+      if (call.getType().getSqlTypeName() == VARCHAR && (leftOperand.getType().getSqlTypeName() == VARBINARY
+          || leftOperand.getType().getSqlTypeName() == BINARY)) {
         SqlOperator fromUTF8 = createUDF("from_utf8", explicit(VARCHAR));
         return Optional.of(rexBuilder.makeCall(fromUTF8, leftOperand));
       }

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/Calcite2TrinoUDFConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/Calcite2TrinoUDFConverter.java
@@ -426,10 +426,11 @@ public class Calcite2TrinoUDFConverter {
             rexBuilder.makeCall(trinoWithTimeZone, leftOperand, rexBuilder.makeLiteral("UTC")))));
       }
 
-      // Trino doesn't allow casting varbinary/binary to varchar, we need to use the built-in function `from_utf8`
+      // Trino doesn't allow casting varbinary/binary to varchar/char, we need to use the built-in function `from_utf8`
       // to replace the cast, i.e. CAST(binary AS VARCHAR) -> from_utf8(binary)
-      if (call.getType().getSqlTypeName() == VARCHAR && (leftOperand.getType().getSqlTypeName() == VARBINARY
-          || leftOperand.getType().getSqlTypeName() == BINARY)) {
+      if ((call.getType().getSqlTypeName() == VARCHAR || call.getType().getSqlTypeName() == CHAR)
+          && (leftOperand.getType().getSqlTypeName() == VARBINARY
+              || leftOperand.getType().getSqlTypeName() == BINARY)) {
         SqlOperator fromUTF8 = createUDF("from_utf8", explicit(VARCHAR));
         return Optional.of(rexBuilder.makeCall(fromUTF8, leftOperand));
       }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -721,4 +721,14 @@ public class HiveToTrinoConverterTest {
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
+
+  @Test
+  public void testCastVarbinaryToVarchar() {
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+
+    RelNode relNode = hiveToRelConverter.convertSql("SELECT CAST(b AS STRING) FROM test.table_with_binary_column");
+    String targetSql = "SELECT \"from_utf8\"(\"b\")\n" + "FROM \"test\".\"table_with_binary_column\"";
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
 }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -731,4 +731,14 @@ public class HiveToTrinoConverterTest {
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
+
+  @Test
+  public void testCastVarbinaryToChar() {
+    RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+
+    RelNode relNode = hiveToRelConverter.convertSql("SELECT CAST(b AS CHAR(255)) FROM test.table_with_binary_column");
+    String targetSql = "SELECT \"from_utf8\"(\"b\")\n" + "FROM \"test\".\"table_with_binary_column\"";
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
 }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
@@ -364,6 +364,8 @@ public class TestUtils {
     run(driver, "CREATE TABLE test.duplicate_column_name_b (some_id string)");
     run(driver, "CREATE VIEW IF NOT EXISTS test.view_namesake_column_names AS \n"
         + "SELECT a.some_id FROM test.duplicate_column_name_a a LEFT JOIN ( SELECT trim(some_id) AS SOME_ID FROM test.duplicate_column_name_b) b ON a.some_id = b.some_id WHERE a.some_id != ''");
+
+    run(driver, "CREATE TABLE test.table_with_binary_column (b binary)");
   }
 
   public static RelNode convertView(String db, String view) {


### PR DESCRIPTION
Trino doesn't allow casting varbinary/binary to varchar, we need to use the built-in function `from_utf8` to replace the cast, i.e. `CAST(binary AS VARCHAR) -> from_utf8(binary)`

Tests:
1. Unit test
2. Tested on the affected production view
3. i-test, no regression after verification