### PR TITLE
[Reference PR] Coral-Schema: Upgrade Avro to 1.10 and modify makeNullable logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ allprojects {
   repositories {
     mavenCentral()
     maven {
+      url 'https://linkedin.jfrog.io/artifactory/avro-util/'
+    }
+    maven {
       url 'https://linkedin.bintray.com/maven/'
     }
   }

--- a/coral-schema/build.gradle
+++ b/coral-schema/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
   compile project(path: ':coral-hive')
+  compile deps.'avroCompatHelper'
 
   testCompile(deps.'hive'.'hive-exec-core') {
     exclude group: 'org.apache.avro', module: 'avro-tools'
@@ -11,4 +12,10 @@ dependencies {
 
   testCompile deps.'hadoop'.'hadoop-mapreduce-client-core'
   testCompile deps.'kryo'
+}
+
+configurations.all {
+  resolutionStrategy {
+    force 'org.apache.avro:avro:1.10.2'
+  }
 }

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
@@ -11,6 +11,9 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+
 import org.apache.avro.Schema;
 import org.apache.calcite.rel.type.DynamicRecordType;
 import org.apache.calcite.rel.type.RelDataType;
@@ -22,7 +25,6 @@ import org.apache.calcite.sql.type.MapSqlType;
 import org.apache.calcite.sql.type.MultisetSqlType;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.hadoop.hive.serde2.avro.AvroSerDe;
-import org.codehaus.jackson.node.JsonNodeFactory;
 
 import com.linkedin.coral.com.google.common.base.Preconditions;
 
@@ -139,7 +141,7 @@ class RelDataTypeToAvroType {
     for (RelDataTypeField relField : relRecord.getFieldList()) {
       final String comment = fieldComments != null && fieldComments.size() > relField.getIndex()
           ? fieldComments.get(relField.getIndex()) : null;
-      fields.add(new Schema.Field(toAvroQualifiedName(relField.getName()),
+      fields.add(AvroCompatibilityHelper.createSchemaField(toAvroQualifiedName(relField.getName()),
           relDataTypeToAvroType(relField.getType(), toAvroQualifiedName(relField.getName())), comment, null));
     }
 

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -566,6 +566,7 @@ class SchemaUtilities {
         case INT:
         case LONG:
         case STRING:
+        case UNION:
           return leftSchema;
         case FIXED:
           if (isSameNamespace(leftSchema, rightSchema, strictMode)) {

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/ToLowercaseSchemaVisitor.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/ToLowercaseSchemaVisitor.java
@@ -9,9 +9,9 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.Lists;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 
 import org.apache.avro.Schema;
-import org.codehaus.jackson.JsonNode;
 
 
 /**
@@ -64,10 +64,10 @@ public class ToLowercaseSchemaVisitor extends AvroSchemaVisitor<Schema> {
   }
 
   private Schema.Field lowercaseField(Schema.Field field, Schema schema) {
-    Schema.Field lowercasedField =
-        new Schema.Field(field.name().toLowerCase(), schema, field.doc(), field.defaultValue(), field.order());
+    Schema.Field lowercasedField = AvroCompatibilityHelper.createSchemaField(field.name().toLowerCase(), schema,
+        field.doc(), SchemaUtilities.defaultValue(field), field.order());
 
-    for (Map.Entry<String, JsonNode> prop : field.getJsonProps().entrySet()) {
+    for (Map.Entry<String, Object> prop : field.getObjectProps().entrySet()) {
       lowercasedField.addProp(prop.getKey(), prop.getValue());
     }
 

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/ToNullableSchemaVisitor.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/ToNullableSchemaVisitor.java
@@ -10,9 +10,9 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.Lists;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 
 import org.apache.avro.Schema;
-import org.codehaus.jackson.JsonNode;
 
 
 /**
@@ -61,13 +61,12 @@ public class ToNullableSchemaVisitor extends AvroSchemaVisitor<Schema> {
   }
 
   private Schema.Field nullableField(Schema.Field field, Schema schema) {
-    Schema.Field nullableField = new Schema.Field(field.name(), SchemaUtilities.makeNullable(schema), field.doc(),
-        field.defaultValue(), field.order());
+    Schema.Field nullableField = AvroCompatibilityHelper.createSchemaField(field.name(),
+        SchemaUtilities.makeNullable(schema), field.doc(), SchemaUtilities.defaultValue(field), field.order());
 
-    for (Map.Entry<String, JsonNode> prop : field.getJsonProps().entrySet()) {
+    for (Map.Entry<String, Object> prop : field.getObjectProps().entrySet()) {
       nullableField.addProp(prop.getKey(), prop.getValue());
     }
-
     return nullableField;
   }
 }

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/TypeInfoToAvroSchemaConverter.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/TypeInfoToAvroSchemaConverter.java
@@ -9,6 +9,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+
 import org.apache.avro.Schema;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.serde2.avro.AvroSerDe;
@@ -21,8 +24,6 @@ import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.UnionTypeInfo;
-import org.codehaus.jackson.node.JsonNodeFactory;
-import org.codehaus.jackson.node.NullNode;
 
 import com.linkedin.coral.com.google.common.collect.Lists;
 
@@ -63,7 +64,8 @@ public class TypeInfoToAvroSchemaConverter {
       // We will set the recordName to be capitalized, and the recordNameSpace will be in lower case
       final Schema schema = convertTypeInfoToAvroSchema(fieldTypeInfo, recordNamespace + "." + recordName.toLowerCase(),
           StringUtils.capitalize(fieldName));
-      final Schema.Field f = new Schema.Field(fieldName, schema, null, mkFieldsOptional ? NullNode.instance : null);
+      final Schema.Field f = AvroCompatibilityHelper.createSchemaField(fieldName, schema, null,
+          mkFieldsOptional ? Schema.Field.NULL_DEFAULT_VALUE : null);
       fields.add(f);
     }
 

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
@@ -9,14 +9,15 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+
 import org.apache.avro.Schema;
 import org.apache.hadoop.hive.serde2.avro.AvroSerDe;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.node.IntNode;
-import org.codehaus.jackson.node.TextNode;
 import org.testng.annotations.Test;
 
 import com.linkedin.coral.com.google.common.base.Preconditions;
@@ -247,8 +248,7 @@ public class MergeHiveSchemaWithAvroTests {
   }
 
   private void assertSchema(Schema expected, Schema actual) {
-    assertEquals(expected, actual);
-    assertEquals(expected.toString(true), actual.toString(true));
+    assertEquals(actual.toString(true), expected.toString(true));
   }
 
   private Schema merge(StructTypeInfo typeInfo, Schema avro) {
@@ -289,7 +289,7 @@ public class MergeHiveSchemaWithAvroTests {
 
   private Schema.Field nullable(Schema.Field field) {
     Preconditions.checkArgument(!AvroSerdeUtils.isNullableType(field.schema()));
-    return field(field.name(), nullable(field.schema()), field.doc(), null, field.getProps());
+    return field(field.name(), nullable(field.schema()), field.doc(), null, field.getObjectProps());
   }
 
   private Schema nullable(Schema schema) {
@@ -300,16 +300,16 @@ public class MergeHiveSchemaWithAvroTests {
     return nullable(Schema.create(type));
   }
 
-  private Schema.Field field(String name, Schema schema, String doc, Object defaultValue, Map<String, String> props) {
-    Schema.Field field = new Schema.Field(name, schema, doc, (JsonNode) defaultValue);
+  private Schema.Field field(String name, Schema schema, String doc, Object defaultValue, Map<String, Object> props) {
+    Schema.Field field = AvroCompatibilityHelper.createSchemaField(name, schema, doc, defaultValue);
     if (props != null) {
       props.forEach(field::addProp);
     }
     return field;
   }
 
-  private Schema.Field field(String name, Schema schema, String doc, int defaultValue, Map<String, String> props) {
-    Schema.Field field = new Schema.Field(name, schema, doc, new IntNode(defaultValue));
+  private Schema.Field field(String name, Schema schema, String doc, int defaultValue, Map<String, Object> props) {
+    Schema.Field field = AvroCompatibilityHelper.createSchemaField(name, schema, doc, defaultValue);
     if (props != null) {
       props.forEach(field::addProp);
     }
@@ -317,7 +317,7 @@ public class MergeHiveSchemaWithAvroTests {
   }
 
   private Schema.Field required(String name, Schema schema, String doc, Object defaultValue,
-      Map<String, String> props) {
+      Map<String, Object> props) {
     return field(name, schema, doc, defaultValue, props);
   }
 
@@ -326,7 +326,7 @@ public class MergeHiveSchemaWithAvroTests {
   }
 
   private Schema.Field required(String name, Schema.Type type, String doc, Object defaultValue,
-      Map<String, String> props) {
+      Map<String, Object> props) {
     return required(name, Schema.create(type), doc, defaultValue, props);
   }
 

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
@@ -8,6 +8,8 @@ package com.linkedin.coral.schema.avro;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.testng.Assert;
@@ -18,11 +20,11 @@ public class SchemaUtilitiesTests {
   @Test
   public void testCloneFieldList() {
     Schema dummySchema = SchemaBuilder.record("test").fields().name("a").type().intType().noDefault().endRecord();
-    Schema.Field field1 =
-        new Schema.Field("one", dummySchema, "", dummySchema.getJsonProp("key"), Schema.Field.Order.IGNORE);
+    Schema.Field field1 = AvroCompatibilityHelper.createSchemaField("one", dummySchema, "", dummySchema.getProp("key"),
+        Schema.Field.Order.IGNORE);
     field1.addProp("field_key1", "field_value1");
-    Schema.Field field2 =
-        new Schema.Field("two", dummySchema, "", dummySchema.getJsonProp("key"), Schema.Field.Order.IGNORE);
+    Schema.Field field2 = AvroCompatibilityHelper.createSchemaField("two", dummySchema, "", dummySchema.getProp("key"),
+        Schema.Field.Order.IGNORE);
     field2.addProp("field_key2", "field_value2");
     List<Schema.Field> originalList = new ArrayList<>();
     originalList.add(field1);
@@ -34,8 +36,8 @@ public class SchemaUtilitiesTests {
 
     // Without props being identical, equal-check will not pass.
     // A dummy field3 with only property being different from field1
-    Schema.Field field3 =
-        new Schema.Field("one", dummySchema, "", dummySchema.getJsonProp("key"), Schema.Field.Order.IGNORE);
+    Schema.Field field3 = AvroCompatibilityHelper.createSchemaField("one", dummySchema, "", dummySchema.getProp("key"),
+        Schema.Field.Order.IGNORE);
     field3.addProp("field_key1", "random");
     Assert.assertFalse(resultList.contains(field3));
   }
@@ -58,7 +60,7 @@ public class SchemaUtilitiesTests {
 
   @Test
   public void testHasDuplicateLowercaseColumnNames() {
-    Schema schema = new Schema.Parser().parse(TestUtils.loadSchema("testHasDuplicateLowercaseColumnNames.avsc"));
+    Schema schema = AvroCompatibilityHelper.parse(TestUtils.loadSchema("testHasDuplicateLowercaseColumnNames.avsc"));
     boolean hasDuplicateLowercaseColumnNames = SchemaUtilities.HasDuplicateLowercaseColumnNames.visit(schema);
 
     Assert.assertTrue(hasDuplicateLowercaseColumnNames);
@@ -66,7 +68,7 @@ public class SchemaUtilitiesTests {
 
   @Test
   public void testNotHasDuplicateLowercaseColumnNames() {
-    Schema schema = new Schema.Parser().parse(TestUtils.loadSchema("testNotHasDuplicateLowercaseColumnNames.avsc"));
+    Schema schema = AvroCompatibilityHelper.parse(TestUtils.loadSchema("testNotHasDuplicateLowercaseColumnNames.avsc"));
     boolean hasDuplicateLowercaseColumnNames = SchemaUtilities.HasDuplicateLowercaseColumnNames.visit(schema);
 
     Assert.assertFalse(hasDuplicateLowercaseColumnNames);
@@ -74,7 +76,7 @@ public class SchemaUtilitiesTests {
 
   @Test
   public void testForceLowercaseSchemaTrue() {
-    Schema inputSchema = new Schema.Parser().parse(TestUtils.loadSchema("base-complex.avsc"));
+    Schema inputSchema = AvroCompatibilityHelper.parse(TestUtils.loadSchema("base-complex.avsc"));
     Schema outputSchema = ToLowercaseSchemaVisitor.visit(inputSchema);
 
     Assert.assertEquals(outputSchema.toString(true),
@@ -83,7 +85,7 @@ public class SchemaUtilitiesTests {
 
   @Test
   public void testToNullableSchema() {
-    Schema inputSchema = new Schema.Parser().parse(TestUtils.loadSchema("base-complex-non-nullable.avsc"));
+    Schema inputSchema = AvroCompatibilityHelper.parse(TestUtils.loadSchema("base-complex-non-nullable.avsc"));
     Schema outputSchema = ToNullableSchemaVisitor.visit(inputSchema);
 
     Assert.assertEquals(outputSchema.toString(true), TestUtils.loadSchema("testToNullableSchema-expected.avsc"));

--- a/coral-schema/src/test/resources/base-complex-nullable-with-defaults.avsc
+++ b/coral-schema/src/test/resources/base-complex-nullable-with-defaults.avsc
@@ -7,7 +7,7 @@
     "type" : "int"
   }, {
     "name" : "Int_Field",
-    "type" : [ "null", "int" ],
+    "type" : [ "int", "null" ],
     "default" : 101
   }, {
     "name" : "Array_Col",

--- a/coral-schema/src/test/resources/base-nested-union.avsc
+++ b/coral-schema/src/test/resources/base-nested-union.avsc
@@ -6,6 +6,7 @@
     {
       "name": "unionCol",
       "type": [
+        "null",
         {
           "type": "record",
           "name": "r1",

--- a/coral-schema/src/test/resources/docTestResources/testSelectWithLiterals-expected-with-doc.avsc
+++ b/coral-schema/src/test/resources/docTestResources/testSelectWithLiterals-expected-with-doc.avsc
@@ -20,7 +20,6 @@
       "type" : "array",
       "items" : [ "null", "string" ]
     } ],
-    "doc" : "Sample array col.",
-    "default" : null
+    "doc" : "Sample array col."
   } ]
 }

--- a/coral-schema/src/test/resources/testAggregate-expected.avsc
+++ b/coral-schema/src/test/resources/testAggregate-expected.avsc
@@ -28,28 +28,23 @@
         "type" : "boolean"
       }, {
         "name" : "Int_Field",
-        "type" : [ "null", "int" ],
-        "default" : null
+        "type" : [ "null", "int" ]
       }, {
         "name" : "Bigint_Field",
         "type" : "long"
       }, {
         "name" : "Float_Field",
-        "type" : [ "null", "float" ],
-        "default" : null
+        "type" : [ "null", "float" ]
       }, {
         "name" : "Double_Field",
         "type" : "double"
       }, {
         "name" : "Date_String_Field",
-        "type" : [ "null", "string" ],
-        "default" : null
+        "type" : [ "null", "string" ]
       }, {
         "name" : "String_Field",
-        "type" : [ "null", "string" ],
-        "default" : null
+        "type" : [ "null", "string" ]
       } ]
-    } ],
-    "default" : null
+    } ]
   } ]
 }

--- a/coral-schema/src/test/resources/testCompatibleUnion-expected.avsc
+++ b/coral-schema/src/test/resources/testCompatibleUnion-expected.avsc
@@ -10,15 +10,13 @@
     "type" : [ "null", {
       "type" : "array",
       "items" : [ "null", "string" ]
-    } ],
-    "default" : null
+    } ]
   }, {
     "name" : "Map_Col",
     "type" : [ "null", {
       "type" : "map",
       "values" : [ "null", "string" ]
-    } ],
-    "default" : null
+    } ]
   }, {
     "name" : "Struct_Col",
     "type" : [ "null", {
@@ -30,28 +28,23 @@
         "type" : "boolean"
       }, {
         "name" : "Int_Field",
-        "type" : [ "null", "int" ],
-        "default" : null
+        "type" : [ "null", "int" ]
       }, {
         "name" : "Bigint_Field",
         "type" : "long"
       }, {
         "name" : "Float_Field",
-        "type" : [ "null", "float" ],
-        "default" : null
+        "type" : [ "null", "float" ]
       }, {
         "name" : "Double_Field",
         "type" : "double"
       }, {
         "name" : "Date_String_Field",
-        "type" : [ "null", "string" ],
-        "default" : null
+        "type" : [ "null", "string" ]
       }, {
         "name" : "String_Field",
-        "type" : [ "null", "string" ],
-        "default" : null
+        "type" : [ "null", "string" ]
       } ]
-    } ],
-    "default" : null
+    } ]
   } ]
 }

--- a/coral-schema/src/test/resources/testDecimalType-expected.avsc
+++ b/coral-schema/src/test/resources/testDecimalType-expected.avsc
@@ -9,7 +9,6 @@
       "logicalType" : "decimal",
       "precision" : 2,
       "scale" : 1
-    } ],
-    "default" : null
+    } ]
   } ]
 }

--- a/coral-schema/src/test/resources/testFilter-expected.avsc
+++ b/coral-schema/src/test/resources/testFilter-expected.avsc
@@ -10,7 +10,6 @@
     "type" : [ "null", {
       "type" : "array",
       "items" : [ "null", "string" ]
-    } ],
-    "default" : null
+    } ]
   } ]
 }

--- a/coral-schema/src/test/resources/testNullabilityBasic-expected.avsc
+++ b/coral-schema/src/test/resources/testNullabilityBasic-expected.avsc
@@ -10,40 +10,34 @@
     "type" : [ "null", {
       "type" : "array",
       "items" : [ "null", "string" ]
-    } ],
-    "default" : null
+    } ]
   }, {
     "name" : "Map_Col",
     "type" : [ "null", {
       "type" : "map",
       "values" : [ "null", "string" ]
-    } ],
-    "default" : null
+    } ]
   }, {
     "name" : "Int_Field_1",
-    "type" : [ "null", "int" ],
-    "default" : null
+    "type" : [ "null", "int" ]
   }, {
     "name" : "Int_Field_2",
     "type" : "int"
   }, {
     "name" : "Double_Field_1",
-    "type" : [ "null", "double" ],
-    "default" : null
+    "type" : [ "null", "double" ]
   }, {
     "name" : "Double_Field_2",
     "type" : "double"
   }, {
     "name" : "Bool_Field_1",
-    "type" : [ "null", "boolean" ],
-    "default" : null
+    "type" : [ "null", "boolean" ]
   }, {
     "name" : "Bool_Field_2",
     "type" : "boolean"
   }, {
     "name" : "String_Field_1",
-    "type" : [ "null", "string" ],
-    "default" : null
+    "type" : [ "null", "string" ]
   }, {
     "name" : "String_Field_2",
     "type" : "string"
@@ -58,28 +52,23 @@
         "type" : "boolean"
       }, {
         "name" : "Int_Field",
-        "type" : [ "null", "int" ],
-        "default" : null
+        "type" : [ "null", "int" ]
       }, {
         "name" : "Bigint_Field",
         "type" : "long"
       }, {
         "name" : "Float_Field",
-        "type" : [ "null", "float" ],
-        "default" : null
+        "type" : [ "null", "float" ]
       }, {
         "name" : "Double_Field",
         "type" : "double"
       }, {
         "name" : "Date_String_Field",
-        "type" : [ "null", "string" ],
-        "default" : null
+        "type" : [ "null", "string" ]
       }, {
         "name" : "String_Field",
-        "type" : [ "null", "string" ],
-        "default" : null
+        "type" : [ "null", "string" ]
       } ]
-    } ],
-    "default" : null
+    } ]
   } ]
 }

--- a/coral-schema/src/test/resources/testProjectStructInnerField-expected.avsc
+++ b/coral-schema/src/test/resources/testProjectStructInnerField-expected.avsc
@@ -10,8 +10,7 @@
     "type" : "boolean"
   }, {
     "name" : "Struct_Inner_Int_Col",
-    "type" : [ "null", "int" ],
-    "default" : null
+    "type" : [ "null", "int" ]
   }, {
     "name" : "Struct_Inner_Bigint_Col",
     "type" : "long"

--- a/coral-schema/src/test/resources/testSelectDeepNestedStructFieldFromDeepNestComplex-expected.avsc
+++ b/coral-schema/src/test/resources/testSelectDeepNestedStructFieldFromDeepNestComplex-expected.avsc
@@ -4,23 +4,18 @@
   "namespace" : "default.v",
   "fields" : [ {
     "name" : "Int_Field_1",
-    "type" : [ "null", "int" ],
-    "default" : null
+    "type" : [ "null", "int" ]
   }, {
     "name" : "Int_Field_2",
-    "type" : [ "null", "int" ],
-    "default" : null
+    "type" : [ "null", "int" ]
   }, {
     "name" : "Int_Field_3",
-    "type" : [ "null", "int" ],
-    "default" : null
+    "type" : [ "null", "int" ]
   }, {
     "name" : "Int_Field_4",
-    "type" : [ "null", "int" ],
-    "default" : null
+    "type" : [ "null", "int" ]
   }, {
     "name" : "Int_Field_5",
-    "type" : [ "null", "int" ],
-    "default" : null
+    "type" : [ "null", "int" ]
   } ]
 }

--- a/coral-schema/src/test/resources/testSelectNestedStructFieldFromNestComplex-expected.avsc
+++ b/coral-schema/src/test/resources/testSelectNestedStructFieldFromNestComplex-expected.avsc
@@ -10,7 +10,6 @@
     "type" : [ "null", "int" ]
   }, {
     "name" : "Int_Field3",
-    "type" : [ "null", "int" ],
-    "default" : null
+    "type" : [ "null", "int" ]
   } ]
 }

--- a/coral-schema/src/test/resources/testSelectStar-expected.avsc
+++ b/coral-schema/src/test/resources/testSelectStar-expected.avsc
@@ -10,15 +10,13 @@
     "type" : [ "null", {
       "type" : "array",
       "items" : [ "null", "string" ]
-    } ],
-    "default" : null
+    } ]
   }, {
     "name" : "Map_Col",
     "type" : [ "null", {
       "type" : "map",
       "values" : [ "null", "string" ]
-    } ],
-    "default" : null
+    } ]
   }, {
     "name" : "Struct_Col",
     "type" : [ "null", {
@@ -30,28 +28,23 @@
         "type" : "boolean"
       }, {
         "name" : "Int_Field",
-        "type" : [ "null", "int" ],
-        "default" : null
+        "type" : [ "null", "int" ]
       }, {
         "name" : "Bigint_Field",
         "type" : "long"
       }, {
         "name" : "Float_Field",
-        "type" : [ "null", "float" ],
-        "default" : null
+        "type" : [ "null", "float" ]
       }, {
         "name" : "Double_Field",
         "type" : "double"
       }, {
         "name" : "Date_String_Field",
-        "type" : [ "null", "string" ],
-        "default" : null
+        "type" : [ "null", "string" ]
       }, {
         "name" : "String_Field",
-        "type" : [ "null", "string" ],
-        "default" : null
+        "type" : [ "null", "string" ]
       } ]
-    } ],
-    "default" : null
+    } ]
   } ]
 }

--- a/coral-schema/src/test/resources/testSelectStarFromNestComplex-expected.avsc
+++ b/coral-schema/src/test/resources/testSelectStarFromNestComplex-expected.avsc
@@ -15,29 +15,25 @@
         "namespace" : "default.v.v",
         "fields" : [ {
           "name" : "Bool_Field",
-          "type" : [ "null", "boolean" ],
-          "default" : null
+          "type" : [ "null", "boolean" ]
         }, {
           "name" : "Int_Field",
           "type" : [ "null", "int" ]
         }, {
           "name" : "Bigint_Field",
-          "type" : [ "null", "long" ],
-          "default" : null
+          "type" : [ "null", "long" ]
         }, {
           "name" : "Float_Field",
           "type" : [ "null", "float" ]
         }, {
           "name" : "Double_Field",
-          "type" : [ "null", "double" ],
-          "default" : null
+          "type" : [ "null", "double" ]
         }, {
           "name" : "Date_String_Field",
           "type" : [ "null", "string" ]
         }, {
           "name" : "String_Field",
-          "type" : [ "null", "string" ],
-          "default" : null
+          "type" : [ "null", "string" ]
         }, {
           "name" : "Array_Col_1",
           "type" : [ "null", {
@@ -46,8 +42,7 @@
               "type" : "array",
               "items" : "string"
             }
-          } ],
-          "default" : null
+          } ]
         }, {
           "name" : "Array_Col_2",
           "type" : [ "null", {
@@ -56,8 +51,7 @@
               "type" : "map",
               "values" : "string"
             }
-          } ],
-          "default" : null
+          } ]
         }, {
           "name" : "Map_Col_3",
           "type" : [ "null", {
@@ -66,8 +60,7 @@
               "type" : "map",
               "values" : "string"
             }
-          } ],
-          "default" : null
+          } ]
         }, {
           "name" : "Map_Col_4",
           "type" : [ "null", {
@@ -76,12 +69,10 @@
               "type" : "array",
               "items" : "string"
             }
-          } ],
-          "default" : null
+          } ]
         } ]
       } ]
-    } ],
-    "default" : null
+    } ]
   }, {
     "name" : "map_col",
     "type" : [ "null", {
@@ -95,8 +86,7 @@
           "type" : [ "null", "int" ]
         } ]
       } ]
-    } ],
-    "default" : null
+    } ]
   }, {
     "name" : "struct_col",
     "type" : [ "null", {
@@ -105,32 +95,25 @@
       "namespace" : "default.v.v",
       "fields" : [ {
         "name" : "bool_field",
-        "type" : [ "null", "boolean" ],
-        "default" : null
+        "type" : [ "null", "boolean" ]
       }, {
         "name" : "int_field",
-        "type" : [ "null", "int" ],
-        "default" : null
+        "type" : [ "null", "int" ]
       }, {
         "name" : "bigint_field",
-        "type" : [ "null", "long" ],
-        "default" : null
+        "type" : [ "null", "long" ]
       }, {
         "name" : "float_field",
-        "type" : [ "null", "float" ],
-        "default" : null
+        "type" : [ "null", "float" ]
       }, {
         "name" : "double_field",
-        "type" : [ "null", "double" ],
-        "default" : null
+        "type" : [ "null", "double" ]
       }, {
         "name" : "date_string_field",
-        "type" : [ "null", "string" ],
-        "default" : null
+        "type" : [ "null", "string" ]
       }, {
         "name" : "string_field",
-        "type" : [ "null", "string" ],
-        "default" : null
+        "type" : [ "null", "string" ]
       }, {
         "name" : "inner_struct_col",
         "type" : {
@@ -139,17 +122,14 @@
           "namespace" : "default.v.v.Struct_col",
           "fields" : [ {
             "name" : "Int_Field3",
-            "type" : [ "null", "int" ],
-            "default" : null
+            "type" : [ "null", "int" ]
           } ]
         }
       } ]
-    } ],
-    "default" : null
+    } ]
   }, {
     "name" : "datepartition",
     "type" : [ "null", "string" ],
-    "doc" : "This is the partition column. Partition columns, if present in the schema, should also be projected in the data.",
-    "default" : null
+    "doc" : "This is the partition column. Partition columns, if present in the schema, should also be projected in the data."
   } ]
 }

--- a/coral-schema/src/test/resources/testSelectStarWithNullsAndDefaults.avsc
+++ b/coral-schema/src/test/resources/testSelectStarWithNullsAndDefaults.avsc
@@ -7,22 +7,20 @@
     "type" : "int"
   }, {
     "name" : "Int_Field",
-    "type" : [ "null", "int" ],
+    "type" : [ "int", "null" ],
     "default" : 101
   }, {
     "name" : "Array_Col",
     "type" : [ "null", {
       "type" : "array",
       "items" : [ "null", "string" ]
-    } ],
-    "default" : null
+    } ]
   }, {
     "name" : "Map_Col",
     "type" : [ "null", {
       "type" : "map",
       "values" : [ "null", "string" ]
-    } ],
-    "default" : null
+    } ]
   }, {
     "name" : "Struct_Col",
     "type" : [ "null", {
@@ -34,8 +32,7 @@
         "type" : "boolean"
       }, {
         "name" : "Int_Field1",
-        "type" : [ "null", "int" ],
-        "default" : null
+        "type" : [ "null", "int" ]
       }, {
         "name" : "Int_Field2",
         "type" : [ "int", "null" ],
@@ -45,19 +42,16 @@
         "type" : "double"
       }, {
         "name" : "Date_String_Field",
-        "type" : [ "null", "string" ],
-        "default" : null
+        "type" : [ "null", "string" ]
       }, {
         "name" : "String_Field",
         "type" : [ "string", "null" ],
         "default" : ""
       } ]
-    } ],
-    "default" : null
+    } ]
   }, {
     "name" : "datepartition",
     "type" : [ "null", "string" ],
-    "doc" : "This is the partition column. Partition columns, if present in the schema, should also be projected in the data.",
-    "default" : null
+    "doc" : "This is the partition column. Partition columns, if present in the schema, should also be projected in the data."
   } ]
 }

--- a/coral-schema/src/test/resources/testSelectStarWithPartition.avsc
+++ b/coral-schema/src/test/resources/testSelectStarWithPartition.avsc
@@ -33,7 +33,6 @@
   }, {
     "name" : "datepartition",
     "type" : [ "null", "string" ],
-    "doc" : "This is the partition column. Partition columns, if present in the schema, should also be projected in the data.",
-    "default" : null
+    "doc" : "This is the partition column. Partition columns, if present in the schema, should also be projected in the data."
   } ]
 }

--- a/coral-schema/src/test/resources/testSelectWithLiterals-expected.avsc
+++ b/coral-schema/src/test/resources/testSelectWithLiterals-expected.avsc
@@ -18,7 +18,6 @@
     "type" : [ "null", {
       "type" : "array",
       "items" : [ "null", "string" ]
-    } ],
-    "default" : null
+    } ]
   } ]
 }

--- a/coral-schema/src/test/resources/testSelectWithMultipleLiterals-expected.avsc
+++ b/coral-schema/src/test/resources/testSelectWithMultipleLiterals-expected.avsc
@@ -38,7 +38,6 @@
     "type" : [ "null", {
       "type" : "array",
       "items" : [ "null", "string" ]
-    } ],
-    "default" : null
+    } ]
   } ]
 }

--- a/coral-schema/src/test/resources/testSubQueryFrom-expected.avsc
+++ b/coral-schema/src/test/resources/testSubQueryFrom-expected.avsc
@@ -10,7 +10,6 @@
     "type" : [ "null", {
       "type" : "map",
       "values" : [ "null", "string" ]
-    } ],
-    "default" : null
+    } ]
   } ]
 }

--- a/coral-schema/src/test/resources/testUnion-expected.avsc
+++ b/coral-schema/src/test/resources/testUnion-expected.avsc
@@ -16,28 +16,23 @@
         "type" : "boolean"
       }, {
         "name" : "Int_Field",
-        "type" : [ "null", "int" ],
-        "default" : null
+        "type" : [ "null", "int" ]
       }, {
         "name" : "Bigint_Field",
         "type" : "long"
       }, {
         "name" : "Float_Field",
-        "type" : [ "null", "float" ],
-        "default" : null
+        "type" : [ "null", "float" ]
       }, {
         "name" : "Double_Field",
         "type" : "double"
       }, {
         "name" : "Date_String_Field",
-        "type" : [ "null", "string" ],
-        "default" : null
+        "type" : [ "null", "string" ]
       }, {
         "name" : "String_Field",
-        "type" : [ "null", "string" ],
-        "default" : null
+        "type" : [ "null", "string" ]
       } ]
-    } ],
-    "default" : null
+    } ]
   } ]
 }

--- a/coral-schema/src/test/resources/testUnionForceLowercase-expected.avsc
+++ b/coral-schema/src/test/resources/testUnionForceLowercase-expected.avsc
@@ -10,15 +10,13 @@
     "type" : [ "null", {
       "type" : "array",
       "items" : [ "null", "string" ]
-    } ],
-    "default" : null
+    } ]
   }, {
     "name" : "map_col",
     "type" : [ "null", {
       "type" : "map",
       "values" : [ "null", "string" ]
-    } ],
-    "default" : null
+    } ]
   }, {
     "name" : "struct_col",
     "type" : [ "null", {
@@ -30,28 +28,23 @@
         "type" : "boolean"
       }, {
         "name" : "int_field",
-        "type" : [ "null", "int" ],
-        "default" : null
+        "type" : [ "null", "int" ]
       }, {
         "name" : "bigint_field",
         "type" : "long"
       }, {
         "name" : "float_field",
-        "type" : [ "null", "float" ],
-        "default" : null
+        "type" : [ "null", "float" ]
       }, {
         "name" : "double_field",
         "type" : "double"
       }, {
         "name" : "date_string_field",
-        "type" : [ "null", "string" ],
-        "default" : null
+        "type" : [ "null", "string" ]
       }, {
         "name" : "string_field",
-        "type" : [ "null", "string" ],
-        "default" : null
+        "type" : [ "null", "string" ]
       } ]
-    } ],
-    "default" : null
+    } ]
   } ]
 }

--- a/coral-schema/src/test/resources/testUnionPreserveNamespace.avsc
+++ b/coral-schema/src/test/resources/testUnionPreserveNamespace.avsc
@@ -33,7 +33,6 @@
   }, {
     "name" : "datepartition",
     "type" : [ "null", "string" ],
-    "doc" : "This is the partition column. Partition columns, if present in the schema, should also be projected in the data.",
-    "default" : null
+    "doc" : "This is the partition column. Partition columns, if present in the schema, should also be projected in the data."
   } ]
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,5 +1,6 @@
 def versions = [
   'antlr': '3.4',
+  'avro-utl': '0.2.113',
   'hadoop': '2.7.0',
   'hive': '1.2.2',
   'ivy': '2.4.0',
@@ -15,6 +16,7 @@ def versions = [
 ext.deps = [
   'antlr': "org.antlr:antlr:${versions['antlr']}",
   'antlr-runtime': "org.antlr:antlr-runtime:${versions['antlr']}",
+  'avroCompatHelper': "com.linkedin.avroutil1:helper-all:${versions['avro-utl']}",
   'hadoop': [
     'hadoop-common': "org.apache.hadoop:hadoop-common:${versions['hadoop']}",
     'hadoop-mapreduce-client-common': "org.apache.hadoop:hadoop-mapreduce-client-common:${versions['hadoop']}",


### PR DESCRIPTION
This PR is based on #307 by @i-ony with the following modifications:
1. Combine the commits and rebase for simplicity
2. Remove unnecessary changes to [build.gradle of other modules](https://github.com/linkedin/coral/pull/307/files#diff-a44c8ceda67698445c043896bee418bce68a0d9a23eb62f2373233c5307201ce) and [dependencies.gradle](https://github.com/linkedin/coral/pull/307/files#diff-02b139e755ab0e27e0b0a6f9845843ef189116955cc340c49a4022587dbb2b52), we just need to add `avroCompatHelper` dependency and force Coral-Schema to use Avro 1.10 by the following config in Coral-Schema's build.gradle:
```
configurations.all {
  resolutionStrategy {
    force 'org.apache.avro:avro:1.10.2'
  }
}
```
3. Modify `makeNullable` method to take a boolean parameter `nullAsSecond`, if it's true, will construct schemas like `[long, null]`. Previously, `makeNullable` can only construct `[null, long]` with `null` as the first option.
4. Modify `MergeHiveSchemaWithAvro.struct`, `MergeHiveSchemaWithAvro.list`, `MergeHiveSchemaWithAvro.map` and `MergeHiveSchemaWithAvro.primitive` methods which call `SchemaUtilities.makeNullable` to construct nullable schema with the same order as `partner` by the following code:
```
SchemaUtilities.makeNullable(result, SchemaUtilities.isNullSecond(partner));
```
so that if `partner` is `[long, null]`, the return result is also `[long, null]` rather than `[null, long]`

5. Similar to 4, in `SchemaUtilities.getUnionFieldSchema` method, if leftSchema and rightSchema are both nullable, we construct final schema with the same order as left schema (it's just one of the options, we need further discussion to determine the behavior):
```
return makeNullable(getUnionFieldSchema(makeNonNullable(leftSchema), makeNonNullable(rightSchema), strictMode),
          isNullSecond(leftSchema));
```

Tested on the affected production view, which can be translated with change 4 and 5.

FYI @wmoustafa @aastha25