### PR TITLE
[Coral-Trino] Migrate 'adjustReturnTypeWithCast' transformation from RelNode to SqlNode layer

### DIFF
--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CoralToTrinoSqlCallConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CoralToTrinoSqlCallConverter.java
@@ -28,6 +28,7 @@ import com.linkedin.coral.trino.rel2trino.transformers.CoralRegistryOperatorRena
 import com.linkedin.coral.trino.rel2trino.transformers.CurrentTimestampTransformer;
 import com.linkedin.coral.trino.rel2trino.transformers.GenericCoralRegistryOperatorRenameSqlCallTransformer;
 import com.linkedin.coral.trino.rel2trino.transformers.MapValueConstructorTransformer;
+import com.linkedin.coral.trino.rel2trino.transformers.ReturnTypeAdjustmentTransformer;
 import com.linkedin.coral.trino.rel2trino.transformers.ToDateOperatorTransformer;
 
 import static com.linkedin.coral.trino.rel2trino.CoralTrinoConfigKeys.*;
@@ -116,7 +117,9 @@ public class CoralToTrinoSqlCallConverter extends SqlShuttle {
             "com.linkedin.stdudfs.urnextractor.hive.UrnExtractorFunctionWrapper", 1, "urn_extractor"),
         new CoralRegistryOperatorRenameSqlCallTransformer(
             "com.linkedin.stdudfs.hive.daliudfs.UrnExtractorFunctionWrapper", 1, "urn_extractor"),
-        new GenericCoralRegistryOperatorRenameSqlCallTransformer());
+        new GenericCoralRegistryOperatorRenameSqlCallTransformer(),
+
+        new ReturnTypeAdjustmentTransformer(configs));
   }
 
   private SqlOperator hiveToCoralSqlOperator(String functionName) {

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/ReturnTypeAdjustmentTransformer.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/ReturnTypeAdjustmentTransformer.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2023 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.trino.rel2trino.transformers;
+
+import java.util.Locale;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.apache.calcite.sql.SqlBasicTypeNameSpec;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlDataTypeSpec;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+import com.linkedin.coral.common.transformers.SqlCallTransformer;
+
+import static com.linkedin.coral.trino.rel2trino.CoralTrinoConfigKeys.*;
+
+
+/**
+ * This class adjusts the return types of certain functions to ensure compatibility with Trino.
+ * It casts the result of the transformed call to the same return type as in Hive for certain versions.
+ *
+ * Example:
+ *  DATEDIFF function in Hive returns int type, but the corresponding function DATE_DIFF in Trino
+ *  returns bigint type. To ensure compatibility, a CAST is added to convert the result to the int type.
+ */
+public class ReturnTypeAdjustmentTransformer extends SqlCallTransformer {
+
+  private static final Map<String, SqlTypeName> OPERATORS_TO_ADJUST = ImmutableMap.<String, SqlTypeName> builder()
+      .put("date_diff", SqlTypeName.INTEGER).put("cardinality", SqlTypeName.INTEGER).put("ceil", SqlTypeName.BIGINT)
+      .put("ceiling", SqlTypeName.BIGINT).put("floor", SqlTypeName.BIGINT).put("date_add", SqlTypeName.VARCHAR).build();
+  private final Map<String, Boolean> configs;
+
+  public ReturnTypeAdjustmentTransformer(Map<String, Boolean> configs) {
+    this.configs = configs;
+  }
+
+  @Override
+  protected boolean condition(SqlCall sqlCall) {
+    String lowercaseOperatorName = sqlCall.getOperator().getName().toLowerCase(Locale.ROOT);
+    if ("date_add".equals(lowercaseOperatorName) && !configs.getOrDefault(CAST_DATEADD_TO_STRING, false)) {
+      return false;
+    }
+    return OPERATORS_TO_ADJUST.containsKey(lowercaseOperatorName);
+  }
+
+  @Override
+  protected SqlCall transform(SqlCall sqlCall) {
+    String lowercaseOperatorName = sqlCall.getOperator().getName().toLowerCase(Locale.ROOT);
+    SqlTypeName targetType = OPERATORS_TO_ADJUST.get(lowercaseOperatorName);
+    if (targetType != null) {
+      return createCast(sqlCall, targetType);
+    }
+    return sqlCall;
+  }
+
+  private SqlCall createCast(SqlNode node, SqlTypeName typeName) {
+    SqlDataTypeSpec targetTypeNode =
+        new SqlDataTypeSpec(new SqlBasicTypeNameSpec(typeName, SqlParserPos.ZERO), SqlParserPos.ZERO);
+    return SqlStdOperatorTable.CAST.createCall(SqlParserPos.ZERO, node, targetTypeNode);
+  }
+}

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/ReturnTypeAdjustmentTransformer.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/ReturnTypeAdjustmentTransformer.java
@@ -24,12 +24,11 @@ import static com.linkedin.coral.trino.rel2trino.CoralTrinoConfigKeys.*;
 
 
 /**
- * This class adjusts the return types of certain functions to ensure compatibility with Trino.
- * It casts the result of the transformed call to the same return type as in Hive for certain versions.
+ * This transformer casts the result of some Trino functions to the same return type as in Hive.
  *
  * Example:
- *  DATEDIFF function in Hive returns int type, but the corresponding function DATE_DIFF in Trino
- *  returns bigint type. To ensure compatibility, a CAST is added to convert the result to the int type.
+ *  "DATEDIFF" function in Hive returns int type, but the corresponding function "DATE_DIFF" in Trino
+ *  returns bigint type. To ensure compatibility, a "CAST" is added to convert the result to the int type.
  */
 public class ReturnTypeAdjustmentTransformer extends SqlCallTransformer {
 

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -124,7 +124,7 @@ public class HiveToTrinoConverterTest {
 
         { "test", "view_with_outer_explode_struct_array", "SELECT \"$cor0\".\"a\" AS \"a\", \"t0\".\"c\" AS \"c\"\n"
             + "FROM \"test\".\"table_with_struct_array\" AS \"$cor0\"\n"
-            + "CROSS JOIN UNNEST(TRANSFORM(\"if\"(\"$cor0\".\"b\" IS NOT NULL AND CAST(CARDINALITY(\"$cor0\".\"b\") AS INTEGER) > 0, \"$cor0\".\"b\", ARRAY[NULL]), x -> ROW(x))) AS \"t0\" (\"c\")" },
+            + "CROSS JOIN UNNEST(TRANSFORM(\"if\"(\"$cor0\".\"b\" IS NOT NULL AND CARDINALITY(\"$cor0\".\"b\") > 0, \"$cor0\".\"b\", ARRAY[NULL]), x -> ROW(x))) AS \"t0\" (\"c\")" },
 
         { "test", "view_with_explode_map", "SELECT \"$cor0\".\"a\" AS \"a\", \"t0\".\"c\" AS \"c\", \"t0\".\"d\" AS \"d\"\n"
             + "FROM \"test\".\"table_with_map\" AS \"$cor0\"\n"
@@ -546,7 +546,7 @@ public class HiveToTrinoConverterTest {
     RelNode relNode = hiveToRelConverter.convertSql(
         "SELECT date_add('2021-08-20', 1), date_add('2021-08-20 00:00:00', 1), date_sub('2021-08-20', 1), date_sub('2021-08-20 00:00:00', 1)");
     String targetSql =
-        "SELECT CAST(\"date_add\"('day', 1, \"date\"(CAST('2021-08-20' AS TIMESTAMP))) AS VARCHAR(65535)), CAST(\"date_add\"('day', 1, \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP))) AS VARCHAR(65535)), CAST(\"date_add\"('day', 1 * -1, \"date\"(CAST('2021-08-20' AS TIMESTAMP))) AS VARCHAR(65535)), CAST(\"date_add\"('day', 1 * -1, \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP))) AS VARCHAR(65535))\n"
+        "SELECT CAST(\"date_add\"('day', 1, \"date\"(CAST('2021-08-20' AS TIMESTAMP))) AS VARCHAR), CAST(\"date_add\"('day', 1, \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP))) AS VARCHAR), CAST(\"date_add\"('day', 1 * -1, \"date\"(CAST('2021-08-20' AS TIMESTAMP))) AS VARCHAR), CAST(\"date_add\"('day', 1 * -1, \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP))) AS VARCHAR)\n"
             + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:
  1. If you are new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you have added and executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
  7. Make sure that the command './gradlew clean build' passes. Resolve any formatting errors by running './gradlew spotlessApply'.
-->

### What changes are proposed in this pull request, and why are they necessary?
<!--
Kindly explain the proposed changes in this section. The goal is to outline the modifications and how this PR addresses the issue. Also, clarify the reasons for these changes. For example,
  1. If a new API is proposed, explain the intended use case.
  2. If a bug is being fixed, describe why it is a bug.
  3. If design documentation is available, please include the link.
-->
This PR migrates 'adjustReturnTypeWithCast' transformation from RelNode to SqlNode layer.

### How was this patch tested?
<!--
Please describe all the tests conducted.
If new unit tests were included, mention that they were added in this section. Make sure to add test cases that thoroughly examine both negative and positive cases, if possible.
If the testing approach differed from regular unit tests (e.g., regression testing), please explain how it was conducted.
If no tests were added, please explain why they were not included and/or why it was difficult to add them.
-->
1. Existing UTs which covers the change, made 2 changes:
- Removed `CAST` in `TRANSFORM(\"if\"(\"$cor0\".\"b\" IS NOT NULL AND CAST(CARDINALITY(\"$cor0\".\"b\") AS INTEGER) > 0, \"$cor0\".\"b\", ARRAY[NULL]), x -> ROW(x)))`, because current `RelToTrinoConverter` uses SqlLiteral for [transform wrapper](https://github.com/linkedin/coral/blob/master/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java#L194), then `SqlCallTransformer` can't transform `CARDINALITY` in that SqlLiteral. But it's fine because we add `CAST` to make selected field types align between Hive and Trino, `CARDINALITY` here is generated by Coral without appearing in the selected fields, so it will not affect the view queries on Trino
- Modified `VARCHAR(65535)` to `VARCHAR`, it's fine because [the max length of VARCHAR is optional in Trino](https://trino.io/docs/current/language/types.html#varchar)
2. Regression test on all the production views, no regression after verification
