### PR TITLE
Coral-Service: upgrade spring boot gradle plugin version to 2.4.0

### DIFF
--- a/coral-service/build.gradle
+++ b/coral-service/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'org.springframework.boot' version '2.1.2.RELEASE'
+  id 'org.springframework.boot' version '2.4.0'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'java'
 }


### PR DESCRIPTION
upgrade spring boot gradle plugin version to 2.4.0，can run "java -jar coral-service-xxx.jar" as an  independent service. 
in 2.1.2.RELEASE will occur error as below
![image](https://user-images.githubusercontent.com/37388552/197675327-a016d792-da78-489a-bb67-071258617487.png)
