### PR TITLE
Coral-Common: Return 'string' for 'char' type in 'RelDataTypeToHiveTypeStringConverter'

### DIFF
--- a/coral-common/src/main/java/com/linkedin/coral/common/utils/RelDataTypeToHiveTypeStringConverter.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/utils/RelDataTypeToHiveTypeStringConverter.java
@@ -69,7 +69,7 @@ public class RelDataTypeToHiveTypeStringConverter {
       case BOOLEAN:
         return "boolean";
       case CHAR:
-        return "char";
+        return String.format("char(%d)", relDataType.getPrecision());
       case VARCHAR:
         return "string";
       case DATE:

--- a/coral-common/src/main/java/com/linkedin/coral/common/utils/RelDataTypeToHiveTypeStringConverter.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/utils/RelDataTypeToHiveTypeStringConverter.java
@@ -69,7 +69,6 @@ public class RelDataTypeToHiveTypeStringConverter {
       case BOOLEAN:
         return "boolean";
       case CHAR:
-        return String.format("char(%d)", relDataType.getPrecision());
       case VARCHAR:
         return "string";
       case DATE:

--- a/coral-common/src/test/java/com/linkedin/coral/common/utils/RelDataTypeToHiveDataTypeStringConverterTest.java
+++ b/coral-common/src/test/java/com/linkedin/coral/common/utils/RelDataTypeToHiveDataTypeStringConverterTest.java
@@ -168,4 +168,14 @@ public class RelDataTypeToHiveDataTypeStringConverterTest {
     assertEquals(hiveDataTypeSchemaString, expectedHiveDataTypeSchemaString);
   }
 
+  @Test
+  public void testCharRelDataType() {
+    String expectedHiveDataTypeSchemaString = "char(16)";
+
+    BasicSqlType charSqlType = new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.CHAR, 16);
+
+    String hiveDataTypeSchemaString = RelDataTypeToHiveTypeStringConverter.convertRelDataType(charSqlType);
+
+    assertEquals(hiveDataTypeSchemaString, expectedHiveDataTypeSchemaString);
+  }
 }

--- a/coral-common/src/test/java/com/linkedin/coral/common/utils/RelDataTypeToHiveDataTypeStringConverterTest.java
+++ b/coral-common/src/test/java/com/linkedin/coral/common/utils/RelDataTypeToHiveDataTypeStringConverterTest.java
@@ -170,7 +170,7 @@ public class RelDataTypeToHiveDataTypeStringConverterTest {
 
   @Test
   public void testCharRelDataType() {
-    String expectedHiveDataTypeSchemaString = "char(16)";
+    String expectedHiveDataTypeSchemaString = "string";
 
     BasicSqlType charSqlType = new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.CHAR, 16);
 


### PR DESCRIPTION
`char` is not a valid Hive type string, it should be mapped to `string` as the Hive type according to the schema of the corresponding production views.

Tests:
1. New UT
2. Regression test on prod views
3. Tested on the affected prod view with gateway Spark shell
