### PR TITLE
Coral-Service: Enable the location of hive.properties to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,10 @@ cd coral-service
 ```  
 ../gradlew bootRun  
 ```  
-
+You can also specify a custom location of `hive.properties` file through `--hivePropsLocation` as follows
+```
+ ./gradlew bootRun --args='--hivePropsLocation=/tmp/hive.properties'
+```
 Then you can interact with the service using your [browser](#coral-service-ui) or the [CLI](#coral-service-cli).
 
 ### Coral Service UI

--- a/coral-service/src/main/java/com/linkedin/coral/coralservice/controller/TranslationController.java
+++ b/coral-service/src/main/java/com/linkedin/coral/coralservice/controller/TranslationController.java
@@ -31,8 +31,8 @@ import static com.linkedin.coral.coralservice.utils.TranslationUtils.*;
 @Service
 @Profile({ "remoteMetastore", "default" })
 public class TranslationController implements ApplicationListener<ContextRefreshedEvent> {
-  @Value("${hiveProps:}")
-  private String hiveProps;
+  @Value("${hivePropsLocation:}")
+  private String hivePropsLocation;
 
   private final static ImmutableMap<String, String> LANGUAGE_MAP =
       ImmutableMap.of("hive", "Hive QL", "trino", "Trino SQL", "spark", "Spark SQL");
@@ -41,7 +41,7 @@ public class TranslationController implements ApplicationListener<ContextRefresh
   public void onApplicationEvent(ContextRefreshedEvent event) {
     // runs after the Spring context has been initialized
     try {
-      initHiveMetastoreClient(hiveProps);
+      initHiveMetastoreClient(hivePropsLocation);
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/coral-service/src/main/java/com/linkedin/coral/coralservice/controller/TranslationController.java
+++ b/coral-service/src/main/java/com/linkedin/coral/coralservice/controller/TranslationController.java
@@ -7,6 +7,7 @@ package com.linkedin.coral.coralservice.controller;
 
 import com.google.common.collect.ImmutableMap;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.ContextRefreshedEvent;
@@ -30,6 +31,9 @@ import static com.linkedin.coral.coralservice.utils.TranslationUtils.*;
 @Service
 @Profile({ "remoteMetastore", "default" })
 public class TranslationController implements ApplicationListener<ContextRefreshedEvent> {
+  @Value("${hiveProps:}")
+  private String hiveProps;
+
   private final static ImmutableMap<String, String> LANGUAGE_MAP =
       ImmutableMap.of("hive", "Hive QL", "trino", "Trino SQL", "spark", "Spark SQL");
 
@@ -37,7 +41,7 @@ public class TranslationController implements ApplicationListener<ContextRefresh
   public void onApplicationEvent(ContextRefreshedEvent event) {
     // runs after the Spring context has been initialized
     try {
-      initHiveMetastoreClient();
+      initHiveMetastoreClient(hiveProps);
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/coral-service/src/main/java/com/linkedin/coral/coralservice/metastore/MetastoreProvider.java
+++ b/coral-service/src/main/java/com/linkedin/coral/coralservice/metastore/MetastoreProvider.java
@@ -44,12 +44,12 @@ public class MetastoreProvider {
   private static final String DEFAULT_METASTORE_AUTHENTICATION = "SIMPLE";
   private static final String KERBEROS_AUTHENTICATION = "kerberos";
 
-  public static HiveMetastoreClient getMetastoreClient(String hiveProps) throws Exception {
+  public static HiveMetastoreClient getMetastoreClient(String hivePropsLocation) throws Exception {
     InputStream hivePropsStream = null;
-    if (hiveProps.trim().isEmpty()) {
+    if (hivePropsLocation.trim().isEmpty()) {
       hivePropsStream = CoralProvider.class.getClassLoader().getResourceAsStream("hive.properties");
     } else {
-      hivePropsStream = new FileInputStream(hiveProps);
+      hivePropsStream = new FileInputStream(hivePropsLocation);
     }
     final Properties props = new Properties();
     props.load(hivePropsStream);

--- a/coral-service/src/main/java/com/linkedin/coral/coralservice/metastore/MetastoreProvider.java
+++ b/coral-service/src/main/java/com/linkedin/coral/coralservice/metastore/MetastoreProvider.java
@@ -1,10 +1,11 @@
 /**
- * Copyright 2022 LinkedIn Corporation. All rights reserved.
+ * Copyright 2022-2023 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
 package com.linkedin.coral.coralservice.metastore;
 
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
@@ -43,10 +44,18 @@ public class MetastoreProvider {
   private static final String DEFAULT_METASTORE_AUTHENTICATION = "SIMPLE";
   private static final String KERBEROS_AUTHENTICATION = "kerberos";
 
-  public static HiveMetastoreClient getMetastoreClient() throws Exception {
-    final InputStream hiveConfStream = CoralProvider.class.getClassLoader().getResourceAsStream("hive.properties");
+  public static HiveMetastoreClient getMetastoreClient(String hiveProps) throws Exception {
+    InputStream hivePropsStream = null;
+    if (hiveProps.trim().isEmpty()) {
+      hivePropsStream = CoralProvider.class.getClassLoader().getResourceAsStream("hive.properties");
+    } else {
+      hivePropsStream = new FileInputStream(hiveProps);
+    }
     final Properties props = new Properties();
-    props.load(hiveConfStream);
+    props.load(hivePropsStream);
+    if (hivePropsStream != null) {
+      hivePropsStream.close();
+    }
     return new HiveMscAdapter(MetastoreProvider.getRemoteMetastoreClient(props));
   }
 

--- a/coral-service/src/main/java/com/linkedin/coral/coralservice/utils/CoralProvider.java
+++ b/coral-service/src/main/java/com/linkedin/coral/coralservice/utils/CoralProvider.java
@@ -42,9 +42,9 @@ public class CoralProvider {
   public static HiveConf conf;
   public static final String CORAL_SERVICE_DIR = "coral.service.test.dir";
 
-  public static void initHiveMetastoreClient() throws Exception {
+  public static void initHiveMetastoreClient(String hiveProps) throws Exception {
     // Connect to remote production Hive Metastore Client
-    hiveMetastoreClient = MetastoreProvider.getMetastoreClient();
+    hiveMetastoreClient = MetastoreProvider.getMetastoreClient(hiveProps);
   }
 
   public static void initLocalMetastore() throws IOException, HiveException, MetaException {

--- a/coral-service/src/main/java/com/linkedin/coral/coralservice/utils/CoralProvider.java
+++ b/coral-service/src/main/java/com/linkedin/coral/coralservice/utils/CoralProvider.java
@@ -42,9 +42,9 @@ public class CoralProvider {
   public static HiveConf conf;
   public static final String CORAL_SERVICE_DIR = "coral.service.test.dir";
 
-  public static void initHiveMetastoreClient(String hiveProps) throws Exception {
+  public static void initHiveMetastoreClient(String hivePropsLocation) throws Exception {
     // Connect to remote production Hive Metastore Client
-    hiveMetastoreClient = MetastoreProvider.getMetastoreClient(hiveProps);
+    hiveMetastoreClient = MetastoreProvider.getMetastoreClient(hivePropsLocation);
   }
 
   public static void initLocalMetastore() throws IOException, HiveException, MetaException {


### PR DESCRIPTION
## Summary ##
This patch enables the location of "hive.properties" to be configurable. By default it falls back to the hive.properties file in the resources folder. This will be helpful when the service is deployed in a hadoop cluster and we need to rely on a cluster specifc config deployed in the containers to boot up the service.

## Testing done ##
./gradlew  clean build with all the unit tests passing

Verified that ./gradlew bootRun picks up the hive.properties in resources folder.

Verified that the ./gradlew bootRun --args='--hivePropsLocation=/tmp/hive.properties'  picks up the hiveProps from the location.