### PR TITLE
Coral-Schema: Return nullable schema for inner fields created by operator

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
@@ -6,7 +6,6 @@
 package com.linkedin.coral.schema.avro;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import javax.annotation.Nonnull;
@@ -79,10 +78,7 @@ class RelDataTypeToAvroType {
 
   private static Schema relDataTypeToAvroType(RelDataType relDataType, String recordName) {
     final Schema avroSchema = relDataTypeToAvroTypeNonNullable(relDataType, recordName);
-    if (relDataType.isNullable() && avroSchema.getType() != Schema.Type.NULL) {
-      return Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.NULL), avroSchema));
-    }
-    return avroSchema;
+    return SchemaUtilities.makeNullable(avroSchema, false);
   }
 
   private static Schema basicSqlTypeToAvroType(BasicSqlType relDataType) {

--- a/coral-schema/src/test/resources/testCaseCallWithNullBranchAndComplexDataTypeBranch-expected.avsc
+++ b/coral-schema/src/test/resources/testCaseCallWithNullBranchAndComplexDataTypeBranch-expected.avsc
@@ -6,7 +6,7 @@
     "name" : "col1",
     "type" : [ "null", {
       "type" : "array",
-      "items" : "string"
+      "items" : [ "null", "string" ]
     } ],
     "doc" : "Field created in view by applying operator 'CASE' with argument(s): true, value with type VARCHAR(65535) ARRAY, value with type VARCHAR(65535) ARRAY"
   } ]

--- a/coral-schema/src/test/resources/testProjectUdfReturnedStruct-expected.avsc
+++ b/coral-schema/src/test/resources/testProjectUdfReturnedStruct-expected.avsc
@@ -13,10 +13,10 @@
       "namespace" : "default.foo_udf_return_struct.foo_udf_return_struct",
       "fields" : [ {
         "name" : "isEven",
-        "type" : "boolean"
+        "type" : [ "null", "boolean" ]
       }, {
         "name" : "number",
-        "type" : "int"
+        "type" : [ "null", "int" ]
       } ]
     },
     "doc" : "Field created in view by applying UDF 'com.linkedin.coral.hive.hive2rel.CoralTestUDFReturnStruct' with argument(s): coral.schema.avro.base.complex.basecomplex.Id"


### PR DESCRIPTION
## Change Summary
At present, we are using `RelDataType.isNullable()` to determine if an inner field should be nullable or not while converting `RelDataType` to Avro schema, but Spark expects all the inner fields created by operator to be nullable. This PR is to make Coral-Schema return nullable schema for inner fields created by operator to be aligned with Spark's expectation.

## Tests
1. Modified UTs, these changed fields are created by operator, they are nullable now with this PR
2. Regression test on all the prod views, no translation regression
3. Tested on the affected prod views, can be queried on Spark shell with this PR