### PR TITLE
[Coral-Common] Modify return type of operator "/"

### DIFF
--- a/coral-common/src/main/java/com/linkedin/coral/common/HiveTypeSystem.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/HiveTypeSystem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2023 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -159,6 +159,15 @@ public class HiveTypeSystem extends RelDataTypeSystemImpl {
   @Override
   public boolean isSchemaCaseSensitive() {
     return false;
+  }
+
+  /**
+   * This method needs to be overridden to make sure that the "/" operator returns
+   * {@link org.apache.calcite.sql.type.ReturnTypes#DOUBLE}, which is compatible with the expected data type in Hive/Spark.
+   */
+  @Override
+  public RelDataType deriveDecimalDivideType(RelDataTypeFactory typeFactory, RelDataType type1, RelDataType type2) {
+    return nullableType(typeFactory, SqlTypeName.DOUBLE);
   }
 
   private RelDataType nullableType(RelDataTypeFactory typeFactory, SqlTypeName typeName) {

--- a/coral-common/src/main/java/com/linkedin/coral/common/HiveTypeSystem.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/HiveTypeSystem.java
@@ -9,6 +9,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeSystemImpl;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeUtil;
 
 
 // Copied from Hive source code
@@ -162,12 +163,16 @@ public class HiveTypeSystem extends RelDataTypeSystemImpl {
   }
 
   /**
-   * This method needs to be overridden to make sure that the "/" operator returns
-   * {@link org.apache.calcite.sql.type.ReturnTypes#DOUBLE}, which is compatible with the expected data type in Hive/Spark.
+   * This method needs to be overridden to make sure that the "/" operator returns {@link org.apache.calcite.sql.type.ReturnTypes#DOUBLE}
+   * if neither of the operands is decimal type, which is compatible with the expected data type in Hive/Spark.
    */
   @Override
   public RelDataType deriveDecimalDivideType(RelDataTypeFactory typeFactory, RelDataType type1, RelDataType type2) {
-    return nullableType(typeFactory, SqlTypeName.DOUBLE);
+    if (SqlTypeUtil.isDecimal(type1) || SqlTypeUtil.isDecimal(type2)) {
+      return super.deriveDecimalDivideType(typeFactory, type1, type2);
+    } else {
+      return nullableType(typeFactory, SqlTypeName.DOUBLE);
+    }
   }
 
   private RelDataType nullableType(RelDataTypeFactory typeFactory, SqlTypeName typeName) {

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -1078,5 +1078,16 @@ public class ViewToAvroSchemaConverterTests {
         TestUtils.loadSchema("testUnionFloatAndDoublePromoteToDouble-expected.avsc"));
   }
 
+  @Test
+  public void testDivideReturnType() {
+    String viewSql = "CREATE VIEW v AS SELECT 1/2 AS a FROM baseprimitive";
+    TestUtils.executeCreateViewQuery("default", "v", viewSql);
+
+    ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);
+    Schema actualSchema = viewToAvroSchemaConverter.toAvroSchema("default", "v");
+
+    Assert.assertEquals(actualSchema.toString(true), TestUtils.loadSchema("testDivideReturnType-expected.avsc"));
+  }
+
   // TODO: add more unit tests
 }

--- a/coral-schema/src/test/resources/testDivideReturnType-expected.avsc
+++ b/coral-schema/src/test/resources/testDivideReturnType-expected.avsc
@@ -1,0 +1,10 @@
+{
+  "type" : "record",
+  "name" : "v",
+  "namespace" : "default.v",
+  "fields" : [ {
+    "name" : "a",
+    "type" : [ "null", "double" ],
+    "doc" : "Field created in view by applying operator '/' with argument(s): 1, 2"
+  } ]
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:
  1. If you are new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you have added and executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
  7. Make sure that the command './gradlew clean build' passes. Resolve any formatting errors by running './gradlew spotlessApply'.
-->

### What changes are proposed in this pull request, and why are they necessary?
<!--
Kindly explain the proposed changes in this section. The goal is to outline the modifications and how this PR addresses the issue. Also, clarify the reasons for these changes. For example,
  1. If a new API is proposed, explain the intended use case.
  2. If a bug is being fixed, describe why it is a bug.
  3. If design documentation is available, please include the link.
-->
This PR overrides the return type of operator `/` to `DOUBLE`.

We need to correct the return type of `/` to fix the type mismatch issue uncovered by #394. Because with #394, Coral RelNode won’t be generated with `CAST` to the intermediate view’s schema. Check #394 for more details.

Consider the following example:
```
CREATE OR REPLACE VIEW v1 AS SELECT 1/2 AS a;
CREATE OR REPLACE VIEW v2 AS SELECT * FROM v1;
```
Both v1’s and v2’s Hive schema are `(a double)`, but if we query v2 on Spark, it will fail without this PR.
Because for input SQL `SELECT 1/2`, the Calcite-generated RelNode type is `INT` rather than `DOUBLE`, then Coral schema type is also `INT`, which is different from the Spark analyzed type `DOUBLE`. Then Spark will try to upcast `DOUBLE` to `INT` but fails. So we need this PR to ensure `SELECT 1/2`'s schema to be `DOUBLE`.

### How was this patch tested?
<!--
Please describe all the tests conducted.
If new unit tests were included, mention that they were added in this section. Make sure to add test cases that thoroughly examine both negative and positive cases, if possible.
If the testing approach differed from regular unit tests (e.g., regression testing), please explain how it was conducted.
If no tests were added, please explain why they were not included and/or why it was difficult to add them.
-->
1. New unit test. Without this change, return type of `SELECT 1/2` is `INT` rather than `DOUBLE`
2. Regression test on all the production views