### PR TITLE
Coral-Schema: return nullable schema for array item and map value

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/ToNullableSchemaVisitor.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/ToNullableSchemaVisitor.java
@@ -46,12 +46,12 @@ public class ToNullableSchemaVisitor extends AvroSchemaVisitor<Schema> {
 
   @Override
   public Schema array(Schema array, Schema element) {
-    return Schema.createArray(element);
+    return Schema.createArray(SchemaUtilities.makeNullable(element, false));
   }
 
   @Override
   public Schema map(Schema map, Schema value) {
-    return Schema.createMap(value);
+    return Schema.createMap(SchemaUtilities.makeNullable(value, false));
   }
 
   @Override

--- a/coral-schema/src/test/resources/testToNullableSchema-expected.avsc
+++ b/coral-schema/src/test/resources/testToNullableSchema-expected.avsc
@@ -18,14 +18,14 @@
     "name" : "Array_Col",
     "type" : [ "null", {
       "type" : "array",
-      "items" : "string"
+      "items" : [ "null", "string" ]
     } ],
     "default" : null
   }, {
     "name" : "Map_Col",
     "type" : [ "null", {
       "type" : "map",
-      "values" : "string"
+      "values" : [ "null", "string" ]
     } ],
     "default" : null
   }, {
@@ -86,7 +86,7 @@
         "name" : "Map_Col",
         "type" : [ "null", {
           "type" : "map",
-          "values" : "string"
+          "values" : [ "null", "string" ]
         } ],
         "default" : null
       } ]


### PR DESCRIPTION
Previously, `ToNullableSchemaVisitor` couldn't make the array item or map value nullable, this PR is to fix this issue.

Tests:
1. Unit test
2. Regression test, no regression on prod views
3. Tested on the affected views on gateway, which can be queried with this change