### PR TITLE
Coral-Hive: Avoid dropping 'CAST' on String

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/transformers/CoralRelToSqlNodeConverter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/transformers/CoralRelToSqlNodeConverter.java
@@ -81,7 +81,7 @@ public class CoralRelToSqlNodeConverter extends RelToSqlConverter {
         /**
          * The default value is `false`, then Coral will drop `CAST` for RexNode like `CAST(number_string AS BIGINT) > 0`,
          * which might cause translation quality issue.
-         * For example, without explict `CAST`, Spark will cast the `number_string` to {@link Integer} implicitly,
+         * For example, without explicit `CAST`, Spark will cast the `number_string` to {@link Integer} implicitly,
          * but if the value of the number_string is greater than {@link Integer.MAX_VALUE}, the result of the condition is wrong.
          *
          * Check `CoralSparkTest#testCastOnString` for an example.

--- a/coral-hive/src/main/java/com/linkedin/coral/transformers/CoralRelToSqlNodeConverter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/transformers/CoralRelToSqlNodeConverter.java
@@ -83,6 +83,7 @@ public class CoralRelToSqlNodeConverter extends RelToSqlConverter {
          * which might cause translation quality issue.
          * For example, without explicit `CAST`, Spark will cast the `number_string` to {@link Integer} implicitly,
          * but if the value of the number_string is greater than {@link Integer.MAX_VALUE}, the result of the condition is wrong.
+         * Note: Changing the default value to `true` only preserves the existing `CAST` and doesn't introduce new `CAST`.
          *
          * Check `CoralSparkTest#testCastOnString` for an example.
          */

--- a/coral-hive/src/main/java/com/linkedin/coral/transformers/CoralRelToSqlNodeConverter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/transformers/CoralRelToSqlNodeConverter.java
@@ -78,6 +78,14 @@ public class CoralRelToSqlNodeConverter extends RelToSqlConverter {
     return new SqlDialect(context) {
       @Override
       public boolean requireCastOnString() {
+        /**
+         * The default value is `false`, then Coral will drop `CAST` for RexNode like `CAST(number_string AS BIGINT) > 0`,
+         * which might cause translation quality issue.
+         * For example, without explict `CAST`, Spark will cast the `number_string` to {@link Integer} implicitly,
+         * but if the value of the number_string is greater than {@link Integer.MAX_VALUE}, the result of the condition is wrong.
+         *
+         * Check `CoralSparkTest#testCastOnString` for an example.
+         */
         return true;
       }
     };

--- a/coral-hive/src/main/java/com/linkedin/coral/transformers/CoralRelToSqlNodeConverter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/transformers/CoralRelToSqlNodeConverter.java
@@ -75,7 +75,12 @@ public class CoralRelToSqlNodeConverter extends RelToSqlConverter {
     SqlDialect.Context context = SqlDialect.EMPTY_CONTEXT.withDatabaseProduct(SqlDialect.DatabaseProduct.HIVE)
         .withNullCollation(NullCollation.HIGH);
 
-    return new SqlDialect(context);
+    return new SqlDialect(context) {
+      @Override
+      public boolean requireCastOnString() {
+        return true;
+      }
+    };
   }
 
   /**

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -857,8 +857,7 @@ public class CoralSparkTest {
   public void testCastOnString() {
     RelNode relNode = TestUtils.toRelNode("SELECT CAST('99999999999' AS BIGINT) > 0");
 
-    String targetSql = "SELECT CAST('99999999999' AS BIGINT) > 0\n" +
-        "FROM (VALUES  (0)) t (ZERO)";
+    String targetSql = "SELECT CAST('99999999999' AS BIGINT) > 0\n" + "FROM (VALUES  (0)) t (ZERO)";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -853,6 +853,15 @@ public class CoralSparkTest {
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
+  @Test
+  public void testCastOnString() {
+    RelNode relNode = TestUtils.toRelNode("SELECT CAST('99999999999' AS BIGINT) > 0");
+
+    String targetSql = "SELECT CAST('99999999999' AS BIGINT) > 0\n" +
+        "FROM (VALUES  (0)) t (ZERO)";
+    assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
+  }
+
   private static String getCoralSparkTranslatedSqlWithAliasFromCoralSchema(String db, String view) {
     RelNode relNode = TestUtils.toRelNode(db, view);
     Schema schema = TestUtils.getAvroSchemaForView(db, view, false);


### PR DESCRIPTION
## Change summary
Previously, the default value of [requireCastOnString](https://github.com/linkedin/linkedin-calcite/blob/c13ba44c6974574d07a47766e32e695e5c5e042f/core/src/main/java/org/apache/calcite/sql/SqlDialect.java#L612) is `false`, then Coral will drop `CAST` for RexNode like `CAST(number_string AS BIGINT) > 0`, which might cause translation quality issue.
For example, without explicit `CAST`, Spark will cast the `number_string` to `int` implicitly, but if the value of the `number_string` is greater than `Integer.MAX_VALUE`, the result of the condition is wrong.

## Tests
1. New UT
2. Regression test on production views
3. Test on the affected production views