### PR TITLE
Coral-Spark: Migrate 'CAST(ROW: RECORD_TYPE)' and 'extract_union' transformations from RelNode to SqlNode layer

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/CoalesceStructUtility.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2023 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -22,7 +22,7 @@ import org.apache.calcite.sql.type.SqlTypeTransforms;
 
 /**
  * A utility class to coalesce the {@link RelDataType} of struct between Trino's representation and
- * hive's extract_union UDF's representation on exploded union.
+ * Hive/Spark's extract_union UDF's representation on exploded union.
  *
  */
 public class CoalesceStructUtility {

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/CoralToSparkSqlCallConverter.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/CoralToSparkSqlCallConverter.java
@@ -15,6 +15,8 @@ import org.apache.calcite.sql.util.SqlShuttle;
 import com.linkedin.coral.common.transformers.OperatorRenameSqlCallTransformer;
 import com.linkedin.coral.common.transformers.SqlCallTransformers;
 import com.linkedin.coral.spark.containers.SparkUDFInfo;
+import com.linkedin.coral.spark.transformers.CastToNamedStructTransformer;
+import com.linkedin.coral.spark.transformers.ExtractUnionFunctionTransformer;
 import com.linkedin.coral.spark.transformers.FallBackToLinkedInHiveUDFTransformer;
 import com.linkedin.coral.spark.transformers.TransportUDFTransformer;
 
@@ -153,7 +155,13 @@ public class CoralToSparkSqlCallConverter extends SqlShuttle {
         new OperatorRenameSqlCallTransformer(SqlStdOperatorTable.CARDINALITY, 1, "size"),
 
         // Fall back to the original Hive UDF defined in StaticHiveFunctionRegistry after failing to apply transformers above
-        new FallBackToLinkedInHiveUDFTransformer(sparkUDFInfos));
+        new FallBackToLinkedInHiveUDFTransformer(sparkUDFInfos),
+
+        // Transform `CAST(ROW: RECORD_TYPE)` to `named_struct`
+        new CastToNamedStructTransformer(),
+
+        // Transform `extract_union` to `coalesce_struct`
+        new ExtractUnionFunctionTransformer(sparkUDFInfos));
   }
 
   @Override

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/transformers/CastToNamedStructTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/transformers/CastToNamedStructTransformer.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2023 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.spark.transformers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlRowTypeNameSpec;
+import org.apache.calcite.sql.SqlRowTypeSpec;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import com.linkedin.coral.common.transformers.SqlCallTransformer;
+import com.linkedin.coral.hive.hive2rel.functions.HiveNamedStructFunction;
+
+
+/**
+ * This transformer transforms `CAST(ROW: RECORD_TYPE)` to `named_struct` in Spark.
+ * For example, the SqlCall `CAST(ROW(123, 'xyz') AS ROW(`abc` INTEGER, `def` CHAR(3) CHARACTER SET `ISO-8859-1`))`
+ * will be transformed to `named_struct('abc', 123, 'def', 'xyz')`
+ */
+public class CastToNamedStructTransformer extends SqlCallTransformer {
+  @Override
+  protected boolean condition(SqlCall sqlCall) {
+    if (sqlCall.getOperator().getKind() == SqlKind.CAST) {
+      final SqlNode firstOperand = sqlCall.getOperandList().get(0);
+      final SqlNode secondOperand = sqlCall.getOperandList().get(1);
+      return firstOperand instanceof SqlCall && ((SqlCall) firstOperand).getOperator().getKind() == SqlKind.ROW
+          && secondOperand instanceof SqlRowTypeSpec;
+    }
+    return false;
+  }
+
+  @Override
+  protected SqlCall transform(SqlCall sqlCall) {
+    List<SqlNode> newOperands = new ArrayList<>();
+    final SqlCall rowCall = (SqlCall) sqlCall.getOperandList().get(0); // like `ROW(123, 'xyz')` in above example
+    final SqlRowTypeSpec sqlRowTypeSpec = (SqlRowTypeSpec) sqlCall.getOperandList().get(1); // like `ROW(`abc` INTEGER, `def` CHAR(3) CHARACTER SET `ISO-8859-1`))` in above example
+    for (int i = 0; i < rowCall.getOperandList().size(); ++i) {
+      final String fieldName =
+          ((SqlRowTypeNameSpec) sqlRowTypeSpec.getTypeNameSpec()).getFieldNames().get(i).names.get(0);
+      newOperands.add(new SqlIdentifier("'" + fieldName + "'", SqlParserPos.ZERO)); // need to single-quote the field name
+      newOperands.add(rowCall.getOperandList().get(i));
+    }
+    return HiveNamedStructFunction.NAMED_STRUCT.createCall(sqlCall.getParserPosition(), newOperands);
+  }
+}

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/transformers/CastToNamedStructTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/transformers/CastToNamedStructTransformer.java
@@ -21,7 +21,7 @@ import com.linkedin.coral.hive.hive2rel.functions.HiveNamedStructFunction;
 
 
 /**
- * This transformer transforms `CAST(ROW: RECORD_TYPE)` to `named_struct` in Spark.
+ * This transformer transforms Coral IR function `CAST(ROW: RECORD_TYPE)` to Spark compatible function `named_struct`.
  * For example, the SqlCall `CAST(ROW(123, 'xyz') AS ROW(`abc` INTEGER, `def` CHAR(3) CHARACTER SET `ISO-8859-1`))`
  * will be transformed to `named_struct('abc', 123, 'def', 'xyz')`
  */

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/transformers/ExtractUnionFunctionTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/transformers/ExtractUnionFunctionTransformer.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2023 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.spark.transformers;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNumericLiteral;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import com.linkedin.coral.com.google.common.collect.ImmutableList;
+import com.linkedin.coral.common.transformers.SqlCallTransformer;
+import com.linkedin.coral.hive.hive2rel.functions.CoalesceStructUtility;
+import com.linkedin.coral.spark.containers.SparkUDFInfo;
+
+
+/**
+ * This transformer transforms `extract_union` to `coalesce_struct`.
+ * Instead of leaving `extract_union` visible to Spark, since we adopted the new exploded struct schema (a.k.a struct_tr)
+ * that is different from extract_union's output (a.k.a struct_ex) to interpret union in Coral IR,
+ * we need to swap the reference of `extract_union` to a new UDF that is coalescing the difference between
+ * struct_tr and struct_ex.
+ * See {@link CoalesceStructUtility#COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY} and its comments for more details.
+ *
+ * Check `CoralSparkTest#testUnionExtractUDF` for examples.
+ */
+public class ExtractUnionFunctionTransformer extends SqlCallTransformer {
+  private static final String EXTRACT_UNION = "extract_union";
+  private static final String COALESCE_STRUCT = "coalesce_struct";
+
+  private final Set<SparkUDFInfo> sparkUDFInfos;
+
+  public ExtractUnionFunctionTransformer(Set<SparkUDFInfo> sparkUDFInfos) {
+    this.sparkUDFInfos = sparkUDFInfos;
+  }
+
+  @Override
+  protected boolean condition(SqlCall sqlCall) {
+    return EXTRACT_UNION.equalsIgnoreCase(sqlCall.getOperator().getName());
+  }
+
+  @Override
+  protected SqlCall transform(SqlCall sqlCall) {
+    sparkUDFInfos.add(new SparkUDFInfo("com.linkedin.coalescestruct.GenericUDFCoalesceStruct", "coalesce_struct",
+        ImmutableList.of(URI.create("ivy://com.linkedin.coalesce-struct:coalesce-struct-impl:+")),
+        SparkUDFInfo.UDFTYPE.HIVE_CUSTOM_UDF));
+    final List<SqlNode> operandList = sqlCall.getOperandList();
+    final SqlOperator coalesceStructFunction =
+        createSqlOperator(COALESCE_STRUCT, CoalesceStructUtility.COALESCE_STRUCT_FUNCTION_RETURN_STRATEGY);
+    if (operandList.size() == 1) {
+      // one arg case: extract_union(field_name)
+      return coalesceStructFunction.createCall(sqlCall.getParserPosition(), operandList);
+    } else if (operandList.size() == 2) {
+      // two arg case: extract_union(field_name, ordinal)
+      final int newOrdinal = ((SqlNumericLiteral) operandList.get(1)).getValueAs(Integer.class) + 1;
+      return coalesceStructFunction.createCall(sqlCall.getParserPosition(), ImmutableList.of(operandList.get(0),
+          SqlNumericLiteral.createExactNumeric(String.valueOf(newOrdinal), SqlParserPos.ZERO)));
+    } else {
+      return sqlCall;
+    }
+  }
+}


### PR DESCRIPTION
Similar to #351, this PR migrates `CAST(ROW: RECORD_TYPE)` and `extract_union` transformations from `RelNode` layer in `IRRelToSparkRelTransformer` to `SqlNode` layer. 

In order to avoid creating a PR that is too big, I will open several more PRs to finish migrating all the transformations in `IRRelToSparkRelTransformer` to `SqlNode` layer and remove `IRRelToSparkRelTransformer`.

Tests:
1. Existing unit tests, which already cover the changes
2. Regression test
3. Querying several complex production views on gateway, no regression