### PR TITLE
Remove 2 wrongly registered UDFs

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -429,11 +429,6 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
         STRING_STRING);
     createAddUserDefinedFunction("com.linkedin.dali.view.udf.entityhandles.PhoneNumberNormalizer",
         FunctionReturnTypes.STRING, STRING_STRING_STRING);
-    createAddUserDefinedFunction("com.linkedin.dali.views.feed.udf.GenerateDecoratedFeedUpdateData",
-        FunctionReturnTypes.arrayOfType(SqlTypeName.ANY),
-        family(SqlTypeFamily.STRING, SqlTypeFamily.MAP, SqlTypeFamily.MAP));
-    createAddUserDefinedFunction("com.linkedin.dali.views.feed.udf.UnifiedResultsToFeedUpdates",
-        FunctionReturnTypes.arrayOfType(SqlTypeName.ANY), family(SqlTypeFamily.ARRAY));
     createAddUserDefinedFunction("com.linkedin.dali.views.job.udf.GetUUID", FunctionReturnTypes.STRING, BINARY);
     createAddUserDefinedFunction("com.linkedin.dali.views.premium.udf.GetOrderUrn", FunctionReturnTypes.STRING,
         family(SqlTypeFamily.MAP, SqlTypeFamily.STRING));


### PR DESCRIPTION
These 2 UDFs are registered with wrong return types (`SqlTypeName.ANY` should never appear in the UDF return type), removing them given they can be handled by the dynamic Hive generic UDF registration. Didn't choose to modify registered return type given the return types are too complex to register manually, and might be modified afterwards. We should only register UDFs that can't be handled by the dynamic Hive generic UDF registration.

Note: We need to be careful about the return type for UDF registration, because it would affect the RelNode data type [consumed by Trino](https://github.com/trinodb/trino/blob/master/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java#L218) for return type validation.
