### PR TITLE
Coral-Schema: Use "timestamp-millis" as the correct timestamp logicalType for Spark3 and Avro 1.10

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
@@ -107,7 +107,7 @@ class RelDataTypeToAvroType {
         return Schema.create(Schema.Type.NULL);
       case TIMESTAMP:
         Schema schema = Schema.create(Schema.Type.LONG);
-        schema.addProp("logicalType", "timestamp");
+        schema.addProp("logicalType", "timestamp-millis");
         return schema;
       case DECIMAL:
         JsonNodeFactory factory = JsonNodeFactory.instance;

--- a/coral-schema/src/test/resources/rel2avro-testTimestampTypeField-expected.avsc
+++ b/coral-schema/src/test/resources/rel2avro-testTimestampTypeField-expected.avsc
@@ -6,7 +6,7 @@
     "name" : "timestamp_field",
     "type" : [ "null", {
       "type" : "long",
-      "logicalType" : "timestamp"
+      "logicalType" : "timestamp-millis"
     } ],
     "default" : null
   } ]


### PR DESCRIPTION
Previously, Avro 1.7 didn’t actually support timestamp logical type, so we used `"logicalType" : "timestamp"`, and added the handler for `"timestamp"` in LI-Spark2 specially. However, Spark3 doesn't recognize `"timestamp"` anymore, we should modify it to `"timestamp-millis"` which is officially supported by Avro 1.10 and [can be recognized by Spark3](https://github.com/apache/spark/blob/master/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala#L137).

Tested on the affected production view, it could return timestamp type as expected with this patch.