### PR TITLE
Upgradle calcite to v1.21.0.160

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -8,7 +8,7 @@ def versions = [
   'jetbrains': '16.0.2',
   'jline': '0.9.94',
   'kryo': '2.22',
-  'linkedin-calcite-core': '1.21.0.153',
+  'linkedin-calcite-core': '1.21.0.160',
   'pig': '0.15.0',
   'spark': '2.4.0',
   'spark3': '3.1.1',


### PR DESCRIPTION
### What changes are proposed in this pull request, and why are they necessary?
Upgrading calcite to v1.21.0.160 to include calcite bug fix - https://github.com/linkedin/linkedin-calcite/pull/86.

Consider table:
`tablea: [b: struct<b1:string>]`

previously the following SQL could not be translated to RelNode representation:
`SELECT talias.b.b1 AS tmp FROM (SELECT tablea.b FROM tablea) AS talias`

It would fail with the Exception:
`Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: -1 at java.util.ArrayList.elementData(ArrayList.java:424) at java.util.ArrayList.get(ArrayList.java:437) at org.apache.calcite.sql.validate.SelectNamespace.getMonotonicity(SelectNamespace.java:73) at org.apache.calcite.sql.SqlIdentifier.getMonotonicity(SqlIdentifier.java:371) at org.apache.calcite.sql.SqlCallBinding.getOperandMonotonicity(SqlCallBinding.java:188) at org.apache.calcite.sql.SqlAsOperator.getMonotonicity(SqlAsOperator.java:139) at org.apache.calcite.sql.SqlCall.getMonotonicity(SqlCall.java:182) at org.apache.calcite.sql2rel.SqlToRelConverter.convertSelectList(SqlToRelConverter.java:3962) at org.apache.calcite.sql2rel.SqlToRelConverter.convertSelectImpl(SqlToRelConverter.java:670) at org.apache.calcite.sql2rel.SqlToRelConverter.convertSelect(SqlToRelConverter.java:627) at org.apache.calcite.sql2rel.SqlToRelConverter.convertQueryRecursive(SqlToRelConverter.java:3181) `

Field `b1` couldn't be discovered as it is a subfield inside struct `b`.

now it is successfully translated.

### How was this patch tested?
`./gradlew clean build`
Unit tests
Tested against production views.
Verified there's no regression for hive SQL -> spark SQL, hive SQL -> trino SQL, hive SQL -> avro schema translations paths. 
