### PR TITLE
Coral-Trino: Add Gson to its dependencies

### DIFF
--- a/coral-trino/build.gradle
+++ b/coral-trino/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+  compile deps.'gson'
   compile project(path: ':coral-hive')
   compile project(path: ':shading:coral-trino-parser', configuration: 'shadow')
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,6 +1,7 @@
 def versions = [
   'antlr': '3.4',
   'avro-utl': '0.2.117',
+  'gson': '2.9.0',
   'hadoop': '2.7.0',
   'hive': '1.2.2',
   'ivy': '2.4.0',
@@ -17,6 +18,7 @@ ext.deps = [
   'antlr': "org.antlr:antlr:${versions['antlr']}",
   'antlr-runtime': "org.antlr:antlr-runtime:${versions['antlr']}",
   'avroCompatHelper': "com.linkedin.avroutil1:helper-all:${versions['avro-utl']}",
+  'gson': "com.google.code.gson:gson:${versions['gson']}",
   'hadoop': [
     'hadoop-common': "org.apache.hadoop:hadoop-common:${versions['hadoop']}",
     'hadoop-mapreduce-client-common': "org.apache.hadoop:hadoop-mapreduce-client-common:${versions['hadoop']}",


### PR DESCRIPTION
This PR rolls back part of #274 to add `gson` back to the dependencies of coral-trino.

Removing it would cause the following exception when Coral is integrated with Trino:
```
java.lang.NoClassDefFoundError: com/google/gson/JsonParser
	at com.linkedin.coral.trino.rel2trino.UDFTransformer.parseJsonObjectsFromString(UDFTransformer.java:370)
	at com.linkedin.coral.trino.rel2trino.UDFTransformer.of(UDFTransformer.java:225)
	at com.linkedin.coral.trino.rel2trino.UDFMapUtils.createUDFMapEntry(UDFMapUtils.java:50)
	at com.linkedin.coral.trino.rel2trino.UDFMapUtils.createUDFMapEntry(UDFMapUtils.java:80)
	at com.linkedin.coral.trino.rel2trino.CalciteTrinoUDFMap.<clinit>(CalciteTrinoUDFMap.java:40)
	at com.linkedin.coral.trino.rel2trino.Calcite2TrinoUDFConverter$TrinoRexConverter.visitCall(Calcite2TrinoUDFConverter.java:251)
	at com.linkedin.coral.trino.rel2trino.Calcite2TrinoUDFConverter$TrinoRexConverter.visitCall(Calcite2TrinoUDFConverter.java:163)
	at org.apache.calcite.rex.RexCall.accept(RexCall.java:191)
	at org.apache.calcite.rex.RexShuttle.visitList(RexShuttle.java:149)
	at com.linkedin.coral.trino.rel2trino.Calcite2TrinoUDFConverter$TrinoRexConverter.visitCast(Calcite2TrinoUDFConverter.java:415)
	at com.linkedin.coral.trino.rel2trino.Calcite2TrinoUDFConverter$TrinoRexConverter.visitCall(Calcite2TrinoUDFConverter.java:217)
	at com.linkedin.coral.trino.rel2trino.Calcite2TrinoUDFConverter$TrinoRexConverter.visitCall(Calcite2TrinoUDFConverter.java:163)
	at org.apache.calcite.rex.RexCall.accept(RexCall.java:191)
	at org.apache.calcite.rex.RexShuttle.apply(RexShuttle.java:277)
	at org.apache.calcite.rex.RexShuttle.mutate(RexShuttle.java:239)
	at org.apache.calcite.rex.RexShuttle.apply(RexShuttle.java:257)
	at org.apache.calcite.rel.core.Project.accept(Project.java:144)
	at com.linkedin.coral.trino.rel2trino.Calcite2TrinoUDFConverter$1.visit(Calcite2TrinoUDFConverter.java:80)
	at org.apache.calcite.rel.logical.LogicalProject.accept(LogicalProject.java:121)
	at com.linkedin.coral.trino.rel2trino.Calcite2TrinoUDFConverter.convertRel(Calcite2TrinoUDFConverter.java:157)
	at com.linkedin.coral.trino.rel2trino.RelToTrinoConverter.convert(RelToTrinoConverter.java:79)
	at io.trino.plugin.hive.ViewReaderUtil$HiveViewReader.decodeViewData(ViewReaderUtil.java:178)
	at io.trino.plugin.hive.HiveMetadata.lambda$getView$62(HiveMetadata.java:2055)
	at java.base/java.util.Optional.map(Optional.java:265)
	at io.trino.plugin.hive.HiveMetadata.getView(HiveMetadata.java:2049)
	at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata.getView(ClassLoaderSafeConnectorMetadata.java:534)
	at io.trino.metadata.MetadataManager.getView(MetadataManager.java:1131)
	at io.trino.sql.rewrite.ShowQueriesRewrite$Visitor.visitShowColumns(ShowQueriesRewrite.java:390)
	at io.trino.sql.rewrite.ShowQueriesRewrite$Visitor.visitShowColumns(ShowQueriesRewrite.java:168)
	at io.trino.sql.tree.ShowColumns.accept(ShowColumns.java:68)
	at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.trino.sql.rewrite.ShowQueriesRewrite.rewrite(ShowQueriesRewrite.java:165)
	at io.trino.sql.rewrite.StatementRewrite.rewrite(StatementRewrite.java:61)
	at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:88)
	at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:83)
	at io.trino.execution.SqlQueryExecution.analyze(SqlQueryExecution.java:263)
	at io.trino.execution.SqlQueryExecution.<init>(SqlQueryExecution.java:186)
	at io.trino.execution.SqlQueryExecution$SqlQueryExecutionFactory.createQueryExecution(SqlQueryExecution.java:768)
	at io.trino.dispatcher.LocalDispatchQueryFactory.lambda$createDispatchQuery$0(LocalDispatchQueryFactory.java:129)
	at io.trino.$gen.Trino_unknown____20221101_170245_2.call(Unknown Source)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:125)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:69)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:78)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.ClassNotFoundException: com.google.gson.JsonParser
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:476)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
	at io.trino.server.PluginClassLoader.loadClass(PluginClassLoader.java:89)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 46 more
```