### PR TITLE
Coral-Service: Handle error message for local mode creation failure

### DIFF
--- a/coral-service/src/main/java/com/linkedin/coral/coralservice/controller/TranslationControllerLocal.java
+++ b/coral-service/src/main/java/com/linkedin/coral/coralservice/controller/TranslationControllerLocal.java
@@ -44,8 +44,13 @@ public class TranslationControllerLocal extends TranslationController {
           .body("Only queries starting with \"CREATE DATABASE|TABLE|VIEW\" are accepted.\n");
     }
 
-    SessionState.start(conf);
-    run(driver, statement);
+    try {
+      SessionState.start(conf);
+      run(driver, statement);
+    } catch (Throwable t) {
+      final Throwable cause = t.getCause();
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(cause == null ? t.getMessage() : cause.getMessage());
+    }
 
     return ResponseEntity.status(HttpStatus.OK).body("Creation successful\n");
   }


### PR DESCRIPTION
Previously, Coral-Service doesn't return the error message for local mode creation failure, and the UI is like:
<img width="1165" alt="Screen Shot 2023-02-07 at 1 52 17 PM" src="https://user-images.githubusercontent.com/82360990/217375794-7c193fc4-171f-4a1d-a4f1-42a131d4015a.png">

With this PR, the error message can be displayed properly:
<img width="1115" alt="Screen Shot 2023-02-07 at 1 51 40 PM" src="https://user-images.githubusercontent.com/82360990/217376007-a71700fe-1645-4bfb-b858-630dbd8200f2.png">
