### PR TITLE
Coral-Spark: Migrate fuzzy union 'generic_project' transformation from RelNode to SqlNode layer

### DIFF
--- a/coral-common/src/main/java/com/linkedin/coral/common/utils/RelDataTypeToHiveTypeStringConverter.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/utils/RelDataTypeToHiveTypeStringConverter.java
@@ -3,7 +3,7 @@
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
-package com.linkedin.coral.spark.utils;
+package com.linkedin.coral.common.utils;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/coral-common/src/test/java/com/linkedin/coral/common/utils/RelDataTypeToHiveDataTypeStringConverterTest.java
+++ b/coral-common/src/test/java/com/linkedin/coral/common/utils/RelDataTypeToHiveDataTypeStringConverterTest.java
@@ -3,7 +3,7 @@
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
-package com.linkedin.coral.spark.utils;
+package com.linkedin.coral.common.utils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,8 +22,6 @@ import org.apache.calcite.sql.type.BasicSqlType;
 import org.apache.calcite.sql.type.MapSqlType;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.testng.annotations.Test;
-
-import com.linkedin.coral.common.utils.RelDataTypeToHiveTypeStringConverter;
 
 import static org.testng.Assert.*;
 

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/FuzzyUnionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2022 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2023 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -94,8 +94,9 @@ public class FuzzyUnionTest {
     String view = "union_view_single_branch_evolved";
     SqlNode node = getFuzzyUnionView(database, view);
 
-    String expectedSql = "" + "SELECT *\n" + "FROM \"hive\".\"fuzzy_union\".\"tableb\"\n" + "UNION ALL\n"
-        + "SELECT \"a\", \"generic_project\"(\"b\", 'b') AS \"b\"\n" + "FROM \"hive\".\"fuzzy_union\".\"tablec\"";
+    String expectedSql = "SELECT *\n" + "FROM \"hive\".\"fuzzy_union\".\"tableb\"\n" + "UNION ALL\n"
+        + "SELECT \"a\", \"generic_project\"(\"b\", 'b', 'struct<b1:string>') AS \"b\"\n"
+        + "FROM \"hive\".\"fuzzy_union\".\"tablec\"";
 
     converter.getSqlValidator().validate(node);
     String expandedSql = nodeToStr(node);
@@ -122,9 +123,10 @@ public class FuzzyUnionTest {
     String view = "union_view_double_branch_evolved_different";
     SqlNode node = getFuzzyUnionView(database, view);
 
-    String expectedSql = "" + "SELECT \"a\", \"generic_project\"(\"b\", 'b') AS \"b\"\n"
+    String expectedSql = "SELECT \"a\", \"generic_project\"(\"b\", 'b', 'struct<b1:string>') AS \"b\"\n"
         + "FROM \"hive\".\"fuzzy_union\".\"tablef\"\n" + "UNION ALL\n"
-        + "SELECT \"a\", \"generic_project\"(\"b\", 'b') AS \"b\"\n" + "FROM \"hive\".\"fuzzy_union\".\"tableg\"";
+        + "SELECT \"a\", \"generic_project\"(\"b\", 'b', 'struct<b1:string>') AS \"b\"\n"
+        + "FROM \"hive\".\"fuzzy_union\".\"tableg\"";
 
     converter.getSqlValidator().validate(node);
     String expandedSql = nodeToStr(node);
@@ -137,11 +139,13 @@ public class FuzzyUnionTest {
     String view = "union_view_more_than_two_branches_evolved";
     SqlNode node = getFuzzyUnionView(database, view);
 
-    String expectedSql = "" + "SELECT *\n" + "FROM (SELECT \"a\", \"generic_project\"(\"b\", 'b') AS \"b\"\n"
-        + "FROM \"hive\".\"fuzzy_union\".\"tablef\"\n" + "UNION ALL\n"
-        + "SELECT \"a\", \"generic_project\"(\"b\", 'b') AS \"b\"\n"
-        + "FROM \"hive\".\"fuzzy_union\".\"tableg\") AS \"t\"\n" + "UNION ALL\n"
-        + "SELECT \"a\", \"generic_project\"(\"b\", 'b') AS \"b\"\n" + "FROM \"hive\".\"fuzzy_union\".\"tablef\"";
+    String expectedSql =
+        "SELECT *\n" + "FROM (SELECT \"a\", \"generic_project\"(\"b\", 'b', 'struct<b1:string>') AS \"b\"\n"
+            + "FROM \"hive\".\"fuzzy_union\".\"tablef\"\n" + "UNION ALL\n"
+            + "SELECT \"a\", \"generic_project\"(\"b\", 'b', 'struct<b1:string>') AS \"b\"\n"
+            + "FROM \"hive\".\"fuzzy_union\".\"tableg\") AS \"t\"\n" + "UNION ALL\n"
+            + "SELECT \"a\", \"generic_project\"(\"b\", 'b', 'struct<b1:string>') AS \"b\"\n"
+            + "FROM \"hive\".\"fuzzy_union\".\"tablef\"";
 
     converter.getSqlValidator().validate(node);
     String expandedSql = nodeToStr(node);
@@ -154,9 +158,9 @@ public class FuzzyUnionTest {
     String view = "union_view_map_with_struct_value_evolved";
     SqlNode node = getFuzzyUnionView(database, view);
 
-    String expectedSql =
-        "" + "SELECT \"a\", \"generic_project\"(\"b\", 'b') AS \"b\"\n" + "FROM \"hive\".\"fuzzy_union\".\"tableh\"\n"
-            + "UNION ALL\n" + "SELECT *\n" + "FROM \"hive\".\"fuzzy_union\".\"tablei\"";
+    String expectedSql = "SELECT \"a\", \"generic_project\"(\"b\", 'b', 'map<string,struct<b1:string>>') AS \"b\"\n"
+        + "FROM \"hive\".\"fuzzy_union\".\"tableh\"\n" + "UNION ALL\n" + "SELECT *\n"
+        + "FROM \"hive\".\"fuzzy_union\".\"tablei\"";
 
     converter.getSqlValidator().validate(node);
     String expandedSql = nodeToStr(node);
@@ -169,9 +173,9 @@ public class FuzzyUnionTest {
     String view = "union_view_array_with_struct_value_evolved";
     SqlNode node = getFuzzyUnionView(database, view);
 
-    String expectedSql =
-        "" + "SELECT \"a\", \"generic_project\"(\"b\", 'b') AS \"b\"\n" + "FROM \"hive\".\"fuzzy_union\".\"tablej\"\n"
-            + "UNION ALL\n" + "SELECT *\n" + "FROM \"hive\".\"fuzzy_union\".\"tablek\"";
+    String expectedSql = "SELECT \"a\", \"generic_project\"(\"b\", 'b', 'array<struct<b1:string>>') AS \"b\"\n"
+        + "FROM \"hive\".\"fuzzy_union\".\"tablej\"\n" + "UNION ALL\n" + "SELECT *\n"
+        + "FROM \"hive\".\"fuzzy_union\".\"tablek\"";
 
     converter.getSqlValidator().validate(node);
     String expandedSql = nodeToStr(node);
@@ -185,8 +189,9 @@ public class FuzzyUnionTest {
     SqlNode node = getFuzzyUnionView(database, view);
 
     String expectedSql =
-        "" + "SELECT \"a\", \"generic_project\"(\"b\", 'b') AS \"b\"\n" + "FROM \"hive\".\"fuzzy_union\".\"tablel\"\n"
-            + "UNION ALL\n" + "SELECT *\n" + "FROM \"hive\".\"fuzzy_union\".\"tablem\"";
+        "SELECT \"a\", \"generic_project\"(\"b\", 'b', 'struct<b1:string,b2:struct<b3:string,b4:struct<b5:string>>>') AS \"b\"\n"
+            + "FROM \"hive\".\"fuzzy_union\".\"tablel\"\n" + "UNION ALL\n" + "SELECT *\n"
+            + "FROM \"hive\".\"fuzzy_union\".\"tablem\"";
 
     converter.getSqlValidator().validate(node);
     String expandedSql = nodeToStr(node);
@@ -199,8 +204,9 @@ public class FuzzyUnionTest {
     String view = "union_view_same_schema_evolution_with_different_ordering";
     SqlNode node = getFuzzyUnionView(database, view);
 
-    String expectedSql = "" + "SELECT *\n" + "FROM \"hive\".\"fuzzy_union\".\"tablen\"\n" + "UNION ALL\n"
-        + "SELECT \"a\", \"generic_project\"(\"b\", 'b') AS \"b\"\n" + "FROM \"hive\".\"fuzzy_union\".\"tableo\"";
+    String expectedSql = "SELECT *\n" + "FROM \"hive\".\"fuzzy_union\".\"tablen\"\n" + "UNION ALL\n"
+        + "SELECT \"a\", \"generic_project\"(\"b\", 'b', 'struct<b2:double,b1:string,b0:int>') AS \"b\"\n"
+        + "FROM \"hive\".\"fuzzy_union\".\"tableo\"";
 
     converter.getSqlValidator().validate(node);
     String expandedSql = nodeToStr(node);
@@ -213,9 +219,9 @@ public class FuzzyUnionTest {
     String view = "union_view_with_base_table_change";
     SqlNode node = getFuzzyUnionView(database, view);
 
-    String expectedSql = "SELECT \"a\", \"generic_project\"(\"b\", 'b') AS \"b\"\n" + "FROM (SELECT *\n"
-        + "FROM \"hive\".\"fuzzy_union\".\"tablep\"\n" + "UNION ALL\n"
-        + "SELECT \"a\", \"generic_project\"(\"b\", 'b') AS \"b\"\n"
+    String expectedSql = "SELECT \"a\", \"generic_project\"(\"b\", 'b', 'struct<b1:string>') AS \"b\"\n"
+        + "FROM (SELECT *\n" + "FROM \"hive\".\"fuzzy_union\".\"tablep\"\n" + "UNION ALL\n"
+        + "SELECT \"a\", \"generic_project\"(\"b\", 'b', 'struct<b2:double,b1:string,b0:int>') AS \"b\"\n"
         + "FROM \"hive\".\"fuzzy_union\".\"tableq\") AS \"t0\"\n" + "UNION ALL\n" + "SELECT *\n" + "FROM (SELECT *\n"
         + "FROM \"hive\".\"fuzzy_union\".\"tabler\"\n" + "UNION ALL\n" + "SELECT *\n"
         + "FROM \"hive\".\"fuzzy_union\".\"tables\") AS \"t\"";
@@ -232,7 +238,7 @@ public class FuzzyUnionTest {
     SqlNode node = getFuzzyUnionView(database, view);
 
     String expectedSql = "SELECT \"a\"\n" + "FROM (SELECT *\n" + "FROM \"hive\".\"fuzzy_union\".\"tableb\"\n"
-        + "UNION ALL\n" + "SELECT \"a\", \"generic_project\"(\"b\", 'b') AS \"b\"\n"
+        + "UNION ALL\n" + "SELECT \"a\", \"generic_project\"(\"b\", 'b', 'struct<b1:string>') AS \"b\"\n"
         + "FROM \"hive\".\"fuzzy_union\".\"tablec\") AS \"t0\"\n" + "UNION ALL\n" + "SELECT \"a\"\n"
         + "FROM \"hive\".\"fuzzy_union\".\"tableb\"";
 

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/CoralToSparkSqlCallConverter.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/CoralToSparkSqlCallConverter.java
@@ -18,6 +18,7 @@ import com.linkedin.coral.spark.containers.SparkUDFInfo;
 import com.linkedin.coral.spark.transformers.CastToNamedStructTransformer;
 import com.linkedin.coral.spark.transformers.ExtractUnionFunctionTransformer;
 import com.linkedin.coral.spark.transformers.FallBackToLinkedInHiveUDFTransformer;
+import com.linkedin.coral.spark.transformers.FuzzyUnionGenericProjectTransformer;
 import com.linkedin.coral.spark.transformers.TransportUDFTransformer;
 
 import static com.linkedin.coral.spark.transformers.TransportUDFTransformer.*;
@@ -161,7 +162,10 @@ public class CoralToSparkSqlCallConverter extends SqlShuttle {
         new CastToNamedStructTransformer(),
 
         // Transform `extract_union` to `coalesce_struct`
-        new ExtractUnionFunctionTransformer(sparkUDFInfos));
+        new ExtractUnionFunctionTransformer(sparkUDFInfos),
+
+        // Transform `generic_project` function
+        new FuzzyUnionGenericProjectTransformer(sparkUDFInfos));
   }
 
   @Override

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/transformers/FuzzyUnionGenericProjectTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/transformers/FuzzyUnionGenericProjectTransformer.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2023 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.spark.transformers;
+
+import java.net.URI;
+import java.util.Set;
+
+import org.apache.calcite.sql.SqlCall;
+
+import com.linkedin.coral.com.google.common.collect.ImmutableList;
+import com.linkedin.coral.common.functions.GenericProjectFunction;
+import com.linkedin.coral.common.transformers.SqlCallTransformer;
+import com.linkedin.coral.spark.containers.SparkUDFInfo;
+
+
+/**
+ * This transformer transforms the SqlCall `generic_project(col, col_name_string, hive_type_string)`
+ * (check {@link com.linkedin.coral.common.FuzzyUnionSqlRewriter}) to `generic_project(col, hive_type_string)`
+ * to meet Spark's expectation, and registers the `GenericProject` UDF.
+ */
+public class FuzzyUnionGenericProjectTransformer extends SqlCallTransformer {
+
+  private final Set<SparkUDFInfo> sparkUDFInfos;
+
+  public FuzzyUnionGenericProjectTransformer(Set<SparkUDFInfo> sparkUDFInfos) {
+    this.sparkUDFInfos = sparkUDFInfos;
+  }
+
+  @Override
+  protected boolean condition(SqlCall sqlCall) {
+    return sqlCall.getOperator() instanceof GenericProjectFunction && sqlCall.getOperandList().size() == 3;
+  }
+
+  @Override
+  protected SqlCall transform(SqlCall sqlCall) {
+    sparkUDFInfos.add(new SparkUDFInfo("com.linkedin.genericprojectudf.GenericProject", "generic_project",
+        ImmutableList.of(URI.create("ivy://com.linkedin.GenericProject:GenericProject-impl:+")),
+        SparkUDFInfo.UDFTYPE.HIVE_CUSTOM_UDF));
+    return sqlCall.getOperator().createCall(sqlCall.getParserPosition(), sqlCall.getOperandList().get(0),
+        sqlCall.getOperandList().get(2));
+  }
+}

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/utils/RelDataTypeToHiveDataTypeStringConverterTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/utils/RelDataTypeToHiveDataTypeStringConverterTest.java
@@ -23,6 +23,8 @@ import org.apache.calcite.sql.type.MapSqlType;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.testng.annotations.Test;
 
+import com.linkedin.coral.common.utils.RelDataTypeToHiveTypeStringConverter;
+
 import static org.testng.Assert.*;
 
 


### PR DESCRIPTION
Changes:
1. Add the Hive type string as the 3rd parameter of `generic_project` function for convenient transformation in Coral-Spark
2. In Coral-Spark, add `FuzzyUnionGenericProjectTransformer` which transforms the SqlCall `generic_project(col, col_name_string, hive_type_string)` to `generic_project(col, hive_type_string)` to meet Spark's expectation, and registers the `GenericProject` UDF.

Tests:
1. Existing unit tests, which already cover the changes
2. Regression test, no regression
3. Querying several complex production views on gateway, no regression