### PR TITLE
Coral-Trino: Migrate 'ITEM' -> 'element_at' transformation from RelNode to SqlNode layer

### DIFF
--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/Calcite2TrinoUDFConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/Calcite2TrinoUDFConverter.java
@@ -54,7 +54,6 @@ import com.linkedin.coral.com.google.common.collect.Multimap;
 import com.linkedin.coral.common.functions.FunctionReturnTypes;
 import com.linkedin.coral.common.functions.GenericProjectFunction;
 import com.linkedin.coral.trino.rel2trino.functions.GenericProjectToTrinoConverter;
-import com.linkedin.coral.trino.rel2trino.functions.TrinoElementAtFunction;
 
 import static com.linkedin.coral.trino.rel2trino.CoralTrinoConfigKeys.*;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.MULTIPLY;
@@ -197,10 +196,6 @@ public class Calcite2TrinoUDFConverter {
       }
 
       final String operatorName = call.getOperator().getName();
-
-      if (operatorName.equalsIgnoreCase("item") && call.getOperands().size() == 2) {
-        return super.visitCall((RexCall) rexBuilder.makeCall(TrinoElementAtFunction.INSTANCE, call.getOperands()));
-      }
 
       if ((operatorName.equalsIgnoreCase("regexp") || operatorName.equalsIgnoreCase("rlike"))
           && call.getOperands().size() == 2) {


### PR DESCRIPTION
We need this migration now since it's blocking the type derivation for #329.
At present, this transformation happens in RelNode layer, so CoralSqlNode2 [here](https://github.com/linkedin/coral/pull/329/files#diff-a3a3daba44acc4e0b1208c73b4098f34d49eaecdfec6e29c8afbf289abf00a9aR96) contains `element_at` operator, which can't be recognized by `SqlValidator` for [type derivation](https://github.com/linkedin/coral/blob/e4d4db931820fbb64c790fa08d67b4395486a629/coral-common/src/main/java/com/linkedin/coral/common/transformers/SqlCallTransformer.java#L90), so the type derivation fails.
After migrating this conversion to SqlNode layer, the [CoralSqlNode2](https://github.com/linkedin/coral/pull/329/files#diff-a3a3daba44acc4e0b1208c73b4098f34d49eaecdfec6e29c8afbf289abf00a9aR96) contains the original `ITEM` operator, which can be recognized by SqlValidator for type derivation.

Tests:
1. Existing UTs
2. Regression test on prod views
3. Tested with #329 on the affected prod views, no regression on data type derivation anymore