### PR TITLE
Initial draft of migrating CalciteTrinoUDFMap to the use of StandardOperatorTransformer

### DIFF
--- a/coral-common/src/main/java/com/linkedin/coral/common/transformers/OperatorTransformer.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/transformers/OperatorTransformer.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2017-2023 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.common.transformers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.validate.SqlValidator;
+
+
+/**
+ * Abstract class for generic transformations on SqlNodes
+ */
+public abstract class OperatorTransformer {
+  private SqlValidator sqlValidator;
+  private final List<SqlSelect> topSelectNodes = new ArrayList<>();
+
+  public OperatorTransformer() {
+
+  }
+
+  public OperatorTransformer(SqlValidator sqlValidator) {
+    this.sqlValidator = sqlValidator;
+  }
+
+  protected abstract boolean condition(SqlCall sqlCall);
+
+  protected abstract SqlCall transform(SqlCall sqlCall);
+
+  public SqlCall apply(SqlCall sqlCall) {
+    if (sqlCall instanceof SqlSelect) {
+      this.topSelectNodes.add((SqlSelect) sqlCall);
+    }
+    if (condition(sqlCall)) {
+      return transform(sqlCall);
+    } else {
+      return sqlCall;
+    }
+  }
+
+  protected RelDataType getRelDataType(SqlNode sqlNode) {
+    if (sqlValidator == null) {
+      throw new RuntimeException("Please provide sqlValidator to get the RelDataType of a SqlNode!");
+    }
+    for (int i = topSelectNodes.size() - 1; i >= 0; --i) {
+      final SqlSelect topSelectNode = topSelectNodes.get(i);
+      final SqlSelect dummySqlSelect = new SqlSelect(topSelectNode.getParserPosition(), null, SqlNodeList.of(sqlNode),
+          topSelectNode.getFrom(), null, null, null, null, null, null, null);
+      try {
+        sqlValidator.validate(dummySqlSelect);
+        return sqlValidator.getValidatedNodeType(dummySqlSelect).getFieldList().get(0).getType();
+      } catch (Throwable ignored) {
+      }
+    }
+    throw new RuntimeException("Failed to derive the RelDataType for SqlNode " + sqlNode);
+  }
+}

--- a/coral-common/src/main/java/com/linkedin/coral/common/transformers/OperatorTransformerList.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/transformers/OperatorTransformerList.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2023 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.common.transformers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.calcite.sql.SqlCall;
+
+
+/**
+ * Container for OperatorTransformers
+ */
+public class OperatorTransformerList {
+  private final List<OperatorTransformer> operatorTransformers;
+
+  public OperatorTransformerList() {
+    this.operatorTransformers = new ArrayList<>();
+  }
+
+  public OperatorTransformerList(List<OperatorTransformer> operatorTransformers) {
+    this.operatorTransformers = operatorTransformers;
+  }
+
+  public static OperatorTransformerList of(OperatorTransformer... operatorTransformers) {
+    return new OperatorTransformerList(Arrays.asList(operatorTransformers));
+  }
+
+  public static OperatorTransformerList of(List<OperatorTransformer> operatorTransformers) {
+    return new OperatorTransformerList(operatorTransformers);
+  }
+
+  public void register(OperatorTransformer operatorTransformer) {
+    operatorTransformers.add(operatorTransformer);
+  }
+
+  public SqlCall apply(SqlCall sqlCall) {
+    for (OperatorTransformer operatorTransformer : operatorTransformers) {
+      sqlCall = operatorTransformer.apply(sqlCall);
+    }
+    return sqlCall;
+  }
+}

--- a/coral-common/src/main/java/com/linkedin/coral/common/transformers/StandardOperatorTransformer.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/transformers/StandardOperatorTransformer.java
@@ -1,0 +1,277 @@
+/**
+ * Copyright 2017-2023 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.common.transformers;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlOperandTypeChecker;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.sql.validate.SqlUserDefinedFunction;
+
+import static com.linkedin.coral.common.calcite.CalciteUtil.*;
+
+
+/**
+ * Class to instantiate standard transformers, whose condition(SqlCall) method only checks operator name and number of operands
+ * and transform(SqlCall) method is achieved by JSON-format transformers
+ */
+public class StandardOperatorTransformer extends OperatorTransformer {
+  private static final Map<String, SqlOperator> OP_MAP = new HashMap<>();
+
+  // Operators allowed in the transformation
+  static {
+    OP_MAP.put("+", SqlStdOperatorTable.PLUS);
+    OP_MAP.put("-", SqlStdOperatorTable.MINUS);
+    OP_MAP.put("*", SqlStdOperatorTable.MULTIPLY);
+    OP_MAP.put("/", SqlStdOperatorTable.DIVIDE);
+    OP_MAP.put("^", SqlStdOperatorTable.POWER);
+    OP_MAP.put("%", SqlStdOperatorTable.MOD);
+  }
+
+  public static final String OPERATOR = "op";
+  public static final String OPERANDS = "operands";
+  /**
+   * For input node:
+   * - input equals 0 refers to the result
+   * - input great than 0 refers to the index of source operand (starting from 1)
+   */
+  public static final String INPUT = "input";
+  public static final String VALUE = "value";
+  public static final String REGEX = "regex";
+  public static final String NAME = "name";
+
+  public final String fromOperatorName;
+  public final int numOperands;
+  public final SqlOperator targetOperator;
+  public List<JsonObject> operandTransformers;
+  public JsonObject resultTransformer;
+  public List<JsonObject> operatorTransformers;
+
+  /**
+   * Creates a new transformer.
+   *
+   * @param fromOperatorName Name of the function associated with this Operator in the input IR
+   * @param numOperands Number of operands
+   * @param targetOperator Operator in the target language
+   * @param operandTransformers JSON string representing the operand transformations,
+   *                            null for identity transformations
+   * @param resultTransformer JSON string representing the result transformation,
+   *                          null for identity transformation
+   * @param operatorTransformers JSON string representing an array of transformers that can vary the name of the target
+   *                             operator based on runtime parameter values.
+   *                             In the order of the JSON Array, the first transformer that matches the JSON string will
+   *                             have its given operator named selected as the target operator name.
+   *                             Operands are indexed beginning at index 1.
+   *                             An operatorTransformer has the following serialized JSON string format:
+   *                             "[
+   *                               {
+   *                                  \"name\" : \"{Name of function if this matches}\",
+   *                                  \"input\" : {Index of the parameter starting at index 1 that is evaluated },
+   *                                  \"regex\" : \"{Java Regex string matching the parameter at given input}\"
+   *                               },
+   *                               ...
+   *                             ]"
+   *                             For example, a transformer for a operator named "foo" when parameter 2 matches exactly
+   *                             "bar" is specified as:
+   *                             "[
+   *                               {
+   *                                  \"name\" : \"foo\",
+   *                                  \"input\" : 2,
+   *                                  \"regex\" : \"'bar'\"
+   *                               }
+   *                             ]"
+   *                             NOTE: A string literal is represented exactly as ['STRING_LITERAL'] with the single
+   *                             quotation marks INCLUDED.
+   *                             As seen in the example above, the single quotation marks are also present in the
+   *                             regex matcher.
+   *
+   */
+
+  public StandardOperatorTransformer(@Nonnull String fromOperatorName, int numOperands,
+      @Nonnull SqlOperator targetOperator, @Nullable String operandTransformers, @Nullable String resultTransformer,
+      @Nullable String operatorTransformers) {
+    this.fromOperatorName = fromOperatorName;
+    this.numOperands = numOperands;
+    this.targetOperator = targetOperator;
+    if (operandTransformers != null) {
+      this.operandTransformers = parseJsonObjectsFromString(operandTransformers);
+    }
+    if (resultTransformer != null) {
+      this.resultTransformer = new JsonParser().parse(resultTransformer).getAsJsonObject();
+    }
+    if (operatorTransformers != null) {
+      this.operatorTransformers = parseJsonObjectsFromString(operatorTransformers);
+    }
+  }
+
+  @Override
+  public boolean condition(SqlCall sqlCall) {
+    return fromOperatorName.equalsIgnoreCase(sqlCall.getOperator().getName())
+        && sqlCall.getOperandList().size() == numOperands;
+  }
+
+  @Override
+  public SqlCall transform(SqlCall sqlCall) {
+    List<SqlNode> sourceOperands = sqlCall.getOperandList();
+    final SqlOperator newTargetOperator = transformTargetOperator(targetOperator, sourceOperands);
+    if (newTargetOperator == null || newTargetOperator.getName().isEmpty()) {
+      String operands = sourceOperands.stream().map(SqlNode::toString).collect(Collectors.joining(","));
+      throw new IllegalArgumentException(
+          String.format("An equivalent operator in the target IR was not found for the function call: %s(%s)",
+              fromOperatorName, operands));
+    }
+    final List<SqlNode> newOperands = transformOperands(sourceOperands);
+    final SqlCall newCall = createCall(newTargetOperator, newOperands, SqlParserPos.ZERO);
+    return (SqlCall) transformResult(newCall, sourceOperands);
+  }
+
+  private List<SqlNode> transformOperands(List<SqlNode> sourceOperands) {
+    if (operandTransformers == null) {
+      return sourceOperands;
+    }
+    final List<SqlNode> sources = new ArrayList<>();
+    // Add a dummy expression for input 0
+    sources.add(null);
+    sources.addAll(sourceOperands);
+    final List<SqlNode> results = new ArrayList<>();
+    for (JsonObject operandTransformer : operandTransformers) {
+      results.add(transformExpression(operandTransformer, sources));
+    }
+    return results;
+  }
+
+  private SqlNode transformResult(SqlNode result, List<SqlNode> sourceOperands) {
+    if (resultTransformer == null) {
+      return result;
+    }
+    final List<SqlNode> sources = new ArrayList<>();
+    // Result will be input 0
+    sources.add(result);
+    sources.addAll(sourceOperands);
+    return transformExpression(resultTransformer, sources);
+  }
+
+  /**
+   * Performs a single transformer.
+   */
+  private SqlNode transformExpression(JsonObject transformer, List<SqlNode> sourceOperands) {
+    if (transformer.get(OPERATOR) != null) {
+      final List<SqlNode> inputOperands = new ArrayList<>();
+      for (JsonElement inputOperand : transformer.getAsJsonArray(OPERANDS)) {
+        if (inputOperand.isJsonObject()) {
+          inputOperands.add(transformExpression(inputOperand.getAsJsonObject(), sourceOperands));
+        }
+      }
+      final String operatorName = transformer.get(OPERATOR).getAsString();
+      final SqlOperator op = OP_MAP.get(operatorName);
+      if (op == null) {
+        throw new UnsupportedOperationException("Operator " + operatorName + " is not supported in transformation");
+      }
+      return createCall(op, inputOperands, SqlParserPos.ZERO);
+    }
+    if (transformer.get(INPUT) != null) {
+      int index = transformer.get(INPUT).getAsInt();
+      if (index < 0 || index >= sourceOperands.size() || sourceOperands.get(index) == null) {
+        throw new IllegalArgumentException(
+            "Invalid input value: " + index + ". Number of source operands: " + sourceOperands.size());
+      }
+      return sourceOperands.get(index);
+    }
+    final JsonElement value = transformer.get(VALUE);
+    if (value == null) {
+      throw new IllegalArgumentException("JSON node for transformation should be either op, input, or value");
+    }
+    if (!value.isJsonPrimitive()) {
+      throw new IllegalArgumentException("Value should be of primitive type: " + value);
+    }
+
+    final JsonPrimitive primitive = value.getAsJsonPrimitive();
+    if (primitive.isString()) {
+      return createStringLiteral(primitive.getAsString(), SqlParserPos.ZERO);
+    }
+    if (primitive.isBoolean()) {
+      return createLiteralBoolean(primitive.getAsBoolean(), SqlParserPos.ZERO);
+    }
+    if (primitive.isNumber()) {
+      return createLiteralNumber(value.getAsBigDecimal().longValue(), SqlParserPos.ZERO);
+    }
+
+    throw new UnsupportedOperationException("Invalid JSON literal value: " + primitive);
+  }
+
+  /**
+   * Returns a SqlOperator with a function name based on the value of the source operands.
+   */
+  private SqlOperator transformTargetOperator(SqlOperator operator, List<SqlNode> sourceOperands) {
+    if (operatorTransformers == null) {
+      return operator;
+    }
+
+    for (JsonObject operatorTransformer : operatorTransformers) {
+      if (!operatorTransformer.has(REGEX) || !operatorTransformer.has(INPUT) || !operatorTransformer.has(NAME)) {
+        throw new IllegalArgumentException(
+            "JSON node for target operator transformer must have a matcher, input and name");
+      }
+      // We use the same convention as operand and result transformers.
+      // Therefore, we start source index values at index 1 instead of index 0.
+      // Acceptable index values are set to be [1, size]
+      int index = operatorTransformer.get(INPUT).getAsInt() - 1;
+      if (index < 0 || index >= sourceOperands.size()) {
+        throw new IllegalArgumentException(
+            String.format("Index is not within the acceptable range [%d, %d]", 1, sourceOperands.size()));
+      }
+      String functionName = operatorTransformer.get(NAME).getAsString();
+      if (functionName.isEmpty()) {
+        throw new IllegalArgumentException("JSON node for transformation must have a non-empty name");
+      }
+      String matcher = operatorTransformer.get(REGEX).getAsString();
+
+      if (Pattern.matches(matcher, sourceOperands.get(index).toString())) {
+        return createOperator(functionName, operator.getReturnTypeInference(), null);
+      }
+    }
+    return operator;
+  }
+
+  /**
+   * Creates an ArrayList of JsonObjects from a string input.
+   * The input string must be a serialized JSON array.
+   */
+  private static List<JsonObject> parseJsonObjectsFromString(String s) {
+    List<JsonObject> objects = new ArrayList<>();
+    JsonArray transformerArray = new JsonParser().parse(s).getAsJsonArray();
+    for (JsonElement object : transformerArray) {
+      objects.add(object.getAsJsonObject());
+    }
+    return objects;
+  }
+
+  public static SqlOperator createOperator(String functionName, SqlReturnTypeInference returnTypeInference,
+      SqlOperandTypeChecker operandTypeChecker) {
+    return new SqlUserDefinedFunction(new SqlIdentifier(functionName, SqlParserPos.ZERO), returnTypeInference, null,
+        operandTypeChecker, null, null);
+  }
+}

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/Calcite2TrinoUDFConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/Calcite2TrinoUDFConverter.java
@@ -248,13 +248,7 @@ public class Calcite2TrinoUDFConverter {
         }
       }
 
-      final UDFTransformer transformer = CalciteTrinoUDFMap.getUDFTransformer(operatorName, call.operands.size());
-      if (transformer != null && shouldTransformOperator(operatorName)) {
-        return adjustReturnTypeWithCast(rexBuilder,
-            super.visitCall((RexCall) transformer.transformCall(rexBuilder, call.getOperands())));
-      }
-
-      if (operatorName.startsWith("com.linkedin") && transformer == null) {
+      if (operatorName.startsWith("com.linkedin")) {
         return visitUnregisteredUDF(call);
       }
 
@@ -480,10 +474,6 @@ public class Calcite2TrinoUDFConverter {
       }
       results.add(rexBuilder.makeCall(SqlStdOperatorTable.ARRAY_VALUE_CONSTRUCTOR, values));
       return rexBuilder.makeCall(call.getOperator(), results);
-    }
-
-    private boolean shouldTransformOperator(String operatorName) {
-      return !("to_date".equalsIgnoreCase(operatorName) && configs.getOrDefault(AVOID_TRANSFORM_TO_DATE_UDF, false));
     }
 
     /**

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CalciteTrinoOperatorTransformers.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CalciteTrinoOperatorTransformers.java
@@ -1,0 +1,209 @@
+/**
+ * Copyright 2023 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.trino.rel2trino;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+
+import com.linkedin.coral.com.google.common.base.CaseFormat;
+import com.linkedin.coral.com.google.common.base.Converter;
+import com.linkedin.coral.com.google.common.collect.ImmutableMultimap;
+import com.linkedin.coral.common.functions.Function;
+import com.linkedin.coral.common.transformers.OperatorTransformer;
+import com.linkedin.coral.common.transformers.OperatorTransformerList;
+import com.linkedin.coral.common.transformers.StandardOperatorTransformer;
+import com.linkedin.coral.hive.hive2rel.functions.HiveRLikeOperator;
+import com.linkedin.coral.hive.hive2rel.functions.StaticHiveFunctionRegistry;
+import com.linkedin.coral.trino.rel2trino.functions.TrinoElementAtFunction;
+
+
+public class CalciteTrinoOperatorTransformers extends OperatorTransformerList {
+  private static final StaticHiveFunctionRegistry HIVE_REGISTRY = new StaticHiveFunctionRegistry();
+  private static CalciteTrinoOperatorTransformers instance;
+  private CalciteTrinoOperatorTransformers() {
+  }
+
+  private CalciteTrinoOperatorTransformers(List<OperatorTransformer> operatorTransformers) {
+    super(operatorTransformers);
+  }
+
+  public static CalciteTrinoOperatorTransformers getInstance() {
+    if (instance == null) {
+      return new CalciteTrinoOperatorTransformers(initializeOperatorTransformers());
+    }
+    return instance;
+  }
+
+  private static List<OperatorTransformer> initializeOperatorTransformers() {
+    List<OperatorTransformer> operatorTransformers = new ArrayList<>();
+    // conditional functions
+    operatorTransformers.add(createOperatorTransformer(hiveToCalciteOp("nvl"), 2, "coalesce"));
+    // Array and map functions
+    operatorTransformers.add(createOperatorTransformer(SqlStdOperatorTable.ITEM, 2, TrinoElementAtFunction.INSTANCE));
+
+    // Math Functions
+    operatorTransformers.add(createOperatorTransformer(SqlStdOperatorTable.RAND, 0, "RANDOM"));
+    operatorTransformers.add(createOperatorTransformer(SqlStdOperatorTable.RAND, 1, "RANDOM", "[]", null));
+    operatorTransformers.add(createOperatorTransformer(SqlStdOperatorTable.RAND_INTEGER, 1, "RANDOM"));
+    operatorTransformers
+        .add(createOperatorTransformer(SqlStdOperatorTable.RAND_INTEGER, 2, "RANDOM", "[{\"input\":2}]", null));
+    operatorTransformers.add(createOperatorTransformer(SqlStdOperatorTable.TRUNCATE, 2, "TRUNCATE",
+        "[{\"op\":\"*\",\"operands\":[{\"input\":1},{\"op\":\"^\",\"operands\":[{\"value\":10},{\"input\":2}]}]}]",
+        "{\"op\":\"/\",\"operands\":[{\"input\":0},{\"op\":\"^\",\"operands\":[{\"value\":10},{\"input\":2}]}]}"));
+
+    // String Functions
+    operatorTransformers.add(createOperatorTransformer(SqlStdOperatorTable.SUBSTRING, 2, "SUBSTR"));
+    operatorTransformers.add(createOperatorTransformer(SqlStdOperatorTable.SUBSTRING, 3, "SUBSTR"));
+    operatorTransformers.add(createOperatorTransformer(HiveRLikeOperator.RLIKE, 2, "REGEXP_LIKE"));
+    operatorTransformers.add(createOperatorTransformer(HiveRLikeOperator.REGEXP, 2, "REGEXP_LIKE"));
+
+    // JSON Functions
+    operatorTransformers.add(createOperatorTransformer(hiveToCalciteOp("get_json_object"), 2, "json_extract"));
+
+    // map various hive functions
+    operatorTransformers.add(createOperatorTransformer(hiveToCalciteOp("pmod"), 2, "mod",
+        "[{\"op\":\"+\",\"operands\":[{\"op\":\"%\",\"operands\":[{\"input\":1},{\"input\":2}]},{\"input\":2}]},{\"input\":2}]",
+        null));
+    operatorTransformers.add(createOperatorTransformer(hiveToCalciteOp("base64"), 1, "to_base64"));
+    operatorTransformers.add(createOperatorTransformer(hiveToCalciteOp("unbase64"), 1, "from_base64"));
+    operatorTransformers.add(createOperatorTransformer(hiveToCalciteOp("hex"), 1, "to_hex"));
+    operatorTransformers.add(createOperatorTransformer(hiveToCalciteOp("unhex"), 1, "from_hex"));
+    operatorTransformers.add(createOperatorTransformer(hiveToCalciteOp("array_contains"), 2, "contains"));
+    operatorTransformers.add(createOperatorTransformer(hiveToCalciteOp("regexp_extract"), 3, "regexp_extract",
+        "[{\"input\": 1}, {\"op\": \"hive_pattern_to_trino\", \"operands\":[{\"input\": 2}]}, {\"input\": 3}]", null));
+    operatorTransformers.add(createOperatorTransformer(hiveToCalciteOp("instr"), 2, "strpos"));
+    operatorTransformers.add(createOperatorTransformer(hiveToCalciteOp("decode"), 2,
+        "[{\"regex\":\"(?i)('utf-8')\", \"input\":2, \"name\":\"from_utf8\"}]", "[{\"input\":1}]", null));
+
+    operatorTransformers.add(createOperatorTransformer(hiveToCalciteOp("to_date"), 1, "date",
+        "[{\"op\": \"timestamp\", \"operands\":[{\"input\": 1}]}]", null));
+    operatorTransformers
+        .add(
+            createOperatorTransformer(hiveToCalciteOp("date_add"), 2, "date_add",
+                "[{\"value\": 'day'}, {\"input\": 2},  "
+                    + "{\"op\": \"date\", \"operands\":[{\"op\": \"timestamp\", \"operands\":[{\"input\": 1}]}]}]",
+                null));
+    operatorTransformers
+        .add(
+            createOperatorTransformer(hiveToCalciteOp("date_sub"), 2, "date_add",
+                "[{\"value\": 'day'}, " + "{\"op\": \"*\", \"operands\":[{\"input\": 2}, {\"value\": -1}]}, "
+                    + "{\"op\": \"date\", \"operands\":[{\"op\": \"timestamp\", \"operands\":[{\"input\": 1}]}]}]",
+                null));
+    operatorTransformers.add(createOperatorTransformer(hiveToCalciteOp("datediff"), 2, "date_diff",
+        "[{\"value\": 'day'}, {\"op\": \"date\", \"operands\":[{\"op\": \"timestamp\", \"operands\":[{\"input\": 2}]}]}, "
+            + "{\"op\": \"date\", \"operands\":[{\"op\": \"timestamp\", \"operands\":[{\"input\": 1}]}]}]",
+        null));
+
+    // DALI functions
+    // Most "com.linkedin..." UDFs follow convention of having UDF names mapped from camel-cased name to snake-cased name.
+    // For example: For class name IsGuestMemberId, the conventional udf name would be is_guest_member_id.
+    // While this convention fits most UDFs it doesn't fit all. With the following mapping we override the conventional
+    // UDF name mapping behavior to a hardcoded one.
+    // For example instead of UserAgentParser getting mapped to user_agent_parser, we mapped it here to useragentparser
+    Set<String> daliFunctionIdSet = new HashSet<>();
+    operatorTransformers.add(
+        createOperatorTransformer(daliToCalciteOp("com.linkedin.dali.udf.watbotcrawlerlookup.hive.WATBotCrawlerLookup"),
+            3, "wat_bot_crawler_lookup"));
+    addDaliFunctionId(daliFunctionIdSet, "com.linkedin.dali.udf.watbotcrawlerlookup.hive.WATBotCrawlerLookup", 3);
+    operatorTransformers
+        .add(createOperatorTransformer(daliToCalciteOp("com.linkedin.stdudfs.parsing.hive.Ip2Str"), 1, "ip2str"));
+    addDaliFunctionId(daliFunctionIdSet, "com.linkedin.stdudfs.parsing.hive.Ip2Str", 1);
+    operatorTransformers
+        .add(createOperatorTransformer(daliToCalciteOp("com.linkedin.stdudfs.parsing.hive.Ip2Str"), 3, "ip2str"));
+    addDaliFunctionId(daliFunctionIdSet, "com.linkedin.stdudfs.parsing.hive.Ip2Str", 3);
+    operatorTransformers.add(createOperatorTransformer(
+        daliToCalciteOp("com.linkedin.stdudfs.parsing.hive.UserAgentParser"), 2, "useragentparser"));
+    addDaliFunctionId(daliFunctionIdSet, "com.linkedin.stdudfs.parsing.hive.UserAgentParser", 2);
+    operatorTransformers.add(createOperatorTransformer(
+        daliToCalciteOp("com.linkedin.stdudfs.lookup.hive.BrowserLookup"), 3, "browserlookup"));
+    addDaliFunctionId(daliFunctionIdSet, "com.linkedin.stdudfs.lookup.hive.BrowserLookup", 3);
+    operatorTransformers.add(createOperatorTransformer(
+        daliToCalciteOp("com.linkedin.jobs.udf.hive.ConvertIndustryCode"), 1, "converttoindustryv1"));
+    addDaliFunctionId(daliFunctionIdSet, "com.linkedin.jobs.udf.hive.ConvertIndustryCode", 1);
+    operatorTransformers.add(createOperatorTransformer(
+        daliToCalciteOp("com.linkedin.stdudfs.urnextractor.hive.UrnExtractorFunctionWrapper"), 1, "urn_extractor"));
+    addDaliFunctionId(daliFunctionIdSet, "com.linkedin.stdudfs.urnextractor.hive.UrnExtractorFunctionWrapper", 1);
+    operatorTransformers.add(createOperatorTransformer(
+        daliToCalciteOp("com.linkedin.stdudfs.hive.daliudfs.UrnExtractorFunctionWrapper"), 1, "urn_extractor"));
+    addDaliFunctionId(daliFunctionIdSet, "com.linkedin.stdudfs.hive.daliudfs.UrnExtractorFunctionWrapper", 1);
+
+    addDaliUDFs(operatorTransformers, daliFunctionIdSet);
+
+    return operatorTransformers;
+  }
+
+  private static SqlOperator hiveToCalciteOp(String functionName) {
+    Collection<Function> lookup = HIVE_REGISTRY.lookup(functionName);
+    // TODO: provide overloaded function resolution
+    return lookup.iterator().next().getSqlOperator();
+  }
+
+  private static void addDaliFunctionId(Set<String> daliFunctionIdSet, String daliFunctionName, int operandNum) {
+    daliFunctionIdSet.add(daliFunctionName + "_" + operandNum);
+  }
+
+  private static void addDaliUDFs(List<OperatorTransformer> operatorTransformers, Set<String> daliFunctionIdSet) {
+    ImmutableMultimap<String, Function> registry = HIVE_REGISTRY.getRegistry();
+    Converter<String, String> caseConverter = CaseFormat.UPPER_CAMEL.converterTo(CaseFormat.LOWER_UNDERSCORE);
+    for (Map.Entry<String, Function> entry : registry.entries()) {
+      // we cannot use entry.getKey() as function name directly, because keys are all lowercase, which will
+      // fail to be converted to lowercase with underscore correctly
+      final String hiveFunctionName = entry.getValue().getFunctionName();
+      if (!hiveFunctionName.startsWith("com.linkedin")) {
+        continue;
+      }
+      String[] nameSplit = hiveFunctionName.split("\\.");
+      // filter above guarantees we've at least 2 entries
+      String className = nameSplit[nameSplit.length - 1];
+      String funcName = caseConverter.convert(className);
+      SqlOperator op = entry.getValue().getSqlOperator();
+      for (int i = op.getOperandCountRange().getMin(); i <= op.getOperandCountRange().getMax(); i++) {
+        if (!daliFunctionIdSet.contains(hiveFunctionName + "_" + i)) {
+          operatorTransformers.add(createOperatorTransformer(op, i, funcName));
+        }
+      }
+    }
+  }
+
+  private static SqlOperator daliToCalciteOp(String className) {
+    return HIVE_REGISTRY.lookup(className).iterator().next().getSqlOperator();
+  }
+
+  private static OperatorTransformer createOperatorTransformer(SqlOperator calciteOp, int numOperands,
+      String trinoUDFName) {
+    return createOperatorTransformer(calciteOp, numOperands,
+        UDFMapUtils.createUDF(trinoUDFName, calciteOp.getReturnTypeInference()));
+  }
+
+  private static OperatorTransformer createOperatorTransformer(SqlOperator calciteOp, int numOperands,
+      String trinoUDFName, String operandTransformer, String resultTransformer) {
+    return createOperatorTransformer(calciteOp, numOperands,
+        UDFMapUtils.createUDF(trinoUDFName, calciteOp.getReturnTypeInference()), operandTransformer, resultTransformer);
+  }
+
+  private static OperatorTransformer createOperatorTransformer(SqlOperator calciteOp, int numOperands,
+      SqlOperator trinoOp) {
+    return createOperatorTransformer(calciteOp, numOperands, trinoOp, null, null, null);
+  }
+
+  private static OperatorTransformer createOperatorTransformer(SqlOperator calciteOp, int numOperands,
+      SqlOperator trinoOp, String operandTransformer, String resultTransformer) {
+    return createOperatorTransformer(calciteOp, numOperands, trinoOp, operandTransformer, resultTransformer, null);
+  }
+
+  private static OperatorTransformer createOperatorTransformer(SqlOperator calciteOp, int numOperands,
+      SqlOperator trinoOp, String operandTransformer, String resultTransformer, String operatorTransformer) {
+    return new StandardOperatorTransformer(calciteOp.getName(), numOperands, trinoOp, operandTransformer,
+        resultTransformer, operatorTransformer);
+  }
+}

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2023 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -77,7 +77,9 @@ public class RelToTrinoConverter extends RelToSqlConverter {
    */
   public String convert(RelNode relNode) {
     RelNode rel = convertRel(relNode, configs);
-    return convertToSqlNode(rel).accept(new TrinoSqlRewriter()).toSqlString(TrinoSqlDialect.INSTANCE).toString();
+    SqlNode sqlNode = convertToSqlNode(rel);
+    SqlNode sqlNodeWithConvertedUDF = sqlNode.accept(new TrinoSqlUDFConverter(configs));
+    return sqlNodeWithConvertedUDF.accept(new TrinoSqlRewriter()).toSqlString(TrinoSqlDialect.INSTANCE).toString();
   }
 
   /**

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoSqlUDFConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoSqlUDFConverter.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2017-2023 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.trino.rel2trino;
+
+import java.util.Map;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.util.SqlShuttle;
+
+import static com.linkedin.coral.trino.rel2trino.CoralTrinoConfigKeys.*;
+
+
+public class TrinoSqlUDFConverter extends SqlShuttle {
+  private static final String TO_DATE_OPERATOR_NAME = "to_date";
+  private final Map<String, Boolean> configs;
+  public TrinoSqlUDFConverter(Map<String, Boolean> configs) {
+    this.configs = configs;
+  }
+
+  @Override
+  public SqlNode visit(SqlCall call) {
+    if (shouldTransformOperator(call.getOperator().getName())) {
+      CalciteTrinoOperatorTransformers operatorTransformers = CalciteTrinoOperatorTransformers.getInstance();
+      SqlCall transformedCall = operatorTransformers.apply(call);
+      return super.visit(transformedCall);
+    } else {
+      return super.visit(call);
+    }
+  }
+
+  private boolean shouldTransformOperator(String operatorName) {
+    return !(TO_DATE_OPERATOR_NAME.equalsIgnoreCase(operatorName)
+        && configs.getOrDefault(AVOID_TRANSFORM_TO_DATE_UDF, false));
+  }
+}


### PR DESCRIPTION
Based on Jiefan's [PR](https://github.com/linkedin/coral/pull/336/files#diff-2fb1eb21bc5936ee6b8406a4c9e238c018ac121a14cdc928e8e05a7677fb9887), this PR creates a new class of `CalciteTrinoOperatorTransformer` which extends the class of `OperatorTransformerList`. It is a singleton class and initialize all StandardOperatorTransformer according to `UDFTransformers` defined in `CalciteTrinoUDFMap`

Adding a class of `TrinoSqlUDFConverter` which extends the class of `SqlShuttle`. Calling it in `RelToTrinoConverter.convert()` to traverse SqlNode to convert UDF.
To be noted that, there are 5 unit test cases failing because of the following two reasons:

* The operator `timestamp` is not defined in `OP_MAP` in the class of `StandardOperatorTransformer.java`, so the following test cases fail because of `java.lang.UnsupportedOperationException` including:
   * HiveToTrinoConverterTest.testDateFormatFunction
   * HiveToTrinoConverterTest.testTypeCastForDataAddFunction
   * HiveToTrinoConverterTest.testTypeCastForDateDiffFunction
   * HiveToTrinoConverterTest.testViews[26]
* In the test case of RelToTrinoConverterTest.testMapStructAccess, the sql statement to be tested has the operator `[]` like `mcol[scol].IFIELD`.  This identifier is converted as `ITEM($3, $1)` in RelNode. In the previous implementation, the operator `ITEM` is converted into `element_at` in RelNode. However, `[]` is a literal in SqlIdentifier and not considered as an operator in SqlNode, so it cannot be converted into `element_at` by `StandardOperatorTransformer`.
 
