### PR TITLE
Set log level as INFO on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           java-version: 1.8
 
       - name: 3. Perform build
-        run: ./gradlew build
+        run: ./gradlew -i build
 
       - name: 4. Perform release
         # Release job, only for pushes to the main development branch


### PR DESCRIPTION
The existing log level doesn't provide helpful message when the test failed on CI environment. 

Old error message:
```
Gradle suite > Gradle test > com.linkedin.coral.spark.spark2rel.SparkToRelConverterTest.testSupport[13](select * from a order by x limit all, LogicalSort(sort0=[$2], dir0=[ASC-nulls-first])
  LogicalProject(b=[$0], id=[$1], x=[$2])
    LogicalTableScan(table=[[hive, default, a]])
, SELECT "b", "id", "x"
FROM "default"."a"
```

New log message:
```
Gradle suite > Gradle test > com.linkedin.coral.spark.spark2rel.SparkToRelConverterTest.testSupport[13](select * from a order by x limit all, LogicalSort(sort0=[$2], dir0=[ASC-nulls-first])
  LogicalProject(b=[$0], id=[$1], x=[$2])
    LogicalTableScan(table=[[hive, default, a]])
, SELECT "b", "id", "x"
FROM "default"."a"
ORDER BY "x" NULLS FIRST) FAILED
    java.lang.AssertionError: expected:<SELECT "b", "id", "x"
    FROM "default"."a"
    ORDER BY "x" NULLS FIRST> but was:<SELECT *
    FROM "default"."a"
    ORDER BY "x" NULLS FIRST>
        at org.testng.AssertJUnit.assertEquals(AssertJUnit.java:101)
        at org.testng.AssertJUnit.assertEquals(AssertJUnit.java:108)
        at com.linkedin.coral.spark.spark2rel.SparkToRelConverterTest.testSupport(SparkToRelConverterTest.java:175)
```