### PR TITLE
Upgrade linkedin-calcite-core to 1.21.0.153 and add explicit table alias to solve wrong alias issue

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/transformers/CoralRelToSqlNodeConverter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/transformers/CoralRelToSqlNodeConverter.java
@@ -360,6 +360,8 @@ public class CoralRelToSqlNodeConverter extends RelToSqlConverter {
 
   /**
    * Override this method to avoid the duplicated alias for {@link org.apache.calcite.rel.logical.LogicalValues}.
+   * The original {@link org.apache.calcite.rel.rel2sql.SqlImplementor.Result#neededAlias} is `t`, we override
+   * it to be `null`.
    * So that for the input SQL like `SELECT 1`, the translated SQL will be like:
    *
    * SELECT 1
@@ -371,6 +373,8 @@ public class CoralRelToSqlNodeConverter extends RelToSqlConverter {
    * FROM (VALUES  (0)) t (ZERO) t
    *
    * which is wrong.
+   *
+   * TODO: Identify and backport the fix from apache-calcite to linkedin-calcite since the duplicated alias issue only happens in linkedin-calcite
    */
   @Override
   public Result visit(Values e) {

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -75,7 +75,7 @@ public class CoralSparkTest {
   public void testLiteralColumnsFromView() {
     // use date literal in view definition
     String targetSql = "SELECT '2013-01-01', '2017-08-22 01:02:03', CAST(123 AS SMALLINT), CAST(123 AS TINYINT)\n"
-        + "FROM default.foo\n" + "LIMIT 1";
+        + "FROM default.foo foo\n" + "LIMIT 1";
     RelNode relNode = TestUtils.toRelNode("default", "foo_v1");
     CoralSpark coralSpark = CoralSpark.create(relNode);
     String expandedSql = coralSpark.getSparkSql();
@@ -84,8 +84,8 @@ public class CoralSparkTest {
 
   @Test
   public void testGetSQLFromView() {
-    String targetSql = String.join("\n", "SELECT t0.bcol, bar.x", "FROM (SELECT b bcol, SUM(c) sum_c",
-        "FROM default.foo", "GROUP BY b) t0", "INNER JOIN default.bar ON t0.sum_c = bar.y");
+    String targetSql = "SELECT t0.bcol, bar.x\n" + "FROM (SELECT foo.b bcol, SUM(foo.c) sum_c\n"
+        + "FROM default.foo foo\n" + "GROUP BY foo.b) t0\n" + "INNER JOIN default.bar bar ON t0.sum_c = bar.y";
     RelNode relNode = TestUtils.toRelNode("default", "foo_bar_view");
     CoralSpark coralSpark = CoralSpark.create(relNode);
     String expandedSql = coralSpark.getSparkSql();
@@ -124,7 +124,7 @@ public class CoralSparkTest {
     SparkUDFInfo.UDFTYPE targetUdfType = SparkUDFInfo.UDFTYPE.TRANSPORTABLE_UDF;
     assertEquals(testUdfType, targetUdfType);
     String sparkSqlStmt = coralSpark.getSparkSql();
-    String targetSqlStmt = "SELECT default_foo_dali_udf_LessThanHundred(a)\nFROM default.foo";
+    String targetSqlStmt = "SELECT default_foo_dali_udf_LessThanHundred(foo.a)\n" + "FROM default.foo foo";
     assertEquals(sparkSqlStmt, targetSqlStmt);
   }
 
@@ -152,7 +152,7 @@ public class CoralSparkTest {
     SparkUDFInfo.UDFTYPE targetUdfType = SparkUDFInfo.UDFTYPE.HIVE_CUSTOM_UDF;
     assertEquals(testUdfType, targetUdfType);
     String sparkSqlStmt = coralSpark.getSparkSql();
-    String targetSqlStmt = "SELECT default_foo_dali_udf2_GreaterThanHundred(a)\nFROM default.foo";
+    String targetSqlStmt = "SELECT default_foo_dali_udf2_GreaterThanHundred(foo.a)\n" + "FROM default.foo foo";
     assertEquals(sparkSqlStmt, targetSqlStmt);
   }
 
@@ -202,7 +202,7 @@ public class CoralSparkTest {
     RelNode relNode = TestUtils.toRelNode(
         String.join("\n", "", "SELECT a, t.ccol", "FROM complex", "LATERAL VIEW explode(complex.c) t as ccol"));
     String targetSql =
-        "SELECT complex.a, t0.ccol\n" + "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t0 AS ccol";
+        "SELECT complex.a, t0.ccol\n" + "FROM default.complex complex LATERAL VIEW EXPLODE(complex.c) t0 AS ccol";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -215,7 +215,7 @@ public class CoralSparkTest {
     String convertToSparkSql = CoralSpark.create(relNode).getSparkSql();
 
     String targetSql =
-        "SELECT complex.a, t0.ccol\n" + "FROM default.complex LATERAL VIEW OUTER EXPLODE(complex.c) t0 AS ccol";
+        "SELECT complex.a, t0.ccol\n" + "FROM default.complex complex LATERAL VIEW OUTER EXPLODE(complex.c) t0 AS ccol";
     assertEquals(convertToSparkSql, targetSql);
   }
 
@@ -224,7 +224,7 @@ public class CoralSparkTest {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT a, t.ccol, t2.ccol2", "FROM complex ",
         "LATERAL VIEW explode(complex.c) t AS ccol ", "LATERAL VIEW explode(complex.c) t2 AS ccol2 "));
     String targetSql = "SELECT complex.a, t0.ccol, t2.ccol2\n"
-        + "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t0 AS ccol LATERAL VIEW EXPLODE(complex.c) t2 AS ccol2";
+        + "FROM default.complex complex LATERAL VIEW EXPLODE(complex.c) t0 AS ccol LATERAL VIEW EXPLODE(complex.c) t2 AS ccol2";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -233,7 +233,7 @@ public class CoralSparkTest {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT a, t.ccol1, t.ccol2", "FROM complex",
         "LATERAL VIEW explode(complex.m) t as ccol1, ccol2"));
     String targetSql = "SELECT complex.a, t0.ccol1, t0.ccol2\n"
-        + "FROM default.complex LATERAL VIEW EXPLODE(complex.m) t0 AS ccol1, ccol2";
+        + "FROM default.complex complex LATERAL VIEW EXPLODE(complex.m) t0 AS ccol1, ccol2";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -242,7 +242,7 @@ public class CoralSparkTest {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT a, t.ccol1, t.ccol2", "FROM fuzzy_union.tableH",
         "LATERAL VIEW explode(tableH.b) t as ccol1, ccol2"));
     String targetSql = "SELECT tableh.a, t0.ccol1, t0.ccol2\n"
-        + "FROM fuzzy_union.tableh LATERAL VIEW EXPLODE(tableh.b) t0 AS ccol1, ccol2";
+        + "FROM fuzzy_union.tableh tableh LATERAL VIEW EXPLODE(tableh.b) t0 AS ccol1, ccol2";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -251,7 +251,7 @@ public class CoralSparkTest {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT a, t.ccol1, t.ccol2", "FROM complex",
         "LATERAL VIEW OUTER explode(complex.m) t as ccol1, ccol2"));
     String targetSql = "SELECT complex.a, t0.ccol1, t0.ccol2\n"
-        + "FROM default.complex LATERAL VIEW OUTER EXPLODE(complex.m) t0 AS ccol1, ccol2";
+        + "FROM default.complex complex LATERAL VIEW OUTER EXPLODE(complex.m) t0 AS ccol1, ccol2";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -259,7 +259,7 @@ public class CoralSparkTest {
   public void testLateralUDTF() {
     RelNode relNode = TestUtils.toRelNode("default", "foo_lateral_udtf");
     String targetSql = "SELECT complex.a, t.col1\n"
-        + "FROM default.complex LATERAL VIEW default_foo_lateral_udtf_CountOfRow(complex.a) t AS col1";
+        + "FROM default.complex complex LATERAL VIEW default_foo_lateral_udtf_CountOfRow(complex.a) t AS col1";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -268,8 +268,8 @@ public class CoralSparkTest {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "",
         "SELECT array(map('abc', 123, 'def', 567), map('pqr', 65, 'xyz', 89))[0]['abc']", "FROM bar"));
 
-    String targetSql = String.join("\n",
-        "SELECT ARRAY (MAP ('abc', 123, 'def', 567), MAP ('pqr', 65, 'xyz', 89))[0]['abc']", "FROM default.bar");
+    String targetSql =
+        "SELECT ARRAY (MAP ('abc', 123, 'def', 567), MAP ('pqr', 65, 'xyz', 89))[0]['abc']\n" + "FROM default.bar bar";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -277,7 +277,7 @@ public class CoralSparkTest {
   public void testArrayElementWithFunctionArgument() {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT c[size(c) - 1]", "FROM complex"));
 
-    String targetSql = String.join("\n", "SELECT c[size(c) - 1 + 1 - 1]", "FROM default.complex");
+    String targetSql = "SELECT complex.c[size(complex.c) - 1 + 1 - 1]\n" + "FROM default.complex complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -285,14 +285,14 @@ public class CoralSparkTest {
   public void testDataTypeNamedStruct() {
     RelNode relNode =
         TestUtils.toRelNode(String.join("\n", "", "SELECT named_struct('abc', 123, 'def', 'xyz').def", "FROM bar"));
-    String targetSql = String.join("\n", "SELECT named_struct('abc', 123, 'def', 'xyz').def", "FROM default.bar");
+    String targetSql = "SELECT named_struct('abc', 123, 'def', 'xyz').def\n" + "FROM default.bar bar";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testDataTypeString() {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT CAST(1 AS STRING)", "FROM bar"));
-    String targetSql = String.join("\n", "SELECT CAST(1 AS STRING)", "FROM default.bar");
+    String targetSql = "SELECT CAST(1 AS STRING)\n" + "FROM default.bar bar";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -307,8 +307,7 @@ public class CoralSparkTest {
     /*  the test query is translated to:
      *  SELECT named_struct('abc', 123, 'def', 'xyz') named_struc FROM default.bar;
      */
-    String targetSql =
-        String.join("\n", "SELECT named_struct('abc', 123, 'def', 'xyz') named_struc", "FROM default.bar");
+    String targetSql = "SELECT named_struct('abc', 123, 'def', 'xyz') named_struc\n" + "FROM default.bar bar";
     assertEquals(convertToSparkSql, targetSql);
   }
 
@@ -316,7 +315,8 @@ public class CoralSparkTest {
   public void testLateralViewStar() {
     RelNode relNode = TestUtils
         .toRelNode(String.join("\n", "", "SELECT a, t.*", "FROM complex", "LATERAL VIEW explode(complex.c) t"));
-    String targetSql = "SELECT complex.a, t0.col\n" + "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t0 AS col";
+    String targetSql =
+        "SELECT complex.a, t0.col\n" + "FROM default.complex complex LATERAL VIEW EXPLODE(complex.c) t0 AS col";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -325,21 +325,21 @@ public class CoralSparkTest {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT adid, count(1)", "FROM complex",
         "LATERAL VIEW explode(c) t as adid", "GROUP BY adid"));
     String targetSql = "SELECT t0.adid, COUNT(*)\n"
-        + "FROM default.complex LATERAL VIEW EXPLODE(complex.c) t0 AS adid\n" + "GROUP BY t0.adid";
+        + "FROM default.complex complex LATERAL VIEW EXPLODE(complex.c) t0 AS adid\n" + "GROUP BY t0.adid";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testTimestampConversion() {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT cast(b AS timestamp)", "FROM complex"));
-    String targetSql = String.join("\n", "SELECT CAST(b AS TIMESTAMP)", "FROM default.complex");
+    String targetSql = "SELECT CAST(complex.b AS TIMESTAMP)\n" + "FROM default.complex complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testSelectNullAs() {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT NULL AS alias", "FROM complex"));
-    String targetSql = String.join("\n", "SELECT NULL alias", "FROM default.complex");
+    String targetSql = "SELECT NULL alias\n" + "FROM default.complex complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -347,30 +347,28 @@ public class CoralSparkTest {
   public void testSelectSubstring() {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT substring(b,1,2)", "FROM complex"));
     // Default operator SqlSubstringFunction would generate SUBSTRING(b FROM 1 for 2)
-    String targetSql = String.join("\n", "SELECT substr(b, 1, 2)", "FROM default.complex");
+    String targetSql = "SELECT substr(complex.b, 1, 2)\n" + "FROM default.complex complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testCastAsBinary() {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT CAST(NULL AS BINARY)", "FROM complex"));
-    // without fix in CORAL-120 the default translation is CAST(NULL AS VARBINARY)
-    // which is not supported in Spark
-    String targetSql = String.join("\n", "SELECT CAST(NULL AS BINARY)", "FROM default.complex");
+    String targetSql = "SELECT CAST(NULL AS BINARY)\n" + "FROM default.complex complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testInterval() {
     RelNode relNode = TestUtils.toRelNode("SELECT CAST('2021-08-31' AS DATE) + INTERVAL '7' DAY FROM default.complex");
-    String targetSql = "SELECT (CAST('2021-08-31' AS DATE) + INTERVAL '7' DAY)\n" + "FROM default.complex";
+    String targetSql = "SELECT (CAST('2021-08-31' AS DATE) + INTERVAL '7' DAY)\n" + "FROM default.complex complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testIntervalNegative() {
     RelNode relNode = TestUtils.toRelNode("SELECT CAST('2021-08-31' AS DATE) + INTERVAL '-7' DAY FROM default.complex");
-    String targetSql = "SELECT (CAST('2021-08-31' AS DATE) + INTERVAL '-7' DAY)\n" + "FROM default.complex";
+    String targetSql = "SELECT (CAST('2021-08-31' AS DATE) + INTERVAL '-7' DAY)\n" + "FROM default.complex complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -379,7 +377,7 @@ public class CoralSparkTest {
     RelNode relNode = TestUtils
         .toRelNode("SELECT CAST('2021-08-31' AS DATE) + INTERVAL '7 01:02:03' DAY TO SECOND FROM default.complex");
     String targetSql =
-        "SELECT (CAST('2021-08-31' AS DATE) + INTERVAL '7 01:02:03' DAY TO SECOND)\n" + "FROM default.complex";
+        "SELECT (CAST('2021-08-31' AS DATE) + INTERVAL '7 01:02:03' DAY TO SECOND)\n" + "FROM default.complex complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -387,37 +385,39 @@ public class CoralSparkTest {
   public void testIntervalYearToMonth() {
     RelNode relNode =
         TestUtils.toRelNode("SELECT CAST('2021-08-31' AS DATE) + INTERVAL '1-6' YEAR TO MONTH FROM default.complex");
-    String targetSql = "SELECT (CAST('2021-08-31' AS DATE) + INTERVAL '1-6' YEAR TO MONTH)\n" + "FROM default.complex";
+    String targetSql =
+        "SELECT (CAST('2021-08-31' AS DATE) + INTERVAL '1-6' YEAR TO MONTH)\n" + "FROM default.complex complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testSchemaPromotionView() {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT * ", "FROM view_schema_promotion_wrapper"));
-    String targetSql = String.join("\n", "SELECT a, CAST(b AS ARRAY<INTEGER>) b", "FROM default.schema_promotion");
+    String targetSql = "SELECT schema_promotion.a, CAST(schema_promotion.b AS ARRAY<INTEGER>) b\n"
+        + "FROM default.schema_promotion schema_promotion";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testUnionExtractUDF() {
     RelNode relNode = TestUtils.toRelNode("SELECT extract_union(foo) from union_table");
-    String targetSql = String.join("\n", "SELECT coalesce_struct(foo)", "FROM default.union_table");
+    String targetSql = "SELECT coalesce_struct(union_table.foo)\n" + "FROM default.union_table union_table";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
 
     RelNode relNode1 = TestUtils.toRelNode("SELECT extract_union(foo, 2) from union_table");
-    String targetSql1 = String.join("\n", "SELECT coalesce_struct(foo, 3)", "FROM default.union_table");
+    String targetSql1 = "SELECT coalesce_struct(union_table.foo, 3)\n" + "FROM default.union_table union_table";
     assertEquals(CoralSpark.create(relNode1).getSparkSql(), targetSql1);
 
     // Nested union case
     RelNode relNode2 = TestUtils.toRelNode("SELECT extract_union(a) from nested_union");
-    String targetSql2 = String.join("\n", "SELECT coalesce_struct(a)", "FROM default.nested_union");
+    String targetSql2 = "SELECT coalesce_struct(nested_union.a)\n" + "FROM default.nested_union nested_union";
     assertEquals(CoralSpark.create(relNode2).getSparkSql(), targetSql2);
   }
 
   @Test
   public void testDateFunction() {
     RelNode relNode = TestUtils.toRelNode("SELECT date('2021-01-02') as a FROM foo");
-    String targetSql = "SELECT date('2021-01-02') a\n" + "FROM default.foo";
+    String targetSql = "SELECT date('2021-01-02') a\n" + "FROM default.foo foo";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -444,7 +444,7 @@ public class CoralSparkTest {
     RelNode relNode =
         TestUtils.toRelNode("SELECT arr.alias FROM foo tmp LATERAL VIEW EXPLODE(ARRAY('a', 'b')) arr as alias");
 
-    String targetSql = "SELECT t0.alias\n" + "FROM default.foo LATERAL VIEW EXPLODE(ARRAY ('a', 'b')) t0 AS alias";
+    String targetSql = "SELECT t0.alias\n" + "FROM default.foo foo LATERAL VIEW EXPLODE(ARRAY ('a', 'b')) t0 AS alias";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -491,39 +491,39 @@ public class CoralSparkTest {
   @Test
   public void testXpathFunctions() {
     RelNode relNode = TestUtils.toRelNode("select xpath('<a><b>b1</b><b>b2</b></a>','a/*') FROM foo");
-    String targetSql = "SELECT xpath('<a><b>b1</b><b>b2</b></a>', 'a/*')\n" + "FROM default.foo";
+    String targetSql = "SELECT xpath('<a><b>b1</b><b>b2</b></a>', 'a/*')\n" + "FROM default.foo foo";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
 
     relNode = TestUtils.toRelNode("SELECT xpath_string('<a><b>bb</b><c>cc</c></a>', 'a/b') FROM foo");
-    targetSql = "SELECT xpath_string('<a><b>bb</b><c>cc</c></a>', 'a/b')\n" + "FROM default.foo";
+    targetSql = "SELECT xpath_string('<a><b>bb</b><c>cc</c></a>', 'a/b')\n" + "FROM default.foo foo";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
 
     relNode = TestUtils.toRelNode("SELECT xpath_boolean('<a><b>b</b></a>', 'a/b') FROM foo");
-    targetSql = "SELECT xpath_boolean('<a><b>b</b></a>', 'a/b')\n" + "FROM default.foo";
+    targetSql = "SELECT xpath_boolean('<a><b>b</b></a>', 'a/b')\n" + "FROM default.foo foo";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
 
     relNode = TestUtils.toRelNode("SELECT xpath_int('<a>b</a>', 'a = 10') FROM foo");
-    targetSql = "SELECT xpath_int('<a>b</a>', 'a = 10')\n" + "FROM default.foo";
+    targetSql = "SELECT xpath_int('<a>b</a>', 'a = 10')\n" + "FROM default.foo foo";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
 
     relNode = TestUtils.toRelNode("SELECT xpath_short('<a>b</a>', 'a = 10') FROM foo");
-    targetSql = "SELECT xpath_short('<a>b</a>', 'a = 10')\n" + "FROM default.foo";
+    targetSql = "SELECT xpath_short('<a>b</a>', 'a = 10')\n" + "FROM default.foo foo";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
 
     relNode = TestUtils.toRelNode("SELECT xpath_long('<a>b</a>', 'a = 10') FROM foo");
-    targetSql = "SELECT xpath_long('<a>b</a>', 'a = 10')\n" + "FROM default.foo";
+    targetSql = "SELECT xpath_long('<a>b</a>', 'a = 10')\n" + "FROM default.foo foo";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
 
     relNode = TestUtils.toRelNode("SELECT xpath_float('<a>b</a>', 'a = 10') FROM foo");
-    targetSql = "SELECT xpath_float('<a>b</a>', 'a = 10')\n" + "FROM default.foo";
+    targetSql = "SELECT xpath_float('<a>b</a>', 'a = 10')\n" + "FROM default.foo foo";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
 
     relNode = TestUtils.toRelNode("SELECT xpath_double('<a>b</a>', 'a = 10') FROM foo");
-    targetSql = "SELECT xpath_double('<a>b</a>', 'a = 10')\n" + "FROM default.foo";
+    targetSql = "SELECT xpath_double('<a>b</a>', 'a = 10')\n" + "FROM default.foo foo";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
 
     relNode = TestUtils.toRelNode("SELECT xpath_number('<a>b</a>', 'a = 10') FROM foo");
-    targetSql = "SELECT xpath_number('<a>b</a>', 'a = 10')\n" + "FROM default.foo";
+    targetSql = "SELECT xpath_number('<a>b</a>', 'a = 10')\n" + "FROM default.foo foo";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -533,7 +533,7 @@ public class CoralSparkTest {
         TestUtils.toRelNode("SELECT arr.alias FROM foo tmp LATERAL VIEW POSEXPLODE(ARRAY('a', 'b')) arr AS pos, alias");
 
     String targetSql =
-        "SELECT t0.alias\n" + "FROM default.foo LATERAL VIEW POSEXPLODE(ARRAY ('a', 'b')) t0 AS pos, alias";
+        "SELECT t0.alias\n" + "FROM default.foo foo LATERAL VIEW POSEXPLODE(ARRAY ('a', 'b')) t0 AS pos, alias";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -543,7 +543,7 @@ public class CoralSparkTest {
         .toRelNode("SELECT arr.alias FROM foo tmp LATERAL VIEW OUTER POSEXPLODE(ARRAY('a', 'b')) arr AS pos, alias");
 
     String targetSql =
-        "SELECT t0.alias\n" + "FROM default.foo LATERAL VIEW OUTER POSEXPLODE(ARRAY ('a', 'b')) t0 AS pos, alias";
+        "SELECT t0.alias\n" + "FROM default.foo foo LATERAL VIEW OUTER POSEXPLODE(ARRAY ('a', 'b')) t0 AS pos, alias";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -552,7 +552,7 @@ public class CoralSparkTest {
     RelNode relNode = TestUtils.toRelNode("SELECT arr.col FROM foo tmp LATERAL VIEW POSEXPLODE(ARRAY('a', 'b')) arr");
 
     String targetSql =
-        "SELECT t0.col\n" + "FROM default.foo LATERAL VIEW POSEXPLODE(ARRAY ('a', 'b')) t0 AS ORDINALITY, col";
+        "SELECT t0.col\n" + "FROM default.foo foo LATERAL VIEW POSEXPLODE(ARRAY ('a', 'b')) t0 AS ORDINALITY, col";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -587,32 +587,32 @@ public class CoralSparkTest {
   @Test
   public void testMd5Function() {
     RelNode relNode = TestUtils.toRelNode("SELECT md5('ABC') as a FROM foo");
-    String targetSql = "SELECT md5('ABC') a\n" + "FROM default.foo";
+    String targetSql = "SELECT md5('ABC') a\n" + "FROM default.foo foo";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testShaFunction() {
     RelNode relNode = TestUtils.toRelNode("SELECT sha1('ABC') as a FROM foo");
-    String targetSql = "SELECT sha1('ABC') a\n" + "FROM default.foo";
+    String targetSql = "SELECT sha1('ABC') a\n" + "FROM default.foo foo";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
 
     RelNode relNode2 = TestUtils.toRelNode("SELECT sha('ABC') as a FROM foo");
-    String targetSql2 = "SELECT sha('ABC') a\n" + "FROM default.foo";
+    String targetSql2 = "SELECT sha('ABC') a\n" + "FROM default.foo foo";
     assertEquals(CoralSpark.create(relNode2).getSparkSql(), targetSql2);
   }
 
   @Test
   public void testCrc32Function() {
     RelNode relNode = TestUtils.toRelNode("SELECT crc32('ABC') as a FROM foo");
-    String targetSql = "SELECT crc32('ABC') a\n" + "FROM default.foo";
+    String targetSql = "SELECT crc32('ABC') a\n" + "FROM default.foo foo";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testTranslateFunction() {
     RelNode relNode = TestUtils.toRelNode("SELECT translate('aaa', 'a', 'b') FROM default.foo");
-    String targetSql = "SELECT TRANSLATE('aaa', 'a', 'b')\n" + "FROM default.foo";
+    String targetSql = "SELECT TRANSLATE('aaa', 'a', 'b')\n" + "FROM default.foo foo";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -622,14 +622,14 @@ public class CoralSparkTest {
         "SELECT CAST(1 AS DOUBLE), CAST(1.5 AS INT), CAST(2.3 AS STRING), CAST(1631142817 AS TIMESTAMP), CAST('' AS BOOLEAN) FROM default.complex");
     String targetSql =
         "SELECT CAST(1 AS DOUBLE), CAST(1.5 AS INTEGER), CAST(2.3 AS STRING), CAST(1631142817 AS TIMESTAMP), CAST('' AS BOOLEAN)\n"
-            + "FROM default.complex";
+            + "FROM default.complex complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testReflectFunction() {
     RelNode relNode = TestUtils.toRelNode("SELECT reflect('java.lang.String', 'valueOf', 1) FROM default.complex");
-    String targetSql = "SELECT reflect('java.lang.String', 'valueOf', 1)\n" + "FROM default.complex";
+    String targetSql = "SELECT reflect('java.lang.String', 'valueOf', 1)\n" + "FROM default.complex complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -637,18 +637,18 @@ public class CoralSparkTest {
   public void testReflectFunctionReturnType() {
     RelNode relNode = TestUtils.toRelNode("SELECT reflect('java.lang.String', 'valueOf', 1) + 1 FROM default.complex");
     String targetSql =
-        "SELECT CAST(reflect('java.lang.String', 'valueOf', 1) AS INTEGER) + 1\n" + "FROM default.complex";
+        "SELECT CAST(reflect('java.lang.String', 'valueOf', 1) AS INTEGER) + 1\n" + "FROM default.complex complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
 
     relNode = TestUtils.toRelNode("SELECT reflect('java.lang.String', 'valueOf', 1) || 'a' FROM default.complex");
-    targetSql = "SELECT concat(reflect('java.lang.String', 'valueOf', 1), 'a')\n" + "FROM default.complex";
+    targetSql = "SELECT concat(reflect('java.lang.String', 'valueOf', 1), 'a')\n" + "FROM default.complex complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testJavaMethodFunction() {
     RelNode relNode = TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) FROM default.complex");
-    String targetSql = "SELECT reflect('java.lang.String', 'valueOf', 1)\n" + "FROM default.complex";
+    String targetSql = "SELECT reflect('java.lang.String', 'valueOf', 1)\n" + "FROM default.complex complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -657,18 +657,18 @@ public class CoralSparkTest {
     RelNode relNode =
         TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) + 1 FROM default.complex");
     String targetSql =
-        "SELECT CAST(reflect('java.lang.String', 'valueOf', 1) AS INTEGER) + 1\n" + "FROM default.complex";
+        "SELECT CAST(reflect('java.lang.String', 'valueOf', 1) AS INTEGER) + 1\n" + "FROM default.complex complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
 
     relNode = TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) || 'a' FROM default.complex");
-    targetSql = "SELECT concat(reflect('java.lang.String', 'valueOf', 1), 'a')\n" + "FROM default.complex";
+    targetSql = "SELECT concat(reflect('java.lang.String', 'valueOf', 1), 'a')\n" + "FROM default.complex complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testNegationOperator() {
     RelNode relNode = TestUtils.toRelNode("SELECT !FALSE as a FROM foo");
-    String targetSql = "SELECT NOT FALSE a\n" + "FROM default.foo";
+    String targetSql = "SELECT NOT FALSE a\n" + "FROM default.foo foo";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -676,8 +676,8 @@ public class CoralSparkTest {
   public void testAliasOrderBy() {
     RelNode relNode =
         TestUtils.toRelNode("SELECT a, SUBSTR(b, 1, 1) AS aliased_column, c FROM foo ORDER BY aliased_column DESC");
-    String targetSql = "SELECT a, substr(b, 1, 1) aliased_column, c\n" + "FROM default.foo\n"
-        + "ORDER BY substr(b, 1, 1) DESC NULLS LAST";
+    String targetSql = "SELECT foo.a, substr(foo.b, 1, 1) aliased_column, foo.c\n" + "FROM default.foo foo\n"
+        + "ORDER BY substr(foo.b, 1, 1) DESC NULLS LAST";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -685,43 +685,43 @@ public class CoralSparkTest {
   public void testAliasHaving() {
     RelNode relNode = TestUtils.toRelNode(
         "SELECT a, SUBSTR(b, 1, 1) AS aliased_column FROM foo GROUP BY a, b HAVING aliased_column in ('dummy_value')");
-    String targetSql = "SELECT a, substr(b, 1, 1) aliased_column\n" + "FROM default.foo\n" + "GROUP BY a, b\n"
-        + "HAVING substr(b, 1, 1)\n" + "IN ('dummy_value')";
+    String targetSql = "SELECT foo.a, substr(foo.b, 1, 1) aliased_column\n" + "FROM default.foo foo\n"
+        + "GROUP BY foo.a, foo.b\n" + "HAVING substr(foo.b, 1, 1)\n" + "IN ('dummy_value')";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testCastDecimal() {
     RelNode relNode = TestUtils.toRelNode("SELECT CAST(a as DECIMAL(6, 2)) as casted_decimal FROM default.foo");
-    String targetSql = "SELECT CAST(a AS DECIMAL(6, 2)) casted_decimal\n" + "FROM default.foo";
+    String targetSql = "SELECT CAST(foo.a AS DECIMAL(6, 2)) casted_decimal\n" + "FROM default.foo foo";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testCastDecimalDefault() {
     RelNode relNode = TestUtils.toRelNode("SELECT CAST(a as DECIMAL) as casted_decimal FROM default.foo");
-    String targetSql = "SELECT CAST(a AS DECIMAL(10, 0)) casted_decimal\n" + "FROM default.foo";
+    String targetSql = "SELECT CAST(foo.a AS DECIMAL(10, 0)) casted_decimal\n" + "FROM default.foo foo";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testCollectListFunction() {
     RelNode relNode = TestUtils.toRelNode("SELECT collect_list(a) FROM default.foo");
-    String targetSql = "SELECT collect_list(a)\n" + "FROM default.foo";
+    String targetSql = "SELECT collect_list(foo.a)\n" + "FROM default.foo foo";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testCollectSetFunction() {
     RelNode relNode = TestUtils.toRelNode("SELECT collect_set(a) FROM default.foo");
-    String targetSql = "SELECT collect_set(a)\n" + "FROM default.foo";
+    String targetSql = "SELECT collect_set(foo.a)\n" + "FROM default.foo foo";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
   @Test
   public void testSelectArrayIndex() {
     RelNode relNode = TestUtils.toRelNode("SELECT * FROM default.view_expand_array_index");
-    String targetSql = "SELECT c[1] c1\n" + "FROM default.complex";
+    String targetSql = "SELECT complex.c[1] c1\n" + "FROM default.complex complex";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 
@@ -735,10 +735,10 @@ public class CoralSparkTest {
 
   @Test
   public void testNameSakeColumnNamesShouldGetUniqueIdentifiers() {
-    String targetSql = String.join("\n", "SELECT some_id", "FROM (SELECT tablea.some_id, t.SOME_ID SOME_ID0",
-        "FROM duplicate_column_name.tablea",
-        "LEFT JOIN (SELECT TRIM(some_id) SOME_ID, CAST(TRIM(some_id) AS STRING) $f1",
-        "FROM duplicate_column_name.tableb) t ON tablea.some_id = t.$f1) t0", "WHERE t0.some_id <> ''");
+    String targetSql = "SELECT t0.some_id\n" + "FROM (SELECT tablea.some_id, t.SOME_ID SOME_ID0\n"
+        + "FROM duplicate_column_name.tablea tablea\n"
+        + "LEFT JOIN (SELECT TRIM(tableb.some_id) SOME_ID, CAST(TRIM(tableb.some_id) AS STRING) $f1\n"
+        + "FROM duplicate_column_name.tableb tableb) t ON tablea.some_id = t.$f1) t0\n" + "WHERE t0.some_id <> ''";
     RelNode relNode = TestUtils.toRelNode("duplicate_column_name", "view_namesake_column_names");
     CoralSpark coralSpark = CoralSpark.create(relNode);
     String expandedSql = coralSpark.getSparkSql();
@@ -750,7 +750,7 @@ public class CoralSparkTest {
     String sourceSql = "SELECT complex.s.name as name FROM default.complex";
     String expandedSql = getCoralSparkTranslatedSqlWithAliasFromCoralSchema(sourceSql);
 
-    String targetSql = "SELECT s.name name\n" + "FROM default.complex";
+    String targetSql = "SELECT complex.s.name name\n" + "FROM default.complex complex";
     assertEquals(expandedSql, targetSql);
   }
 
@@ -759,7 +759,7 @@ public class CoralSparkTest {
     String sourceSql = "SELECT LOWER(complex.s.name) FROM default.complex";
     String expandedSql = getCoralSparkTranslatedSqlWithAliasFromCoralSchema(sourceSql);
 
-    String targetSql = "SELECT LOWER(s.name) EXPR_0\n" + "FROM default.complex";
+    String targetSql = "SELECT LOWER(complex.s.name) EXPR_0\n" + "FROM default.complex complex";
     assertEquals(expandedSql, targetSql);
   }
 
@@ -768,7 +768,7 @@ public class CoralSparkTest {
     String sourceSql = "SELECT CAST(complex.a AS STRING) FROM default.complex";
     String expandedSql = getCoralSparkTranslatedSqlWithAliasFromCoralSchema(sourceSql);
 
-    String targetSql = "SELECT CAST(a AS STRING) EXPR_0\n" + "FROM default.complex";
+    String targetSql = "SELECT CAST(complex.a AS STRING) EXPR_0\n" + "FROM default.complex complex";
     assertEquals(expandedSql, targetSql);
   }
 
@@ -777,7 +777,7 @@ public class CoralSparkTest {
     String sourceSql = "SELECT basecomplex.id FROM default.basecomplex";
     String expandedSql = getCoralSparkTranslatedSqlWithAliasFromCoralSchema(sourceSql);
 
-    String targetSql = "SELECT id Id\n" + "FROM default.basecomplex";
+    String targetSql = "SELECT basecomplex.id Id\n" + "FROM default.basecomplex basecomplex";
     assertEquals(expandedSql, targetSql);
   }
 
@@ -786,7 +786,8 @@ public class CoralSparkTest {
     String sourceSql = "SELECT basecomplex.Struct_Col.String_Field FROM default.basecomplex";
     String expandedSql = getCoralSparkTranslatedSqlWithAliasFromCoralSchema(sourceSql);
 
-    String targetSql = "SELECT struct_col.string_field String_Field\n" + "FROM default.basecomplex";
+    String targetSql =
+        "SELECT basecomplex.struct_col.string_field String_Field\n" + "FROM default.basecomplex basecomplex";
     assertEquals(expandedSql, targetSql);
   }
 
@@ -795,7 +796,7 @@ public class CoralSparkTest {
     String sourceSql = "SELECT basecomplex.map_col['foo'] FROM default.basecomplex";
     String expandedSql = getCoralSparkTranslatedSqlWithAliasFromCoralSchema(sourceSql);
 
-    String targetSql = "SELECT map_col['foo'] EXPR_0\n" + "FROM default.basecomplex";
+    String targetSql = "SELECT basecomplex.map_col['foo'] EXPR_0\n" + "FROM default.basecomplex basecomplex";
     assertEquals(expandedSql, targetSql);
   }
 
@@ -804,7 +805,7 @@ public class CoralSparkTest {
     String sourceSql = "SELECT basecomplex.map_col['foo'] as foo FROM default.basecomplex";
     String expandedSql = getCoralSparkTranslatedSqlWithAliasFromCoralSchema(sourceSql);
 
-    String targetSql = "SELECT map_col['foo'] foo\n" + "FROM default.basecomplex";
+    String targetSql = "SELECT basecomplex.map_col['foo'] foo\n" + "FROM default.basecomplex basecomplex";
     assertEquals(expandedSql, targetSql);
   }
 
@@ -814,8 +815,8 @@ public class CoralSparkTest {
         "with tmp as (SELECT b bcol, SUM(c) sum_c from default.foo group by b) select tmp.bcol, bar.x from tmp inner join default.bar on tmp.sum_c = bar.y";
     String expandedSql = getCoralSparkTranslatedSqlWithAliasFromCoralSchema(sourceSql);
 
-    String targetSql = "SELECT t1.bcol bcol, bar.x x\n" + "FROM (SELECT b bcol, SUM(c) sum_c\n" + "FROM default.foo\n"
-        + "GROUP BY b) t1\n" + "INNER JOIN default.bar ON t1.sum_c = bar.y";
+    String targetSql = "SELECT t1.bcol bcol, bar.x x\n" + "FROM (SELECT foo.b bcol, SUM(foo.c) sum_c\n"
+        + "FROM default.foo foo\n" + "GROUP BY foo.b) t1\n" + "INNER JOIN default.bar bar ON t1.sum_c = bar.y";
     assertEquals(expandedSql, targetSql);
   }
 
@@ -824,7 +825,7 @@ public class CoralSparkTest {
     String sourceSql = "SELECT * FROM default.basecomplex";
     String expandedSql = getCoralSparkTranslatedSqlWithAliasFromCoralSchema(sourceSql);
 
-    String targetSql = "SELECT *\n" + "FROM default.basecomplex";
+    String targetSql = "SELECT *\n" + "FROM default.basecomplex basecomplex";
     assertEquals(expandedSql, targetSql);
   }
 
@@ -833,7 +834,8 @@ public class CoralSparkTest {
     final String sourceSql = "SELECT CASE WHEN TRUE THEN NULL ELSE split(b, ' ') END AS col1 FROM complex";
     String expandedSql = getCoralSparkTranslatedSqlWithAliasFromCoralSchema(sourceSql);
 
-    String targetSql = "SELECT CASE WHEN TRUE THEN NULL ELSE split(b, ' ') END col1\n" + "FROM default.complex";
+    String targetSql =
+        "SELECT CASE WHEN TRUE THEN NULL ELSE split(complex.b, ' ') END col1\n" + "FROM default.complex complex";
     assertEquals(expandedSql, targetSql);
   }
 

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/FuzzyUnionViewTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/FuzzyUnionViewTest.java
@@ -43,8 +43,8 @@ public class FuzzyUnionViewTest {
     CoralSpark coralSpark = CoralSpark.create(relNode);
     String expandedSql = coralSpark.getSparkSql();
 
-    String expectedSql =
-        "" + "SELECT *\n" + "FROM fuzzy_union.tablea\n" + "UNION ALL\n" + "SELECT *\n" + "FROM fuzzy_union.tablea";
+    String expectedSql = "SELECT *\n" + "FROM fuzzy_union.tablea tablea\n" + "UNION ALL\n" + "SELECT *\n"
+        + "FROM fuzzy_union.tablea tablea0";
 
     assertEquals(expandedSql, expectedSql);
   }
@@ -57,8 +57,9 @@ public class FuzzyUnionViewTest {
     CoralSpark coralSpark = CoralSpark.create(relNode);
     String expandedSql = coralSpark.getSparkSql();
 
-    String expectedSql = "" + "SELECT *\n" + "FROM (SELECT *\n" + "FROM fuzzy_union.tablea\n" + "UNION ALL\n"
-        + "SELECT *\n" + "FROM fuzzy_union.tablea)\n" + "UNION ALL\n" + "SELECT *\n" + "FROM fuzzy_union.tablea";
+    String expectedSql =
+        "SELECT *\n" + "FROM (SELECT *\n" + "FROM fuzzy_union.tablea tablea\n" + "UNION ALL\n" + "SELECT *\n"
+            + "FROM fuzzy_union.tablea tablea0) t\n" + "UNION ALL\n" + "SELECT *\n" + "FROM fuzzy_union.tablea tablea1";
 
     assertEquals(expandedSql, expectedSql);
   }
@@ -71,8 +72,8 @@ public class FuzzyUnionViewTest {
     CoralSpark coralSpark = CoralSpark.create(relNode);
     String expandedSql = coralSpark.getSparkSql();
 
-    String expectedSql =
-        "" + "SELECT *\n" + "FROM fuzzy_union.tablea\n" + "UNION ALL\n" + "SELECT *\n" + "FROM fuzzy_union.tablea";
+    String expectedSql = "SELECT *\n" + "FROM fuzzy_union.tablea tablea\n" + "UNION ALL\n" + "SELECT *\n"
+        + "FROM fuzzy_union.tablea tablea0";
 
     assertEquals(expandedSql, expectedSql);
   }
@@ -85,8 +86,8 @@ public class FuzzyUnionViewTest {
     CoralSpark coralSpark = CoralSpark.create(relNode);
     String expandedSql = coralSpark.getSparkSql();
 
-    String expectedSql = "SELECT *\n" + "FROM fuzzy_union.tableb\n" + "UNION ALL\n"
-        + "SELECT a, generic_project(b, 'struct<b1:string>') b\n" + "FROM fuzzy_union.tablec";
+    String expectedSql = "SELECT *\n" + "FROM fuzzy_union.tableb tableb\n" + "UNION ALL\n"
+        + "SELECT tablec.a, generic_project(tablec.b, 'struct<b1:string>') b\n" + "FROM fuzzy_union.tablec tablec";
 
     assertEquals(expandedSql, expectedSql);
   }
@@ -105,8 +106,8 @@ public class FuzzyUnionViewTest {
     // This query currently does not have any generic_projections despite the top level view schema being inconsistent
     // because the schemas of the branches evolved the same way.
     // This unit test illustrates this behaviour; however, we can re-evaluate our desired behaviour later on.
-    String expectedSql =
-        "SELECT *\n" + "FROM fuzzy_union.tabled\n" + "UNION ALL\n" + "SELECT *\n" + "FROM fuzzy_union.tablee";
+    String expectedSql = "SELECT *\n" + "FROM fuzzy_union.tabled tabled\n" + "UNION ALL\n" + "SELECT *\n"
+        + "FROM fuzzy_union.tablee tablee";
 
     assertEquals(expandedSql, expectedSql);
   }
@@ -119,8 +120,9 @@ public class FuzzyUnionViewTest {
     CoralSpark coralSpark = CoralSpark.create(relNode);
     String expandedSql = coralSpark.getSparkSql();
 
-    String expectedSql = "SELECT a, generic_project(b, 'struct<b1:string>') b\n" + "FROM fuzzy_union.tablef\n"
-        + "UNION ALL\n" + "SELECT a, generic_project(b, 'struct<b1:string>') b\n" + "FROM fuzzy_union.tableg";
+    String expectedSql = "SELECT tablef.a, generic_project(tablef.b, 'struct<b1:string>') b\n"
+        + "FROM fuzzy_union.tablef tablef\n" + "UNION ALL\n"
+        + "SELECT tableg.a, generic_project(tableg.b, 'struct<b1:string>') b\n" + "FROM fuzzy_union.tableg tableg";
 
     assertEquals(expandedSql, expectedSql);
   }
@@ -133,10 +135,11 @@ public class FuzzyUnionViewTest {
     CoralSpark coralSpark = CoralSpark.create(relNode);
     String expandedSql = coralSpark.getSparkSql();
 
-    String expectedSql =
-        "SELECT *\n" + "FROM (SELECT a, generic_project(b, 'struct<b1:string>') b\n" + "FROM fuzzy_union.tablef\n"
-            + "UNION ALL\n" + "SELECT a, generic_project(b, 'struct<b1:string>') b\n" + "FROM fuzzy_union.tableg)\n"
-            + "UNION ALL\n" + "SELECT a, generic_project(b, 'struct<b1:string>') b\n" + "FROM fuzzy_union.tablef";
+    String expectedSql = "SELECT *\n" + "FROM (SELECT tablef.a, generic_project(tablef.b, 'struct<b1:string>') b\n"
+        + "FROM fuzzy_union.tablef tablef\n" + "UNION ALL\n"
+        + "SELECT tableg.a, generic_project(tableg.b, 'struct<b1:string>') b\n" + "FROM fuzzy_union.tableg tableg) t1\n"
+        + "UNION ALL\n" + "SELECT tablef0.a, generic_project(tablef0.b, 'struct<b1:string>') b\n"
+        + "FROM fuzzy_union.tablef tablef0";
 
     assertEquals(expandedSql, expectedSql);
   }
@@ -149,8 +152,8 @@ public class FuzzyUnionViewTest {
     CoralSpark coralSpark = CoralSpark.create(relNode);
     String expandedSql = coralSpark.getSparkSql();
 
-    String expectedSql = "SELECT a, generic_project(b, 'map<string,struct<b1:string>>') b\n"
-        + "FROM fuzzy_union.tableh\n" + "UNION ALL\n" + "SELECT *\n" + "FROM fuzzy_union.tablei";
+    String expectedSql = "SELECT tableh.a, generic_project(tableh.b, 'map<string,struct<b1:string>>') b\n"
+        + "FROM fuzzy_union.tableh tableh\n" + "UNION ALL\n" + "SELECT *\n" + "FROM fuzzy_union.tablei tablei";
 
     assertEquals(expandedSql, expectedSql);
   }
@@ -163,8 +166,8 @@ public class FuzzyUnionViewTest {
     CoralSpark coralSpark = CoralSpark.create(relNode);
     String expandedSql = coralSpark.getSparkSql();
 
-    String expectedSql = "SELECT a, generic_project(b, 'array<struct<b1:string>>') b\n" + "FROM fuzzy_union.tablej\n"
-        + "UNION ALL\n" + "SELECT *\n" + "FROM fuzzy_union.tablek";
+    String expectedSql = "SELECT tablej.a, generic_project(tablej.b, 'array<struct<b1:string>>') b\n"
+        + "FROM fuzzy_union.tablej tablej\n" + "UNION ALL\n" + "SELECT *\n" + "FROM fuzzy_union.tablek tablek";
 
     assertEquals(expandedSql, expectedSql);
   }
@@ -178,8 +181,8 @@ public class FuzzyUnionViewTest {
     String expandedSql = coralSpark.getSparkSql();
 
     String expectedSql =
-        "SELECT a, generic_project(b, 'struct<b1:string,b2:struct<b3:string,b4:struct<b5:string>>>') b\n"
-            + "FROM fuzzy_union.tablel\n" + "UNION ALL\n" + "SELECT *\n" + "FROM fuzzy_union.tablem";
+        "SELECT tablel.a, generic_project(tablel.b, 'struct<b1:string,b2:struct<b3:string,b4:struct<b5:string>>>') b\n"
+            + "FROM fuzzy_union.tablel tablel\n" + "UNION ALL\n" + "SELECT *\n" + "FROM fuzzy_union.tablem tablem";
 
     assertEquals(expandedSql, expectedSql);
   }
@@ -192,8 +195,9 @@ public class FuzzyUnionViewTest {
     CoralSpark coralSpark = CoralSpark.create(relNode);
     String expandedSql = coralSpark.getSparkSql();
 
-    String expectedSql = "SELECT *\n" + "FROM fuzzy_union.tablen\n" + "UNION ALL\n"
-        + "SELECT a, generic_project(b, 'struct<b2:double,b1:string,b0:int>') b\n" + "FROM fuzzy_union.tableo";
+    String expectedSql = "SELECT *\n" + "FROM fuzzy_union.tablen tablen\n" + "UNION ALL\n"
+        + "SELECT tableo.a, generic_project(tableo.b, 'struct<b2:double,b1:string,b0:int>') b\n"
+        + "FROM fuzzy_union.tableo tableo";
 
     assertEquals(expandedSql, expectedSql);
   }

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoSqlDialect.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoSqlDialect.java
@@ -30,6 +30,15 @@ public class TrinoSqlDialect extends SqlDialect {
     return false;
   }
 
+  /**
+   * Override this method so that there will be explicit and correct table alias for selected fields, which is necessary for
+   * data type derivation on SqlNodes
+   */
+  @Override
+  public boolean hasImplicitTableAlias() {
+    return false;
+  }
+
   public void unparseOffsetFetch(SqlWriter writer, SqlNode offset, SqlNode fetch) {
     unparseFetchUsingLimit(writer, offset, fetch);
   }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -53,52 +53,62 @@ public class HiveToTrinoConverterTest {
     return new Object[][] {
 
         { "test", "t_dot_star_view", "SELECT \"tablea\".\"a\" AS \"a\", \"tablea\".\"b\" AS \"b\", \"tablea0\".\"b\" AS \"tbb\"\n"
-            + "FROM \"test\".\"tablea\"\n"
+            + "FROM \"test\".\"tablea\" AS \"tablea\"\n"
             + "INNER JOIN \"test\".\"tablea\" AS \"tablea0\" ON \"tablea\".\"a\" = \"tablea0\".\"a\"" },
 
-        { "test", "fuzzy_union_view", "SELECT *\nFROM \"test\".\"tablea\"\nUNION ALL\n"
-            + "SELECT *\nFROM \"test\".\"tablea\"" },
+        { "test", "fuzzy_union_view", "SELECT *\n" + "FROM \"test\".\"tablea\" AS \"tablea\"\n" + "UNION ALL\n"
+            + "SELECT *\n" + "FROM \"test\".\"tablea\" AS \"tablea0\"" },
 
-        { "test", "fuzzy_union_view_with_more_than_two_tables", "SELECT *\nFROM ("
-            + "SELECT *\nFROM \"test\".\"tablea\"\nUNION ALL\n" + "SELECT *\nFROM \"test\".\"tablea\")\nUNION ALL\n"
-            + "SELECT *\nFROM \"test\".\"tablea\"" },
+        { "test", "fuzzy_union_view_with_more_than_two_tables", "SELECT *\n" + "FROM (SELECT *\n"
+            + "FROM \"test\".\"tablea\" AS \"tablea\"\n" + "UNION ALL\n" + "SELECT *\n"
+            + "FROM \"test\".\"tablea\" AS \"tablea0\") AS \"t\"\n" + "UNION ALL\n" + "SELECT *\n"
+            + "FROM \"test\".\"tablea\" AS \"tablea1\"" },
 
-        { "test", "fuzzy_union_view_with_alias", "SELECT *\n" + "FROM \"test\".\"tablea\"\nUNION ALL\n"
-            + "SELECT *\nFROM \"test\".\"tablea\"" },
+        { "test", "fuzzy_union_view_with_alias", "SELECT *\n" + "FROM \"test\".\"tablea\" AS \"tablea\"\n"
+            + "UNION ALL\n" + "SELECT *\n" + "FROM \"test\".\"tablea\" AS \"tablea0\"" },
 
-        { "test", "fuzzy_union_view_single_branch_evolved", "SELECT *\n" + "FROM \"test\".\"tableb\"\n" + "UNION ALL\n"
-            + "SELECT \"a\", CAST(row(\"b\".\"b1\") as row(\"b1\" varchar)) AS \"b\"\n" + "FROM \"test\".\"tablec\"" },
+        { "test", "fuzzy_union_view_single_branch_evolved", "SELECT *\n" + "FROM \"test\".\"tableb\" AS \"tableb\"\n"
+            + "UNION ALL\n"
+            + "SELECT \"tablec\".\"a\" AS \"a\", CAST(row(\"b\".\"b1\") as row(\"b1\" varchar)) AS \"b\"\n"
+            + "FROM \"test\".\"tablec\" AS \"tablec\"" },
 
-        { "test", "fuzzy_union_view_double_branch_evolved_same", "SELECT *\n" + "FROM \"test\".\"tabled\"\n"
-            + "UNION ALL\n" + "SELECT *\n" + "FROM \"test\".\"tablee\"" },
+        { "test", "fuzzy_union_view_double_branch_evolved_same", "SELECT *\n"
+            + "FROM \"test\".\"tabled\" AS \"tabled\"\n" + "UNION ALL\n" + "SELECT *\n"
+            + "FROM \"test\".\"tablee\" AS \"tablee\"" },
 
-        { "test", "fuzzy_union_view_double_branch_evolved_different", "SELECT \"a\", CAST(row(\"b\".\"b1\") as row(\"b1\" varchar)) AS \"b\"\n"
-            + "FROM \"test\".\"tablef\"\n" + "UNION ALL\n"
-            + "SELECT \"a\", CAST(row(\"b\".\"b1\") as row(\"b1\" varchar)) AS \"b\"\n" + "FROM \"test\".\"tableg\"" },
+        { "test", "fuzzy_union_view_double_branch_evolved_different", "SELECT \"tablef\".\"a\" AS \"a\", CAST(row(\"b\".\"b1\") as row(\"b1\" varchar)) AS \"b\"\n"
+            + "FROM \"test\".\"tablef\" AS \"tablef\"\n" + "UNION ALL\n"
+            + "SELECT \"tableg\".\"a\" AS \"a\", CAST(row(\"b\".\"b1\") as row(\"b1\" varchar)) AS \"b\"\n"
+            + "FROM \"test\".\"tableg\" AS \"tableg\"" },
 
         { "test", "fuzzy_union_view_more_than_two_branches_evolved", "SELECT *\n"
-            + "FROM (SELECT \"a\", CAST(row(\"b\".\"b1\") as row(\"b1\" varchar)) AS \"b\"\n"
-            + "FROM \"test\".\"tablef\"\n" + "UNION ALL\n"
-            + "SELECT \"a\", CAST(row(\"b\".\"b1\") as row(\"b1\" varchar)) AS \"b\"\n" + "FROM \"test\".\"tableg\")\n"
-            + "UNION ALL\n" + "SELECT \"a\", CAST(row(\"b\".\"b1\") as row(\"b1\" varchar)) AS \"b\"\n"
-            + "FROM \"test\".\"tablef\"" },
+            + "FROM (SELECT \"tablef\".\"a\" AS \"a\", CAST(row(\"b\".\"b1\") as row(\"b1\" varchar)) AS \"b\"\n"
+            + "FROM \"test\".\"tablef\" AS \"tablef\"\n" + "UNION ALL\n"
+            + "SELECT \"tableg\".\"a\" AS \"a\", CAST(row(\"b\".\"b1\") as row(\"b1\" varchar)) AS \"b\"\n"
+            + "FROM \"test\".\"tableg\" AS \"tableg\") AS \"t1\"\n" + "UNION ALL\n"
+            + "SELECT \"tablef0\".\"a\" AS \"a\", CAST(row(\"b\".\"b1\") as row(\"b1\" varchar)) AS \"b\"\n"
+            + "FROM \"test\".\"tablef\" AS \"tablef0\"" },
 
-        { "test", "fuzzy_union_view_map_with_struct_value_evolved", "SELECT \"a\", TRANSFORM_VALUES(b, (k, v) -> cast(row(\"v\".\"b1\") as row(\"b1\" varchar))) AS \"b\"\n"
-            + "FROM \"test\".\"tableh\"\n" + "UNION ALL\n" + "SELECT *\n" + "FROM \"test\".\"tablei\"" },
+        { "test", "fuzzy_union_view_map_with_struct_value_evolved", "SELECT \"tableh\".\"a\" AS \"a\", TRANSFORM_VALUES(b, (k, v) -> cast(row(\"v\".\"b1\") as row(\"b1\" varchar))) AS \"b\"\n"
+            + "FROM \"test\".\"tableh\" AS \"tableh\"\n" + "UNION ALL\n" + "SELECT *\n"
+            + "FROM \"test\".\"tablei\" AS \"tablei\"" },
 
-        { "test", "fuzzy_union_view_array_with_struct_value_evolved", "SELECT \"a\", TRANSFORM(b, x -> cast(row(\"x\".\"b1\") as row(\"b1\" varchar))) AS \"b\"\n"
-            + "FROM \"test\".\"tablej\"\n" + "UNION ALL\n" + "SELECT *\n" + "FROM \"test\".\"tablek\"" },
+        { "test", "fuzzy_union_view_array_with_struct_value_evolved", "SELECT \"tablej\".\"a\" AS \"a\", TRANSFORM(b, x -> cast(row(\"x\".\"b1\") as row(\"b1\" varchar))) AS \"b\"\n"
+            + "FROM \"test\".\"tablej\" AS \"tablej\"\n" + "UNION ALL\n" + "SELECT *\n"
+            + "FROM \"test\".\"tablek\" AS \"tablek\"" },
 
-        { "test", "fuzzy_union_view_deeply_nested_struct_evolved", "SELECT \"a\", CAST(row(\"b\".\"b1\", cast(row(\"b\".\"b2\".\"b3\", cast(row(\"b\".\"b2\".\"b4\".\"b5\") as row(\"b5\" varchar))) as row(\"b3\" varchar, \"b4\" row(\"b5\" varchar)))) as row(\"b1\" varchar, \"b2\" row(\"b3\" varchar, \"b4\" row(\"b5\" varchar)))) AS \"b\"\n"
-            + "FROM \"test\".\"tablel\"\n" + "UNION ALL\n" + "SELECT *\n" + "FROM \"test\".\"tablem\"" },
+        { "test", "fuzzy_union_view_deeply_nested_struct_evolved", "SELECT \"tablel\".\"a\" AS \"a\", CAST(row(\"b\".\"b1\", cast(row(\"b\".\"b2\".\"b3\", cast(row(\"b\".\"b2\".\"b4\".\"b5\") as row(\"b5\" varchar))) as row(\"b3\" varchar, \"b4\" row(\"b5\" varchar)))) as row(\"b1\" varchar, \"b2\" row(\"b3\" varchar, \"b4\" row(\"b5\" varchar)))) AS \"b\"\n"
+            + "FROM \"test\".\"tablel\" AS \"tablel\"\n" + "UNION ALL\n" + "SELECT *\n"
+            + "FROM \"test\".\"tablem\" AS \"tablem\"" },
 
-        { "test", "fuzzy_union_view_deeply_nested_complex_struct_evolved", "SELECT \"a\", CAST(row(\"b\".\"b1\", transform_values(\"b\".\"m1\", (k, v) -> cast(row(\"v\".\"b1\", transform(\"v\".\"a1\", x -> cast(row(\"x\".\"b1\") as row(\"b1\" varchar)))) as row(\"b1\" varchar, \"a1\" array(row(\"b1\" varchar)))))) as row(\"b1\" varchar, \"m1\" map(varchar, row(\"b1\" varchar, \"a1\" array(row(\"b1\" varchar)))))) AS \"b\"\n"
-            + "FROM \"test\".\"tablen\"\n" + "UNION ALL\n" + "SELECT *\n" + "FROM \"test\".\"tableo\"" },
+        { "test", "fuzzy_union_view_deeply_nested_complex_struct_evolved", "SELECT \"tablen\".\"a\" AS \"a\", CAST(row(\"b\".\"b1\", transform_values(\"b\".\"m1\", (k, v) -> cast(row(\"v\".\"b1\", transform(\"v\".\"a1\", x -> cast(row(\"x\".\"b1\") as row(\"b1\" varchar)))) as row(\"b1\" varchar, \"a1\" array(row(\"b1\" varchar)))))) as row(\"b1\" varchar, \"m1\" map(varchar, row(\"b1\" varchar, \"a1\" array(row(\"b1\" varchar)))))) AS \"b\"\n"
+            + "FROM \"test\".\"tablen\" AS \"tablen\"\n" + "UNION ALL\n" + "SELECT *\n"
+            + "FROM \"test\".\"tableo\" AS \"tableo\"" },
 
         { "test", "union_view_same_schema_evolution_with_different_ordering", "SELECT *\n"
-            + "FROM \"test\".\"tablep\"\n" + "UNION ALL\n"
-            + "SELECT \"a\", CAST(row(\"b\".\"b2\", \"b\".\"b1\", \"b\".\"b0\") as row(\"b2\" double, \"b1\" varchar, \"b0\" integer)) AS \"b\"\n"
-            + "FROM \"test\".\"tableq\"" },
+            + "FROM \"test\".\"tablep\" AS \"tablep\"\n" + "UNION ALL\n"
+            + "SELECT \"tableq\".\"a\" AS \"a\", CAST(row(\"b\".\"b2\", \"b\".\"b1\", \"b\".\"b0\") as row(\"b2\" double, \"b1\" varchar, \"b0\" integer)) AS \"b\"\n"
+            + "FROM \"test\".\"tableq\" AS \"tableq\"" },
 
         { "test", "view_with_explode_string_array", "SELECT \"$cor0\".\"a\" AS \"a\", \"t0\".\"c\" AS \"c\"\n"
             + "FROM \"test\".\"table_with_string_array\" AS \"$cor0\"\n"
@@ -124,12 +134,14 @@ public class HiveToTrinoConverterTest {
             + "FROM \"test\".\"table_with_map\" AS \"$cor0\"\n"
             + "CROSS JOIN UNNEST(\"if\"(\"$cor0\".\"b\" IS NOT NULL AND CAST(CARDINALITY(\"$cor0\".\"b\") AS INTEGER) > 0, \"$cor0\".\"b\", MAP (ARRAY[NULL], ARRAY[NULL]))) AS \"t0\" (\"c\", \"d\")" },
 
-        { "test", "map_array_view", "SELECT MAP (ARRAY['key1', 'key2'], ARRAY['value1', 'value2']) AS \"simple_map_col\", "
-            + "MAP (ARRAY['key1', 'key2'], ARRAY[MAP (ARRAY['a', 'c'], ARRAY['b', 'd']), MAP (ARRAY['a', 'c'], ARRAY['b', 'd'])]) AS \"nested_map_col\"\nFROM \"test\".\"tablea\"" },
+        { "test", "map_array_view", "SELECT MAP (ARRAY['key1', 'key2'], ARRAY['value1', 'value2']) AS \"simple_map_col\", MAP (ARRAY['key1', 'key2'], ARRAY[MAP (ARRAY['a', 'c'], ARRAY['b', 'd']), MAP (ARRAY['a', 'c'], ARRAY['b', 'd'])]) AS \"nested_map_col\"\n"
+            + "FROM \"test\".\"tablea\" AS \"tablea\"" },
 
-        { "test", "current_date_and_timestamp_view", "SELECT CAST(CURRENT_TIMESTAMP AS TIMESTAMP(3)), TRIM(CAST(CAST(CURRENT_TIMESTAMP AS TIMESTAMP(3)) AS VARCHAR(65535))) AS \"ct\", CURRENT_DATE, CURRENT_DATE AS \"cd\", \"a\"\nFROM \"test\".\"tablea\"" },
+        { "test", "current_date_and_timestamp_view", "SELECT CAST(CURRENT_TIMESTAMP AS TIMESTAMP(3)), TRIM(CAST(CAST(CURRENT_TIMESTAMP AS TIMESTAMP(3)) AS VARCHAR(65535))) AS \"ct\", CURRENT_DATE, CURRENT_DATE AS \"cd\", \"tablea\".\"a\" AS \"a\"\n"
+            + "FROM \"test\".\"tablea\" AS \"tablea\"" },
 
-        { "test", "date_function_view", "SELECT \"date\"('2021-01-02') AS \"a\"\n" + "FROM \"test\".\"tablea\"" },
+        { "test", "date_function_view", "SELECT \"date\"('2021-01-02') AS \"a\"\n"
+            + "FROM \"test\".\"tablea\" AS \"tablea\"" },
 
         { "test", "lateral_view_json_tuple_view", "SELECT \"$cor0\".\"a\" AS \"a\", \"t0\".\"d\" AS \"d\", \"t0\".\"e\" AS \"e\", \"t0\".\"f\" AS \"f\"\n"
             + "FROM \"test\".\"tablea\" AS \"$cor0\"\nCROSS JOIN LATERAL (SELECT "
@@ -145,48 +157,43 @@ public class HiveToTrinoConverterTest {
             + "\"if\"(\"REGEXP_LIKE\"('rocks', '^[^\\\"]*$'), CAST(\"json_extract\"(\"$cor0\".\"b\".\"b1\", '$[\"' || 'rocks' || '\"]') AS VARCHAR(65535)), NULL) AS \"f\"\n"
             + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")) AS \"t0\"" },
 
-        { "test", "get_json_object_view", "SELECT \"json_extract\"(\"b\".\"b1\", '$.name')\nFROM \"test\".\"tablea\"" },
+        { "test", "get_json_object_view", "SELECT \"json_extract\"(\"tablea\".\"b\".\"b1\", '$.name')\n"
+            + "FROM \"test\".\"tablea\" AS \"tablea\"" },
 
-        { "test", "view_from_utc_timestamp", "SELECT "
-            + "CAST(\"at_timezone\"(\"from_unixtime_nanos\"(CAST(\"a_tinyint\" AS BIGINT) * 1000000), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), "
-            + "CAST(\"at_timezone\"(\"from_unixtime_nanos\"(CAST(\"a_smallint\" AS BIGINT) * 1000000), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), "
-            + "CAST(\"at_timezone\"(\"from_unixtime_nanos\"(CAST(\"a_integer\" AS BIGINT) * 1000000), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), "
-            + "CAST(\"at_timezone\"(\"from_unixtime_nanos\"(CAST(\"a_bigint\" AS BIGINT) * 1000000), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), "
-            + "CAST(\"at_timezone\"(\"from_unixtime\"(CAST(\"a_float\" AS DOUBLE)), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), "
-            + "CAST(\"at_timezone\"(\"from_unixtime\"(CAST(\"a_double\" AS DOUBLE)), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), "
-            + "CAST(\"at_timezone\"(\"from_unixtime\"(CAST(\"a_decimal_three\" AS DOUBLE)), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), "
-            + "CAST(\"at_timezone\"(\"from_unixtime\"(CAST(\"a_decimal_zero\" AS DOUBLE)), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), "
-            + "CAST(\"at_timezone\"(\"from_unixtime\"(\"to_unixtime\"(\"with_timezone\"(\"a_timestamp\", 'UTC'))), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), "
-            + "CAST(\"at_timezone\"(\"from_unixtime\"(\"to_unixtime\"(\"with_timezone\"(\"a_date\", 'UTC'))), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3))\n"
-            + "FROM \"test\".\"table_from_utc_timestamp\"" },
+        { "test", "view_from_utc_timestamp", "SELECT CAST(\"at_timezone\"(\"from_unixtime_nanos\"(CAST(\"table_from_utc_timestamp\".\"a_tinyint\" AS BIGINT) * 1000000), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime_nanos\"(CAST(\"table_from_utc_timestamp\".\"a_smallint\" AS BIGINT) * 1000000), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime_nanos\"(CAST(\"table_from_utc_timestamp\".\"a_integer\" AS BIGINT) * 1000000), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime_nanos\"(CAST(\"table_from_utc_timestamp\".\"a_bigint\" AS BIGINT) * 1000000), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime\"(CAST(\"table_from_utc_timestamp\".\"a_float\" AS DOUBLE)), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime\"(CAST(\"table_from_utc_timestamp\".\"a_double\" AS DOUBLE)), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime\"(CAST(\"table_from_utc_timestamp\".\"a_decimal_three\" AS DOUBLE)), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime\"(CAST(\"table_from_utc_timestamp\".\"a_decimal_zero\" AS DOUBLE)), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime\"(\"to_unixtime\"(\"with_timezone\"(\"table_from_utc_timestamp\".\"a_timestamp\", 'UTC'))), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime\"(\"to_unixtime\"(\"with_timezone\"(\"table_from_utc_timestamp\".\"a_date\", 'UTC'))), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3))\n"
+            + "FROM \"test\".\"table_from_utc_timestamp\" AS \"table_from_utc_timestamp\"" },
 
         { "test", "date_calculation_view", "SELECT \"date\"(CAST(\"substr\"('2021-08-20', 1, 10) AS TIMESTAMP)), \"date\"(CAST('2021-08-20' AS TIMESTAMP)), \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP)), \"date_add\"('day', 1, \"date\"(CAST('2021-08-20' AS TIMESTAMP))), \"date_add\"('day', 1, \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP))), \"date_add\"('day', 1 * -1, \"date\"(CAST('2021-08-20' AS TIMESTAMP))), \"date_add\"('day', 1 * -1, \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP))), CAST(\"date_diff\"('day', \"date\"(CAST('2021-08-21' AS TIMESTAMP)), \"date\"(CAST('2021-08-20' AS TIMESTAMP))) AS INTEGER), CAST(\"date_diff\"('day', \"date\"(CAST('2021-08-19' AS TIMESTAMP)), \"date\"(CAST('2021-08-20' AS TIMESTAMP))) AS INTEGER), CAST(\"date_diff\"('day', \"date\"(CAST('2021-08-19 23:59:59' AS TIMESTAMP)), \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP))) AS INTEGER)\n"
-            + "FROM \"test\".\"tablea\"" },
+            + "FROM \"test\".\"tablea\" AS \"tablea\"" },
 
-        { "test", "pmod_view", "SELECT MOD(MOD(- 9, 4) + 4, 4)\nFROM \"test\".\"tablea\"" },
+        { "test", "pmod_view", "SELECT MOD(MOD(- 9, 4) + 4, 4)\n" + "FROM \"test\".\"tablea\" AS \"tablea\"" },
 
-        { "test", "nullscollationd_view", "SELECT *\nFROM \"test\".\"tabler\"\nORDER BY \"b\" DESC" },
+        { "test", "nullscollationd_view", "SELECT *\n" + "FROM \"test\".\"tabler\" AS \"tabler\"\n"
+            + "ORDER BY \"tabler\".\"b\" DESC" },
 
-        { "test", "view_with_date_and_interval", "SELECT (CAST('2021-08-30' AS DATE) + INTERVAL '3' DAY)\nFROM \"test\".\"tablea\"" },
+        { "test", "view_with_date_and_interval", "SELECT (CAST('2021-08-30' AS DATE) + INTERVAL '3' DAY)\n"
+            + "FROM \"test\".\"tablea\" AS \"tablea\"" },
 
-        { "test", "view_with_timestamp_and_interval", "SELECT (CAST('2021-08-30' AS TIMESTAMP) + INTERVAL -'3 01:02:03' DAY TO SECOND)\nFROM \"test\".\"tablea\"" },
+        { "test", "view_with_timestamp_and_interval", "SELECT (CAST('2021-08-30' AS TIMESTAMP) + INTERVAL -'3 01:02:03' DAY TO SECOND)\n"
+            + "FROM \"test\".\"tablea\" AS \"tablea\"" },
 
-        { "test", "view_with_timestamp_and_interval_2", "SELECT (CAST('2021-08-30' AS TIMESTAMP) + INTERVAL -'1-6' YEAR TO MONTH)\nFROM \"test\".\"tablea\"" },
+        { "test", "view_with_timestamp_and_interval_2", "SELECT (CAST('2021-08-30' AS TIMESTAMP) + INTERVAL -'1-6' YEAR TO MONTH)\n"
+            + "FROM \"test\".\"tablea\" AS \"tablea\"" },
 
-        { "test", "greatest_view", "SELECT \"greatest\"(\"a\", \"b\") AS \"g_int\", \"greatest\"(\"c\", \"d\") AS \"g_string\"\n"
-            + "FROM \"test\".\"table_ints_strings\"" },
+        { "test", "greatest_view", "SELECT \"greatest\"(\"table_ints_strings\".\"a\", \"table_ints_strings\".\"b\") AS \"g_int\", \"greatest\"(\"table_ints_strings\".\"c\", \"table_ints_strings\".\"d\") AS \"g_string\"\n"
+            + "FROM \"test\".\"table_ints_strings\" AS \"table_ints_strings\"" },
 
-        { "test", "least_view", "SELECT \"least\"(\"a\", \"b\") AS \"g_int\", \"least\"(\"c\", \"d\") AS \"g_string\"\n"
-            + "FROM \"test\".\"table_ints_strings\"" },
+        { "test", "least_view", "SELECT \"least\"(\"table_ints_strings\".\"a\", \"table_ints_strings\".\"b\") AS \"g_int\", \"least\"(\"table_ints_strings\".\"c\", \"table_ints_strings\".\"d\") AS \"g_string\"\n"
+            + "FROM \"test\".\"table_ints_strings\" AS \"table_ints_strings\"" },
 
-        { "test", "cast_decimal_view", "SELECT CAST(\"a\" AS DECIMAL(6, 2)) AS \"casted_decimal\"\n"
-            + "FROM \"test\".\"table_ints_strings\"" },
+        { "test", "cast_decimal_view", "SELECT CAST(\"table_ints_strings\".\"a\" AS DECIMAL(6, 2)) AS \"casted_decimal\"\n"
+            + "FROM \"test\".\"table_ints_strings\" AS \"table_ints_strings\"" },
 
-        { "test", "view_namesake_column_names", "SELECT \"some_id\"\n"
+        { "test", "view_namesake_column_names", "SELECT \"t0\".\"some_id\" AS \"some_id\"\n"
             + "FROM (SELECT \"duplicate_column_name_a\".\"some_id\" AS \"some_id\", \"t\".\"SOME_ID\" AS \"SOME_ID0\"\n"
-            + "FROM \"test\".\"duplicate_column_name_a\"\n"
-            + "LEFT JOIN (SELECT TRIM(\"some_id\") AS \"SOME_ID\", CAST(TRIM(\"some_id\") AS VARCHAR(65536)) AS \"$f1\"\n"
-            + "FROM \"test\".\"duplicate_column_name_b\") AS \"t\" ON \"duplicate_column_name_a\".\"some_id\" = \"t\".\"$f1\") AS \"t0\"\n"
+            + "FROM \"test\".\"duplicate_column_name_a\" AS \"duplicate_column_name_a\"\n"
+            + "LEFT JOIN (SELECT TRIM(\"duplicate_column_name_b\".\"some_id\") AS \"SOME_ID\", CAST(TRIM(\"duplicate_column_name_b\".\"some_id\") AS VARCHAR(65536)) AS \"$f1\"\n"
+            + "FROM \"test\".\"duplicate_column_name_b\" AS \"duplicate_column_name_b\") AS \"t\" ON \"duplicate_column_name_a\".\"some_id\" = \"t\".\"$f1\") AS \"t0\"\n"
             + "WHERE \"t0\".\"some_id\" <> ''" } };
   }
 
@@ -211,7 +218,7 @@ public class HiveToTrinoConverterTest {
     RelNode relNode = hiveToRelConverter
         .convertSql("SELECT arr.alias FROM test.tableA tmp LATERAL VIEW EXPLODE(ARRAY('a', 'b')) arr as alias");
 
-    String targetSql = "SELECT \"t0\".\"alias\" AS \"alias\"\n" + "FROM \"test\".\"tablea\",\n"
+    String targetSql = "SELECT \"t0\".\"alias\" AS \"alias\"\n" + "FROM \"test\".\"tablea\" AS \"tablea\",\n"
         + "UNNEST(ARRAY['a', 'b']) AS \"t0\" (\"alias\")";
     RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
     String expandedSql = relToTrinoConverter.convert(relNode);
@@ -328,8 +335,8 @@ public class HiveToTrinoConverterTest {
   public void testAvoidTransformToDate() {
     RelNode relNode = hiveToRelConverter
         .convertSql("SELECT to_date(substr('2021-08-20', 1, 10)), to_date('2021-08-20')" + "FROM test.tableA");
-    String targetSql =
-        "SELECT \"to_date\"(\"substr\"('2021-08-20', 1, 10)), \"to_date\"('2021-08-20')\n" + "FROM \"test\".\"tablea\"";
+    String targetSql = "SELECT \"to_date\"(\"substr\"('2021-08-20', 1, 10)), \"to_date\"('2021-08-20')\n"
+        + "FROM \"test\".\"tablea\" AS \"tablea\"";
 
     RelToTrinoConverter relToTrinoConverter =
         new RelToTrinoConverter(ImmutableMap.of(AVOID_TRANSFORM_TO_DATE_UDF, true));
@@ -446,8 +453,8 @@ public class HiveToTrinoConverterTest {
     RelNode relNode = hiveToRelConverter
         .convertSql("SELECT CAST(a_timestamp AS DECIMAL(10, 0)) AS d\nFROM test.table_from_utc_timestamp");
     String targetSql =
-        "SELECT CAST(\"to_unixtime\"(\"with_timezone\"(\"a_timestamp\", 'UTC')) AS DECIMAL(10, 0)) AS \"d\"\n"
-            + "FROM \"test\".\"table_from_utc_timestamp\"";
+        "SELECT CAST(\"to_unixtime\"(\"with_timezone\"(\"table_from_utc_timestamp\".\"a_timestamp\", 'UTC')) AS DECIMAL(10, 0)) AS \"d\"\n"
+            + "FROM \"test\".\"table_from_utc_timestamp\" AS \"table_from_utc_timestamp\"";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
@@ -459,16 +466,16 @@ public class HiveToTrinoConverterTest {
     RelNode relNode = hiveToRelConverter.convertSql(
         "SELECT CAST(CAST(a_date AS TIMESTAMP) AS DECIMAL(10, 0)) AS d\nFROM test.table_from_utc_timestamp");
     String targetSql =
-        "SELECT CAST(\"to_unixtime\"(\"with_timezone\"(CAST(\"a_date\" AS TIMESTAMP), 'UTC')) AS DECIMAL(10, 0)) AS \"d\"\n"
-            + "FROM \"test\".\"table_from_utc_timestamp\"";
+        "SELECT CAST(\"to_unixtime\"(\"with_timezone\"(CAST(\"table_from_utc_timestamp\".\"a_date\" AS TIMESTAMP), 'UTC')) AS DECIMAL(10, 0)) AS \"d\"\n"
+            + "FROM \"test\".\"table_from_utc_timestamp\" AS \"table_from_utc_timestamp\"";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
 
     relNode = hiveToRelConverter.convertSql(
         "SELECT CAST(from_utc_timestamp(a_date, 'America/Los_Angeles') AS DECIMAL(10, 0)) AS d\nFROM test.table_from_utc_timestamp");
     targetSql =
-        "SELECT CAST(\"to_unixtime\"(\"with_timezone\"(CAST(\"at_timezone\"(\"from_unixtime\"(\"to_unixtime\"(\"with_timezone\"(\"a_date\", 'UTC'))), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), 'UTC')) AS DECIMAL(10, 0)) AS \"d\"\n"
-            + "FROM \"test\".\"table_from_utc_timestamp\"";
+        "SELECT CAST(\"to_unixtime\"(\"with_timezone\"(CAST(\"at_timezone\"(\"from_unixtime\"(\"to_unixtime\"(\"with_timezone\"(\"table_from_utc_timestamp0\".\"a_date\", 'UTC'))), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), 'UTC')) AS DECIMAL(10, 0)) AS \"d\"\n"
+            + "FROM \"test\".\"table_from_utc_timestamp\" AS \"table_from_utc_timestamp0\"";
     expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
@@ -511,10 +518,10 @@ public class HiveToTrinoConverterTest {
     //
     // However, `struct_col` column doesn't exist in test.tableT
 
-    String targetSql = "SELECT \"struct_col\" AS \"structCol\"\n" + "FROM (SELECT \"structcol\" AS \"struct_col\"\n"
-        + "FROM \"test\".\"tables\"\n" + "UNION ALL\n"
-        + "SELECT CAST(row(\"structcol\".\"a\") as row(\"a\" integer)) AS \"struct_col\"\n"
-        + "FROM \"test\".\"tablet\") AS \"t1\"";
+    String targetSql = "SELECT \"t1\".\"struct_col\" AS \"structCol\"\n"
+        + "FROM (SELECT \"tables\".\"structcol\" AS \"struct_col\"\n" + "FROM \"test\".\"tables\" AS \"tables\"\n"
+        + "UNION ALL\n" + "SELECT CAST(row(\"structcol\".\"a\") as row(\"a\" integer)) AS \"struct_col\"\n"
+        + "FROM \"test\".\"tablet\" AS \"tablet\") AS \"t1\"";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
@@ -602,14 +609,16 @@ public class HiveToTrinoConverterTest {
     RelNode relNode =
         hiveToRelConverter.convertSql("SELECT SUBSTR(a_timestamp, 12, 8) AS d\nFROM test.table_from_utc_timestamp");
     String targetSql =
-        "SELECT \"substr\"(CAST(\"a_timestamp\" AS VARCHAR(65535)), 12, 8) AS \"d\"\nFROM \"test\".\"table_from_utc_timestamp\"";
+        "SELECT \"substr\"(CAST(\"table_from_utc_timestamp\".\"a_timestamp\" AS VARCHAR(65535)), 12, 8) AS \"d\"\n"
+            + "FROM \"test\".\"table_from_utc_timestamp\" AS \"table_from_utc_timestamp\"";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
 
     relNode =
         hiveToRelConverter.convertSql("SELECT SUBSTRING(a_timestamp, 12, 8) AS d\nFROM test.table_from_utc_timestamp");
     targetSql =
-        "SELECT \"substr\"(CAST(\"a_timestamp\" AS VARCHAR(65535)), 12, 8) AS \"d\"\nFROM \"test\".\"table_from_utc_timestamp\"";
+        "SELECT \"substr\"(CAST(\"table_from_utc_timestamp0\".\"a_timestamp\" AS VARCHAR(65535)), 12, 8) AS \"d\"\n"
+            + "FROM \"test\".\"table_from_utc_timestamp\" AS \"table_from_utc_timestamp0\"";
     expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
@@ -621,7 +630,8 @@ public class HiveToTrinoConverterTest {
     RelNode relNode = hiveToRelConverter
         .convertSql("SELECT a, SUBSTR(b, 1, 1) AS aliased_column, c FROM test.tabler ORDER BY aliased_column DESC");
     String targetSql =
-        "SELECT \"a\", \"substr\"(\"b\", 1, 1) AS \"aliased_column\", \"c\"\nFROM \"test\".\"tabler\"\nORDER BY \"substr\"(\"b\", 1, 1) DESC";
+        "SELECT \"tabler\".\"a\" AS \"a\", \"substr\"(\"tabler\".\"b\", 1, 1) AS \"aliased_column\", \"tabler\".\"c\" AS \"c\"\n"
+            + "FROM \"test\".\"tabler\" AS \"tabler\"\n" + "ORDER BY \"substr\"(\"tabler\".\"b\", 1, 1) DESC";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
@@ -632,8 +642,9 @@ public class HiveToTrinoConverterTest {
 
     RelNode relNode = hiveToRelConverter.convertSql(
         "SELECT a, SUBSTR(b, 1, 1) AS aliased_column FROM test.tabler GROUP BY a, b HAVING aliased_column in ('dummy_value')");
-    String targetSql =
-        "SELECT \"a\", \"substr\"(\"b\", 1, 1) AS \"aliased_column\"\nFROM \"test\".\"tabler\"\nGROUP BY \"a\", \"b\"\nHAVING \"substr\"(\"b\", 1, 1)\nIN ('dummy_value')";
+    String targetSql = "SELECT \"tabler\".\"a\" AS \"a\", \"substr\"(\"tabler\".\"b\", 1, 1) AS \"aliased_column\"\n"
+        + "FROM \"test\".\"tabler\" AS \"tabler\"\n" + "GROUP BY \"tabler\".\"a\", \"tabler\".\"b\"\n"
+        + "HAVING \"substr\"(\"tabler\".\"b\", 1, 1)\n" + "IN ('dummy_value')";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
@@ -644,8 +655,8 @@ public class HiveToTrinoConverterTest {
 
     RelNode relNode = hiveToRelConverter
         .convertSql("SELECT CAST(t.a as DECIMAL(6, 2)) as casted_decimal FROM test.table_ints_strings t");
-    String targetSql =
-        "SELECT CAST(\"a\" AS DECIMAL(6, 2)) AS \"casted_decimal\"\n" + "FROM \"test\".\"table_ints_strings\"";
+    String targetSql = "SELECT CAST(\"table_ints_strings\".\"a\" AS DECIMAL(6, 2)) AS \"casted_decimal\"\n"
+        + "FROM \"test\".\"table_ints_strings\" AS \"table_ints_strings\"";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
@@ -656,8 +667,8 @@ public class HiveToTrinoConverterTest {
 
     RelNode relNode =
         hiveToRelConverter.convertSql("SELECT CAST(t.a as DECIMAL) as casted_decimal FROM test.table_ints_strings t");
-    String targetSql =
-        "SELECT CAST(\"a\" AS DECIMAL(10, 0)) AS \"casted_decimal\"\n" + "FROM \"test\".\"table_ints_strings\"";
+    String targetSql = "SELECT CAST(\"table_ints_strings\".\"a\" AS DECIMAL(10, 0)) AS \"casted_decimal\"\n"
+        + "FROM \"test\".\"table_ints_strings\" AS \"table_ints_strings\"";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
@@ -667,7 +678,7 @@ public class HiveToTrinoConverterTest {
     RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
 
     RelNode relNode = hiveToRelConverter.convertSql("SELECT collect_list(a) from test.tableA");
-    String targetSql = "SELECT \"array_agg\"(\"a\")\n" + "FROM \"test\".\"tablea\"";
+    String targetSql = "SELECT \"array_agg\"(\"tablea\".\"a\")\n" + "FROM \"test\".\"tablea\" AS \"tablea\"";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
@@ -677,7 +688,8 @@ public class HiveToTrinoConverterTest {
     RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
 
     RelNode relNode = hiveToRelConverter.convertSql("SELECT collect_set(a) from test.tableA");
-    String targetSql = "SELECT \"array_distinct\"(\"array_agg\"(\"a\"))\n" + "FROM \"test\".\"tablea\"";
+    String targetSql =
+        "SELECT \"array_distinct\"(\"array_agg\"(\"tablea\".\"a\"))\n" + "FROM \"test\".\"tablea\" AS \"tablea\"";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
@@ -711,7 +723,8 @@ public class HiveToTrinoConverterTest {
     RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
 
     RelNode relNode = hiveToRelConverter.convertSql("SELECT CAST(b AS STRING) FROM test.table_with_binary_column");
-    String targetSql = "SELECT \"from_utf8\"(\"b\")\n" + "FROM \"test\".\"table_with_binary_column\"";
+    String targetSql = "SELECT \"from_utf8\"(\"table_with_binary_column\".\"b\")\n"
+        + "FROM \"test\".\"table_with_binary_column\" AS \"table_with_binary_column\"";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
@@ -721,7 +734,8 @@ public class HiveToTrinoConverterTest {
     RelToTrinoConverter relToTrinoConverter = new RelToTrinoConverter();
 
     RelNode relNode = hiveToRelConverter.convertSql("SELECT CAST(b AS CHAR(255)) FROM test.table_with_binary_column");
-    String targetSql = "SELECT \"from_utf8\"(\"b\")\n" + "FROM \"test\".\"table_with_binary_column\"";
+    String targetSql = "SELECT \"from_utf8\"(\"table_with_binary_column\".\"b\")\n"
+        + "FROM \"test\".\"table_with_binary_column\" AS \"table_with_binary_column\"";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/trino2rel/TrinoToRelConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/trino2rel/TrinoToRelConverterTest.java
@@ -69,65 +69,68 @@ public class TrinoToRelConverterTest {
         .add(new TrinoToRelTestDataProvider("select * from foo",
             "LogicalProject(show=[$0], a=[$1], b=[$2], x=[$3], y=[$4])\n"
                 + "  LogicalTableScan(table=[[hive, default, foo]])\n",
-            "SELECT *\n" + "FROM \"default\".\"foo\""))
+            "SELECT *\n" + "FROM \"default\".\"foo\" AS \"foo\""))
         .add(new TrinoToRelTestDataProvider("select * from foo /* end */",
             "LogicalProject(show=[$0], a=[$1], b=[$2], x=[$3], y=[$4])\n"
                 + "  LogicalTableScan(table=[[hive, default, foo]])\n",
-            "SELECT *\n" + "FROM \"default\".\"foo\""))
+            "SELECT *\n" + "FROM \"default\".\"foo\" AS \"foo\""))
         .add(new TrinoToRelTestDataProvider("/* start */ select * from foo",
             "LogicalProject(show=[$0], a=[$1], b=[$2], x=[$3], y=[$4])\n"
                 + "  LogicalTableScan(table=[[hive, default, foo]])\n",
-            "SELECT *\n" + "FROM \"default\".\"foo\""))
+            "SELECT *\n" + "FROM \"default\".\"foo\" AS \"foo\""))
         .add(new TrinoToRelTestDataProvider("/* start */ select * /* middle */ from foo /* end */",
             "LogicalProject(show=[$0], a=[$1], b=[$2], x=[$3], y=[$4])\n"
                 + "  LogicalTableScan(table=[[hive, default, foo]])\n",
-            "SELECT *\n" + "FROM \"default\".\"foo\""))
+            "SELECT *\n" + "FROM \"default\".\"foo\" AS \"foo\""))
         .add(new TrinoToRelTestDataProvider("-- start \n select * -- junk -- hi\n from foo -- done",
             "LogicalProject(show=[$0], a=[$1], b=[$2], x=[$3], y=[$4])\n"
                 + "  LogicalTableScan(table=[[hive, default, foo]])\n",
-            "SELECT *\n" + "FROM \"default\".\"foo\""))
+            "SELECT *\n" + "FROM \"default\".\"foo\" AS \"foo\""))
         .add(new TrinoToRelTestDataProvider("select * from foo a (v, w, x, y, z)",
             "LogicalProject(V=[$0], W=[$1], X=[$2], Y=[$3], Z=[$4])\n"
                 + "  LogicalTableScan(table=[[hive, default, foo]])\n",
-            "SELECT \"show\" AS \"V\", \"a\" AS \"W\", \"b\" AS \"X\", \"x\" AS \"Y\", \"y\" AS \"Z\"\n"
-                + "FROM \"default\".\"foo\""))
+            "SELECT \"foo\".\"show\" AS \"V\", \"foo\".\"a\" AS \"W\", \"foo\".\"b\" AS \"X\", \"foo\".\"x\" AS \"Y\", \"foo\".\"y\" AS \"Z\"\n"
+                + "FROM \"default\".\"foo\" AS \"foo\""))
         .add(new TrinoToRelTestDataProvider("select *, 123, * from foo",
             "LogicalProject(show=[$0], a=[$1], b=[$2], x=[$3], y=[$4], EXPR$5=[123], show0=[$0], a0=[$1], b0=[$2], x0=[$3], y0=[$4])\n"
                 + "  LogicalTableScan(table=[[hive, default, foo]])\n",
-            "SELECT \"show\", \"a\", \"b\", \"x\", \"y\", 123, \"show\" AS \"show0\", \"a\" AS \"a0\", \"b\" AS \"b0\", \"x\" AS \"x0\", \"y\" AS \"y0\"\n"
-                + "FROM \"default\".\"foo\""))
+            "SELECT \"foo\".\"show\" AS \"show\", \"foo\".\"a\" AS \"a\", \"foo\".\"b\" AS \"b\", \"foo\".\"x\" AS \"x\", \"foo\".\"y\" AS \"y\", 123, \"foo\".\"show\" AS \"show0\", \"foo\".\"a\" AS \"a0\", \"foo\".\"b\" AS \"b0\", \"foo\".\"x\" AS \"x0\", \"foo\".\"y\" AS \"y0\"\n"
+                + "FROM \"default\".\"foo\" AS \"foo\""))
         .add(new TrinoToRelTestDataProvider("select show from foo",
             "LogicalProject(SHOW=[$0])\n" + "  LogicalTableScan(table=[[hive, default, foo]])\n",
-            "SELECT \"show\" AS \"SHOW\"\n" + "FROM \"default\".\"foo\""))
+            "SELECT \"foo\".\"show\" AS \"SHOW\"\n" + "FROM \"default\".\"foo\" AS \"foo\""))
         .add(new TrinoToRelTestDataProvider("select extract(day from x), extract(dow from x) from foo",
             "LogicalProject(EXPR$0=[EXTRACT(FLAG(DAY), $3)], EXPR$1=[EXTRACT(FLAG(DOW), $3)])\n"
                 + "  LogicalTableScan(table=[[hive, default, foo]])\n",
-            "SELECT EXTRACT(DAY FROM \"x\"), EXTRACT(DOW FROM \"x\")\n" + "FROM \"default\".\"foo\""))
+            "SELECT EXTRACT(DAY FROM \"foo\".\"x\"), EXTRACT(DOW FROM \"foo\".\"x\")\n"
+                + "FROM \"default\".\"foo\" AS \"foo\""))
         .add(new TrinoToRelTestDataProvider("select 1 + 13 || '15' from foo",
             "LogicalProject(EXPR$0=[concat(+(1, 13), '15')])\n" + "  LogicalTableScan(table=[[hive, default, foo]])\n",
-            "SELECT \"concat\"(CAST(1 + 13 AS VARCHAR(65535)), '15')\n" + "FROM \"default\".\"foo\""))
+            "SELECT \"concat\"(CAST(1 + 13 AS VARCHAR(65535)), '15')\n" + "FROM \"default\".\"foo\" AS \"foo\""))
         .add(new TrinoToRelTestDataProvider("select x is distinct from y from foo where a is not distinct from b",
             "LogicalProject(EXPR$0=[AND(OR(IS NOT NULL($3), IS NOT NULL($4)), IS NOT TRUE(=($3, $4)))])\n"
                 + "  LogicalFilter(condition=[NOT(AND(OR(IS NOT NULL($1), IS NOT NULL($2)), IS NOT TRUE(=($1, $2))))])\n"
                 + "    LogicalTableScan(table=[[hive, default, foo]])\n",
-            "SELECT (\"x\" IS NOT NULL OR \"y\" IS NOT NULL) AND \"x\" = \"y\" IS NOT TRUE\n"
-                + "FROM \"default\".\"foo\"\n"
-                + "WHERE NOT ((\"a\" IS NOT NULL OR \"b\" IS NOT NULL) AND \"a\" = \"b\" IS NOT TRUE)"))
+            "SELECT (\"foo\".\"x\" IS NOT NULL OR \"foo\".\"y\" IS NOT NULL) AND \"foo\".\"x\" = \"foo\".\"y\" IS NOT TRUE\n"
+                + "FROM \"default\".\"foo\" AS \"foo\"\n"
+                + "WHERE NOT ((\"foo\".\"a\" IS NOT NULL OR \"foo\".\"b\" IS NOT NULL) AND \"foo\".\"a\" = \"foo\".\"b\" IS NOT TRUE)"))
         .add(new TrinoToRelTestDataProvider("select x[1] from my_table",
             "LogicalProject(EXPR$0=[ITEM($0, 1)])\n" + "  LogicalTableScan(table=[[hive, default, my_table]])\n",
-            "SELECT element_at(\"x\", 1)\n" + "FROM \"default\".\"my_table\""))
+            "SELECT element_at(\"my_table\".\"x\", 1)\n" + "FROM \"default\".\"my_table\" AS \"my_table\""))
         .add(new TrinoToRelTestDataProvider("select y[1][2] from my_table",
             "LogicalProject(EXPR$0=[ITEM(ITEM($1, 1), 2)])\n"
                 + "  LogicalTableScan(table=[[hive, default, my_table]])\n",
-            "SELECT element_at(element_at(\"y\", 1), 2)\n" + "FROM \"default\".\"my_table\""))
+            "SELECT element_at(element_at(\"my_table\".\"y\", 1), 2)\n"
+                + "FROM \"default\".\"my_table\" AS \"my_table\""))
         .add(new TrinoToRelTestDataProvider("select x[cast(10 * sin(z) as bigint)] from my_table",
             "LogicalProject(EXPR$0=[ITEM($0, CAST(*(10, SIN($2))):BIGINT)])\n"
                 + "  LogicalTableScan(table=[[hive, default, my_table]])\n",
-            "SELECT element_at(\"x\", CAST(10 * SIN(\"z\") AS BIGINT))\n" + "FROM \"default\".\"my_table\""))
+            "SELECT element_at(\"my_table\".\"x\", CAST(10 * SIN(\"my_table\".\"z\") AS BIGINT))\n"
+                + "FROM \"default\".\"my_table\" AS \"my_table\""))
         .add(new TrinoToRelTestDataProvider("select * from unnest(array[1, 2, 3])",
             "LogicalProject(EXPR$0=[$0])\n" + "  HiveUncollect\n" + "    LogicalProject(col=[ARRAY(1, 2, 3)])\n"
                 + "      LogicalValues(tuples=[[{ 0 }]])\n",
-            "SELECT \"col\"\n" + "FROM UNNEST(ARRAY[1, 2, 3]) AS \"t0\" (\"col\")"))
+            "SELECT \"t0\".\"col\"\n" + "FROM UNNEST(ARRAY[1, 2, 3]) AS \"t0\" (\"col\")"))
         .add(new TrinoToRelTestDataProvider("select x from unnest(array[1, 2, 3]) t(x)",
             "LogicalProject(X=[$0])\n" + "  HiveUncollect\n" + "    LogicalProject(col=[ARRAY(1, 2, 3)])\n"
                 + "      LogicalValues(tuples=[[{ 0 }]])\n",
@@ -150,7 +153,7 @@ public class TrinoToRelConverterTest {
         .add(new TrinoToRelTestDataProvider("select * from unnest(array[1, 2, 3]) with ordinality",
             "LogicalProject(EXPR$0=[$0], ORDINALITY=[$1])\n" + "  HiveUncollect(withOrdinality=[true])\n"
                 + "    LogicalProject(col=[ARRAY(1, 2, 3)])\n" + "      LogicalValues(tuples=[[{ 0 }]])\n",
-            "SELECT \"col\", \"ORDINALITY\"\n"
+            "SELECT \"t0\".\"col\", \"t0\".\"ORDINALITY\" AS \"ORDINALITY\"\n"
                 + "FROM UNNEST(ARRAY[1, 2, 3]) WITH ORDINALITY AS \"t0\" (\"col\", \"ORDINALITY\")"))
         .add(new TrinoToRelTestDataProvider("select * from unnest(array[1, 2, 3]) with ordinality t(x, y)",
             "LogicalProject(X=[$0], Y=[$1])\n" + "  HiveUncollect(withOrdinality=[true])\n"
@@ -178,25 +181,27 @@ public class TrinoToRelConverterTest {
             "LogicalProject(ID=[COALESCE($0, $1)])\n" + "  LogicalJoin(condition=[=($0, $1)], joinType=[inner])\n"
                 + "    LogicalProject(EXPR$0=[123])\n" + "      LogicalTableScan(table=[[hive, default, foo]])\n"
                 + "    LogicalProject(EXPR$0=[999])\n" + "      LogicalTableScan(table=[[hive, default, foo]])\n",
-            "SELECT COALESCE(999, 999) AS \"ID\"\n" + "FROM (SELECT 123\n" + "FROM \"default\".\"foo\") AS \"t\"\n"
-                + "INNER JOIN (SELECT 999\n" + "FROM \"default\".\"foo\") AS \"t0\" ON 999 = 999"))
+            "SELECT COALESCE(999, 999) AS \"ID\"\n" + "FROM (SELECT 123\n"
+                + "FROM \"default\".\"foo\" AS \"foo\") AS \"t\"\n" + "INNER JOIN (SELECT 999\n"
+                + "FROM \"default\".\"foo\" AS \"foo0\") AS \"t0\" ON 999 = 999"))
         .add(new TrinoToRelTestDataProvider("select cast('123' as bigint)",
             "LogicalProject(EXPR$0=[CAST('123'):BIGINT])\n" + "  LogicalValues(tuples=[[{ 0 }]])\n",
             "SELECT CAST('123' AS BIGINT)\n" + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")"))
         .add(new TrinoToRelTestDataProvider("select a \"my price\" from \"foo\" \"ORDERS\"",
             "LogicalProject(MY PRICE=[$1])\n" + "  LogicalTableScan(table=[[hive, default, foo]])\n",
-            "SELECT \"a\" AS \"MY PRICE\"\n" + "FROM \"default\".\"foo\""))
+            "SELECT \"foo\".\"a\" AS \"MY PRICE\"\n" + "FROM \"default\".\"foo\" AS \"foo\""))
         .add(new TrinoToRelTestDataProvider("select * from a limit all",
             "LogicalProject(b=[$0], id=[$1], x=[$2])\n" + "  LogicalTableScan(table=[[hive, default, a]])\n",
-            "SELECT *\n" + "FROM \"default\".\"a\""))
+            "SELECT *\n" + "FROM \"default\".\"a\" AS \"a\""))
         .add(new TrinoToRelTestDataProvider("select * from a order by x limit all",
             "LogicalSort(sort0=[$2], dir0=[ASC-nulls-first])\n" + "  LogicalProject(b=[$0], id=[$1], x=[$2])\n"
                 + "    LogicalTableScan(table=[[hive, default, a]])\n",
-            "SELECT *\n" + "FROM \"default\".\"a\"\n" + "ORDER BY \"x\" NULLS FIRST"))
+            "SELECT *\n" + "FROM \"default\".\"a\" AS \"a\"\n" + "ORDER BY \"a\".\"x\" NULLS FIRST"))
         .add(new TrinoToRelTestDataProvider("select * from a union select * from b", "LogicalUnion(all=[false])\n"
             + "  LogicalProject(b=[$0], id=[$1], x=[$2])\n" + "    LogicalTableScan(table=[[hive, default, a]])\n"
             + "  LogicalProject(foobar=[$0], id=[$1], y=[$2])\n" + "    LogicalTableScan(table=[[hive, default, b]])\n",
-            "SELECT *\n" + "FROM \"default\".\"a\"\n" + "UNION\n" + "SELECT *\n" + "FROM \"default\".\"b\""))
+            "SELECT *\n" + "FROM \"default\".\"a\" AS \"a\"\n" + "UNION\n" + "SELECT *\n"
+                + "FROM \"default\".\"b\" AS \"b\""))
         .add(new TrinoToRelTestDataProvider("select strpos('foobar', 'b') as pos",
             "LogicalProject(POS=[instr('FOOBAR', 'B')])\n" + "  LogicalValues(tuples=[[{ 0 }]])\n",
             "SELECT \"strpos\"('FOOBAR', 'B') AS \"POS\"\n" + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")"))

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ def versions = [
   'jetbrains': '16.0.2',
   'jline': '0.9.94',
   'kryo': '2.22',
-  'linkedin-calcite-core': '1.21.0.152',
+  'linkedin-calcite-core': '1.21.0.153',
   'pig': '0.15.0',
   'spark': '2.4.0',
   'spark3': '3.1.1',


### PR DESCRIPTION
## Change Summary
This PR upgrades [linkedin-calcite](https://github.com/linkedin/linkedin-calcite) to pick up the fix https://github.com/linkedin/linkedin-calcite/pull/82.
Then with overriding `hasImplicitTableAlias()` in SqlDialect to `false`, for the input SQL
```
/**
 * Table schema is as following:
 *  myTable(
 *          a: BIGINT,
 *          n1: STRUCT<
 *                n11: STRUCT<b: BIGINT>,
 *                n12: STRUCT<c: BIGINT>
 *              >,
 *          n2: STRUCT<d: BIGINT>,
 *          e: BIGINT
 *  )
 */
SELECT "myTable"."n2"."d" FROM "myTable" WHERE "a" > 5
```
without this PR, the converted SQL is:
```
SELECT \"t0\".\"d\"
FROM (SELECT \"myTable\".\"a\", \"myTable\".\"n1\".\"n11\".\"b\", \"myTable\".\"n1\".\"n12\".\"c\", \"myTable\".\"n2\".\"d\", \"myTable\".\"e\"
FROM \"myDb\".\"myTable\" AS \"myTable\") AS \"t\"
WHERE \"t\".\"a\" > 5
```
which is obviously wrong, but with this PR, the converted SQL is:
```
SELECT \"t\".\"d\"
FROM (SELECT \"myTable\".\"a\", \"myTable\".\"n1\".\"n11\".\"b\", \"myTable\".\"n1\".\"n12\".\"c\", \"myTable\".\"n2\".\"d\", \"myTable\".\"e\"
FROM \"myDb\".\"myTable\" AS \"myTable\") AS \"t\"
WHERE \"t\".\"a\" > 5
```
which is correct.

Besides, the PR also overrides `public Result visit(Values e)` to avoid duplicated alias and adds `resetAlias()` to ensure correct alias so that there won't be regressions after the change.

## Tests
1. Existing unit tests, verified all the changes are valid
2. Regression test on all the prod views, no regression on translation
3. For all the prod views with different translated SQL, verified with local Trino server and gateway Spark shell regression tests, ensured all the new SQLs could work well on prod Trino & Spark.