### PR TITLE
Fix the schema field namespace before converting to lowercase

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverter.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverter.java
@@ -197,14 +197,16 @@ public class ViewToAvroSchemaConverter {
     } else {
       RelNode relNode = hiveToRelConverter.convertView(dbName, tableOrViewName);
       Schema schema = relToAvroSchemaConverter.convert(relNode, strictMode, forceLowercase);
-      if (forceLowercase) {
-        schema = ToLowercaseSchemaVisitor.visit(schema);
-      }
+
       Schema avroSchema = schema;
 
       // In flex mode, we assign a new set of namespace
       if (!strictMode) {
         avroSchema = SchemaUtilities.setupNameAndNamespace(schema, tableOrViewName, dbName + "." + tableOrViewName);
+      }
+
+      if (forceLowercase) {
+        avroSchema = ToLowercaseSchemaVisitor.visit(avroSchema);
       }
 
       return avroSchema;

--- a/coral-schema/src/test/resources/testUnionForceLowercase-expected.avsc
+++ b/coral-schema/src/test/resources/testUnionForceLowercase-expected.avsc
@@ -10,13 +10,15 @@
     "type" : [ "null", {
       "type" : "array",
       "items" : [ "null", "string" ]
-    } ]
+    } ],
+    "default" : null
   }, {
     "name" : "map_col",
     "type" : [ "null", {
       "type" : "map",
       "values" : [ "null", "string" ]
-    } ]
+    } ],
+    "default" : null
   }, {
     "name" : "struct_col",
     "type" : [ "null", {
@@ -28,23 +30,28 @@
         "type" : "boolean"
       }, {
         "name" : "int_field",
-        "type" : [ "null", "int" ]
+        "type" : [ "null", "int" ],
+        "default" : null
       }, {
         "name" : "bigint_field",
         "type" : "long"
       }, {
         "name" : "float_field",
-        "type" : [ "null", "float" ]
+        "type" : [ "null", "float" ],
+        "default" : null
       }, {
         "name" : "double_field",
         "type" : "double"
       }, {
         "name" : "date_string_field",
-        "type" : [ "null", "string" ]
+        "type" : [ "null", "string" ],
+        "default" : null
       }, {
         "name" : "string_field",
-        "type" : [ "null", "string" ]
+        "type" : [ "null", "string" ],
+        "default" : null
       } ]
-    } ]
+    } ],
+    "default" : null
   } ]
 }


### PR DESCRIPTION
`relToAvroSchemaConverter` converts a relNode representation into an Avro schema. During this transformation, the fields are assigned a default namespace: `rel_avro.<fieldName>` . If a schema has nested fields with the same fieldName and this schema is converted to lowercase by `ToLowercaseSchemaVisitor`, the conversion fails a check [here](https://github.com/linkedin/coral/blob/master/coral-schema/src/main/java/com/linkedin/coral/schema/avro/AvroSchemaVisitor.java#L23) as the visitor detects two nested fields with the same namespace.  

This PR reorders "setupNameAndNamespace" & "convertToLowerCase" transformations so that `ToLowercaseSchemaVisitor` takes a correct schema as an input. 

Since the transformations are additive, the reordering should be safe. 

Testing done:
unit tests
tested the affected view on production 


