### PR TITLE
Coral-Service: Reinstantiate converters for each translation

### DIFF
--- a/coral-service/src/main/java/com/linkedin/coral/coralservice/utils/CoralProvider.java
+++ b/coral-service/src/main/java/com/linkedin/coral/coralservice/utils/CoralProvider.java
@@ -24,9 +24,6 @@ import org.springframework.context.annotation.Configuration;
 import com.linkedin.coral.common.HiveMetastoreClient;
 import com.linkedin.coral.common.HiveMscAdapter;
 import com.linkedin.coral.coralservice.metastore.MetastoreProvider;
-import com.linkedin.coral.hive.hive2rel.HiveToRelConverter;
-import com.linkedin.coral.trino.rel2trino.RelToTrinoConverter;
-import com.linkedin.coral.trino.trino2rel.TrinoToRelConverter;
 
 import static com.linkedin.coral.coralservice.CoralServiceApplication.*;
 
@@ -38,12 +35,7 @@ import static com.linkedin.coral.coralservice.CoralServiceApplication.*;
 public class CoralProvider {
   //TODO: provide beans for fields
 
-  private static HiveMetastoreClient hiveMetastoreClient;
-
-  // Converters
-  public static HiveToRelConverter hiveToRelConverter;
-  public static TrinoToRelConverter trinoToRelConverter;
-  public static RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
+  public static HiveMetastoreClient hiveMetastoreClient;
 
   // Local Metastore
   public static Driver driver;
@@ -53,8 +45,6 @@ public class CoralProvider {
   public static void initHiveMetastoreClient() throws Exception {
     // Connect to remote production Hive Metastore Client
     hiveMetastoreClient = MetastoreProvider.getMetastoreClient();
-    hiveToRelConverter = new HiveToRelConverter(hiveMetastoreClient);
-    trinoToRelConverter = new TrinoToRelConverter(hiveMetastoreClient);
   }
 
   public static void initLocalMetastore() throws IOException, HiveException, MetaException {
@@ -74,8 +64,6 @@ public class CoralProvider {
     driver = new Driver(conf);
 
     hiveMetastoreClient = new HiveMscAdapter(Hive.get(conf).getMSC());
-    hiveToRelConverter = new HiveToRelConverter(hiveMetastoreClient);
-    trinoToRelConverter = new TrinoToRelConverter(hiveMetastoreClient);
   }
 
   public static void run(Driver driver, String sql) {

--- a/coral-service/src/main/java/com/linkedin/coral/coralservice/utils/TranslationUtils.java
+++ b/coral-service/src/main/java/com/linkedin/coral/coralservice/utils/TranslationUtils.java
@@ -7,7 +7,10 @@ package com.linkedin.coral.coralservice.utils;
 
 import org.apache.calcite.rel.RelNode;
 
+import com.linkedin.coral.hive.hive2rel.HiveToRelConverter;
 import com.linkedin.coral.spark.CoralSpark;
+import com.linkedin.coral.trino.rel2trino.RelToTrinoConverter;
+import com.linkedin.coral.trino.trino2rel.TrinoToRelConverter;
 
 import static com.linkedin.coral.coralservice.utils.CoralProvider.*;
 
@@ -15,18 +18,18 @@ import static com.linkedin.coral.coralservice.utils.CoralProvider.*;
 public class TranslationUtils {
 
   public static String translateTrinoToSpark(String query) {
-    RelNode relNode = trinoToRelConverter.convertSql(query);
+    RelNode relNode = new TrinoToRelConverter(hiveMetastoreClient).convertSql(query);
     CoralSpark coralSpark = CoralSpark.create(relNode);
     return coralSpark.getSparkSql();
   }
 
   public static String translateHiveToTrino(String query) {
-    RelNode relNode = hiveToRelConverter.convertSql(query);
-    return relToTrinoConverter.convert(relNode);
+    RelNode relNode = new HiveToRelConverter(hiveMetastoreClient).convertSql(query);
+    return new RelToTrinoConverter().convert(relNode);
   }
 
   public static String translateHiveToSpark(String query) {
-    RelNode relNode = hiveToRelConverter.convertSql(query);
+    RelNode relNode = new HiveToRelConverter(hiveMetastoreClient).convertSql(query);
     CoralSpark coralSpark = CoralSpark.create(relNode);
     return coralSpark.getSparkSql();
   }


### PR DESCRIPTION
This PR is to reinstantiate every converter for each single translation.
Previously, converters are created once when the app is started, if we want to create new database or table afterwards, they couldn't be found by the converters. Reinstantiating the converters with latest HMS for each translation would solve this issue.

Tested locally.