### PR TITLE
Coral-service: Enable publishing coral-service jars to repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,9 +77,5 @@ subprojects {
   }
 
   apply from: "${rootDir}/gradle/dependencies.gradle"
-
-  // We exclude `coral-service` given it's a SpringBoot submodule and not compatible with `java-publication.gradle`
-  if (it.name != 'coral-service') {
-    apply from: "${rootDir}/gradle/java-publication.gradle"
-  }
+  apply from: "${rootDir}/gradle/java-publication.gradle"
 }

--- a/coral-service/build.gradle
+++ b/coral-service/build.gradle
@@ -4,6 +4,7 @@ plugins {
   id 'java'
 }
 
+// Ref: https://docs.gradle.org/current/userguide/upgrading_version_6.html?_ga=2.55190571.1487781572.1677273009-780026602.1675378719#publishing_spring_boot_applications
 configurations {
   [apiElements, runtimeElements].each {
     it.outgoing.artifacts.removeIf { it.buildDependencies.getDependencies(null).contains(jar) }

--- a/coral-service/build.gradle
+++ b/coral-service/build.gradle
@@ -4,6 +4,13 @@ plugins {
   id 'java'
 }
 
+configurations {
+  [apiElements, runtimeElements].each {
+    it.outgoing.artifacts.removeIf { it.buildDependencies.getDependencies(null).contains(jar) }
+    it.outgoing.artifact(bootJar)
+  }
+}
+
 repositories {
   maven { url "http://conjars.org/repo" }
 }


### PR DESCRIPTION
## Summary ##
This patch enables publishing the jars of coral-service module. Reasoning behind this patch is elaborated in https://docs.gradle.org/current/userguide/upgrading_version_6.html?_ga=2.55190571.1487781572.1677273009-780026602.1675378719#publishing_spring_boot_applications

## Testing Done ##
./gradlew -Prelease=true -PallArtifacts build

with coral-service jars seen in the local maven repository.