### PR TITLE
[Coral-Service] Exclude 'org.apache.calcite' from 'org.apache.hive:hive-exec'

### DIFF
--- a/coral-service/build.gradle
+++ b/coral-service/build.gradle
@@ -28,7 +28,9 @@ dependencies {
   implementation project(':coral-trino')
   implementation project(':coral-spark')
 
-  implementation 'org.apache.hive:hive-exec:1.2.2:core'
+  implementation('org.apache.hive:hive-exec:1.2.2:core') {
+    exclude group: 'org.apache.calcite', module: 'calcite-core'
+  }
   implementation 'org.apache.hadoop:hadoop-mapreduce-client-core:2.7.0'
   implementation 'org.springframework.boot:spring-boot-starter-web'
   implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:

  1. If you're new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you've added or executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
-->


### What changes are proposed in this pull request, and why are they necessary?
<!--
Kindly explain the proposed changes in this section. The goal is to outline the modifications and how this PR addresses the issue.
Also, clarify the reasons for these changes. For example,
  1. If a new API is proposed, explain the intended use case.
  2. If a bug is being fixed, describe why it's a bug.
  3. If design documentation is available, please include the link.
-->
This PR excludes unnecessary 'org.apache.calcite' from 'org.apache.hive:hive-exec' to avoid the following GitHub build issue:
```
Execution failed for task ':coral-service:compileJava'.
> Could not resolve all files for configuration ':coral-service:compileClasspath'.
   > Could not resolve org.pentaho:pentaho-aggdesigner-algorithm:5.1.5-jhyde.
     Required by:
         project :coral-service > org.apache.hive:hive-exec:1.2.2 > org.apache.calcite:calcite-core:1.2.0-incubating
      > Could not resolve org.pentaho:pentaho-aggdesigner-algorithm:5.1.5-jhyde.
         > Could not get resource 'https://linkedin.bintray.com/maven/org/pentaho/pentaho-aggdesigner-algorithm/5.1.5-jhyde/pentaho-aggdesigner-algorithm-5.1.5-jhyde.pom'.
            > Could not GET 'https://linkedin.bintray.com/maven/org/pentaho/pentaho-aggdesigner-algorithm/5.1.5-jhyde/pentaho-aggdesigner-algorithm-5.1.5-jhyde.pom'.
               > Certificate for <linkedin.bintray.com> doesn't match any of the subject alternative names: [*.jfrog.io, *.int.jfrog.io, jfrog.io, *.pe.jfrog.io]
      > Skipped due to earlier error
```

### How was this patch tested?
<!--
Please describe all the tests conducted.
If new unit tests were included, mention that they were added in this section. Make sure to add test cases that thoroughly examine both negative and positive cases, if possible.
If the testing approach differed from regular unit tests (e.g., regression testing), please explain how it was conducted.
If no tests were added, please explain why they were not included and/or why it was difficult to add them.
-->
1. This PR's GitHub build succeeded
2. Tested Coral-Service local mode, no issue found