### PR TITLE
Coral-Hive: Register a UDF

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -521,6 +521,33 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
         family(SqlTypeFamily.STRING));
     createAddUserDefinedFunction("com.linkedin.orbit.emerger.coercerudfs.DynamicsLineOfBusinessCoercer",
         FunctionReturnTypes.STRING, STRING);
+    createAddUserDefinedFunction("com.linkedin.orbit.emerger.coercerudfs.GenerateId", FunctionReturnTypes.STRING,
+        new SqlOperandTypeChecker() {
+          @Override
+          public boolean checkOperandTypes(SqlCallBinding callBinding, boolean throwOnFailure) {
+            return true;
+          }
+
+          @Override
+          public SqlOperandCountRange getOperandCountRange() {
+            return SqlOperandCountRanges.from(1);
+          }
+
+          @Override
+          public String getAllowedSignatures(SqlOperator op, String opName) {
+            return opName + "(ANY, ...)";
+          }
+
+          @Override
+          public Consistency getConsistency() {
+            return Consistency.NONE;
+          }
+
+          @Override
+          public boolean isOptional(int i) {
+            return false;
+          }
+        });
     createAddUserDefinedFunction("com.linkedin.etg.business.common.udfs.MapD365OptionSet", FunctionReturnTypes.STRING,
         STRING_STRING_STRING);
 


### PR DESCRIPTION
Register this UDF since its dynamic registration takes pretty long to download the dependency jars.
There is no restriction of the operand types, so `checkOperandTypes` returns true.

Tested on the affected prod views.