### PR TITLE
Generate Coral's RelNode for views from base table schema

### DIFF
--- a/coral-common/src/main/java/com/linkedin/coral/common/HiveViewTable.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/HiveViewTable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2023 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -50,7 +50,7 @@ public class HiveViewTable extends HiveTable implements TranslatableTable {
     try {
       RelRoot root = relContext.expandView(relOptTable.getRowType(), hiveTable.getViewExpandedText(), schemaPath,
           ImmutableList.of(hiveTable.getTableName()));
-      root = root.withRel(createCastRel(root.rel, relOptTable.getRowType(), RelFactories.DEFAULT_PROJECT_FACTORY));
+      //      root = root.withRel(createCastRel(root.rel, relOptTable.getRowType(), RelFactories.DEFAULT_PROJECT_FACTORY));
       //root = root.withRel(RelOptUtil.createCastRel(root.rel, relOptTable.getRowType()));
       return root.rel;
     } catch (Exception e) {

--- a/coral-common/src/main/java/com/linkedin/coral/common/HiveViewTable.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/HiveViewTable.java
@@ -10,17 +10,9 @@ import java.util.List;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelRoot;
-import org.apache.calcite.rel.core.RelFactories;
-import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeFactory;
-import org.apache.calcite.rel.type.RelDataTypeField;
-import org.apache.calcite.rex.RexBuilder;
-import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.schema.TranslatableTable;
 import org.apache.hadoop.hive.metastore.api.Table;
 
-import com.linkedin.coral.com.google.common.base.Preconditions;
 import com.linkedin.coral.com.google.common.base.Throwables;
 import com.linkedin.coral.com.google.common.collect.ImmutableList;
 
@@ -50,129 +42,10 @@ public class HiveViewTable extends HiveTable implements TranslatableTable {
     try {
       RelRoot root = relContext.expandView(relOptTable.getRowType(), hiveTable.getViewExpandedText(), schemaPath,
           ImmutableList.of(hiveTable.getTableName()));
-      //      root = root.withRel(createCastRel(root.rel, relOptTable.getRowType(), RelFactories.DEFAULT_PROJECT_FACTORY));
-      //root = root.withRel(RelOptUtil.createCastRel(root.rel, relOptTable.getRowType()));
       return root.rel;
     } catch (Exception e) {
       Throwables.propagateIfInstanceOf(e, RuntimeException.class);
       throw new RuntimeException("Error while parsing view definition", e);
     }
-  }
-
-  public static RelNode createCastRel(final RelNode rel, RelDataType castRowType,
-      RelFactories.ProjectFactory projectFactory) {
-    Preconditions.checkNotNull(projectFactory);
-
-    RelDataType rowType = rel.getRowType();
-    RelDataTypeFactory typeFactory = rel.getCluster().getTypeFactory();
-    if (isRowCastRequired(rowType, castRowType, typeFactory)) {
-      final RexBuilder rexBuilder = rel.getCluster().getRexBuilder();
-      final List<RexNode> castExps = RexUtil.generateCastExpressions(rexBuilder, castRowType, rowType);
-      return projectFactory.createProject(rel, castExps, rowType.getFieldNames());
-    } else {
-      return rel;
-    }
-  }
-
-  // Hive-based Dali readers allow extra fields on struct type columns to flow through. We
-  // try to match that behavior. Hive-based Dali readers do not allow top level columns to flow through
-  // Returns true if an explicit cast is required from rowType to castRowType, false otherwise
-  private static boolean isRowCastRequired(RelDataType rowType, RelDataType castRowType,
-      RelDataTypeFactory typeFactory) {
-    if (rowType == castRowType) {
-      return false;
-    }
-    List<RelDataTypeField> relFields = rowType.getFieldList();
-    List<RelDataTypeField> castFields = castRowType.getFieldList();
-    if (relFields.size() != castFields.size()) {
-      return true;
-    }
-    // the following method will return false if the schema evolution is backward compatible.
-    // i.e., when new fields are inserted to the middle or appended to the end of the field list.
-    return isFieldListCastRequired(relFields, castFields, typeFactory);
-  }
-
-  // Returns true if an explicit cast is required from inputType to castToType, false otherwise
-  // From what we noticed, cast will be required when there's schema promotion
-  private static boolean isTypeCastRequired(RelDataType inputType, RelDataType castToType,
-      RelDataTypeFactory typeFactory) {
-    if (inputType == castToType) {
-      return false;
-    }
-    if (inputType.getSqlTypeName() == ANY || castToType.getSqlTypeName() == ANY) {
-      return false;
-    }
-    // Hive has string type which is varchar(65k). This results in lot of redundant
-    // cast operations due to different precision(length) of varchar.
-    // Also, all projections of string literals are of type CHAR but the hive schema
-    // may mark that column as string. This again results in unnecessary cast operations.
-    // We avoid all these casts
-    if ((inputType.getSqlTypeName() == CHAR || inputType.getSqlTypeName() == VARCHAR)
-        && castToType.getSqlTypeName() == VARCHAR) {
-      return false;
-    }
-
-    // Make sure both source and target has same root SQL Type
-    if (inputType.getSqlTypeName() != castToType.getSqlTypeName()) {
-      return true;
-    }
-
-    // Calcite gets the castToType from the view schema, and it's nullable by default, but the inputType
-    // is inferred from the view sql and for some columns where functions like named_strcut, ISNULL are applied,
-    // calcite will set the inputType to be non-nullable. Thus it generates unnecessary cast operators.
-    // we should ignore the nullability check when deciding whether to do field casting
-    RelDataType nullableFieldDataType = typeFactory.createTypeWithNullability(inputType, true);
-    switch (inputType.getSqlTypeName()) {
-      case ARRAY:
-        return isTypeCastRequired(inputType.getComponentType(), castToType.getComponentType(), typeFactory);
-      case MAP:
-        return isTypeCastRequired(inputType.getKeyType(), castToType.getKeyType(), typeFactory)
-            || isTypeCastRequired(inputType.getValueType(), inputType.getValueType(), typeFactory);
-      case ROW:
-        return isFieldListCastRequired(inputType.getFieldList(), castToType.getFieldList(), typeFactory);
-      default:
-        return !nullableFieldDataType.equals(castToType);
-    }
-  }
-
-  /**
-   * The method will check if the inputFields has to be casted to castToFields.
-   *
-   * e.g.
-   * (1) if castToFields = List(f1, f3), inputFields = List(f1, f2, f3), then return false.
-   * (2) if castToFields = List(f1, f3), inputFields = List(f1, f3, f4), then return false.
-   * (3) if castToFields = List(f1, f3), inputFields = List(f1, f4), then return true.
-   *
-   * @param inputFields a list of RelDataTypeField to cast from if required.
-   * @param castToFields a list of RelDataTypeField to cast to if required.
-   *
-   * @return if a CAST operator will be generated from inputFields to castToFields
-   */
-  private static boolean isFieldListCastRequired(List<RelDataTypeField> inputFields,
-      List<RelDataTypeField> castToFields, RelDataTypeFactory typeFactory) {
-    if (inputFields.size() < castToFields.size()) {
-      return true;
-    }
-
-    int inputIndex = 0;
-    int inputFieldsSize = inputFields.size();
-    for (RelDataTypeField castToField : castToFields) {
-      while (inputIndex < inputFieldsSize) {
-        RelDataTypeField inputField = inputFields.get(inputIndex);
-        if (inputField.getName().equalsIgnoreCase(castToField.getName())) {
-          if (isTypeCastRequired(inputField.getType(), castToField.getType(), typeFactory)) {
-            return true;
-          }
-          break;
-        } else {
-          ++inputIndex;
-        }
-      }
-      // If there's no match for a field in castToFields to inputFields
-      if (inputIndex++ >= inputFieldsSize) {
-        return true;
-      }
-    }
-    return false;
   }
 }

--- a/coral-common/src/main/java/com/linkedin/coral/common/TypeConverter.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/TypeConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2022 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2023 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-common/src/main/java/com/linkedin/coral/common/TypeConverter.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/TypeConverter.java
@@ -146,6 +146,9 @@ public class TypeConverter {
   public static RelDataType convert(UnionTypeInfo unionType, RelDataTypeFactory dtFactory) {
     List<RelDataType> fTypes = unionType.getAllUnionObjectTypeInfos().stream()
         .map(typeInfo -> convert(typeInfo, dtFactory)).collect(Collectors.toList());
+    if (fTypes.size() == 1) {
+      return dtFactory.createTypeWithNullability(fTypes.get(0), true);
+    }
     List<String> fNames = IntStream.range(0, unionType.getAllUnionObjectTypeInfos().size()).mapToObj(i -> "field" + i)
         .collect(Collectors.toList());
     fTypes.add(0, dtFactory.createSqlType(SqlTypeName.INTEGER));

--- a/coral-common/src/main/java/com/linkedin/coral/common/TypeConverter.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/TypeConverter.java
@@ -140,6 +140,7 @@ public class TypeConverter {
   // The schema of output Struct conforms to https://github.com/trinodb/trino/pull/3483
   // except we adopted "integer" for the type of "tag" field instead of "tinyint" in the Trino patch
   // for compatibility with other platforms that Iceberg currently doesn't support tinyint type.
+  // When the field count inside UnionTypeInfo is one, we surface the underlying RelDataType instead.
 
   // Note: this is subject to change in the future pending on the discussion in
   // https://mail-archives.apache.org/mod_mbox/iceberg-dev/202112.mbox/browser

--- a/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionFieldReferenceOperator.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionFieldReferenceOperator.java
@@ -75,22 +75,14 @@ public class FunctionFieldReferenceOperator extends SqlBinaryOperator {
         return funcType.getField(fieldNameStripQuotes(call.operand(1)), false, false).getType();
       }
 
+      // When the first operand is a SqlBasicCall with a non-struct RelDataType and the second operand is `tag_0`,
+      // such as `extract_union`(`product`.`value`).`tag_0` or (`extract_union`(`product`.`value`).`id`).`tag_0`,
+      // derived data type is first operand's RelDataType.
+      // This strategy ensures that RelDataType derivation remains successful for the specified sqlCalls while maintaining backward compatibility.
+      // Such SqlCalls are transformed {@link com.linkedin.coral.transformers.SingleUnionFieldReferenceTransformer}
       if (FunctionFieldReferenceOperator.fieldNameStripQuotes(call.operand(1)).equalsIgnoreCase("tag_0")) {
         return funcType;
       }
-
-      // weed out (`extract_union`(`product`.`value`).`productcategoryurns`).`tag_0`
-      // when productcategoryurns is a single type union
-      //      SqlBasicCall outerSqlBasicCall = (SqlBasicCall) firstOperand;
-      //
-      //      if (outerSqlBasicCall.operand(0) instanceof SqlBasicCall) {
-      //        SqlBasicCall innerSqlBasicCall = outerSqlBasicCall.operand(0);
-      //        if (innerSqlBasicCall.getOperator().getName().equalsIgnoreCase("extract_union")
-      //            && fieldNameStripQuotes(call.operand(1)).equalsIgnoreCase("tag_0")) {
-      //          return funcType;
-      //        }
-      //
-      //      }
     }
     return super.deriveType(validator, scope, call);
   }

--- a/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionFieldReferenceOperator.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionFieldReferenceOperator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2023 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -74,6 +74,23 @@ public class FunctionFieldReferenceOperator extends SqlBinaryOperator {
       if (funcType.isStruct()) {
         return funcType.getField(fieldNameStripQuotes(call.operand(1)), false, false).getType();
       }
+
+      if (FunctionFieldReferenceOperator.fieldNameStripQuotes(call.operand(1)).equalsIgnoreCase("tag_0")) {
+        return funcType;
+      }
+
+      // weed out (`extract_union`(`product`.`value`).`productcategoryurns`).`tag_0`
+      // when productcategoryurns is a single type union
+      //      SqlBasicCall outerSqlBasicCall = (SqlBasicCall) firstOperand;
+      //
+      //      if (outerSqlBasicCall.operand(0) instanceof SqlBasicCall) {
+      //        SqlBasicCall innerSqlBasicCall = outerSqlBasicCall.operand(0);
+      //        if (innerSqlBasicCall.getOperator().getName().equalsIgnoreCase("extract_union")
+      //            && fieldNameStripQuotes(call.operand(1)).equalsIgnoreCase("tag_0")) {
+      //          return funcType;
+      //        }
+      //
+      //      }
     }
     return super.deriveType(validator, scope, call);
   }

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveSqlNodeToCoralSqlNodeConverter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveSqlNodeToCoralSqlNodeConverter.java
@@ -12,6 +12,7 @@ import org.apache.calcite.sql.validate.SqlValidator;
 
 import com.linkedin.coral.common.transformers.SqlCallTransformers;
 import com.linkedin.coral.transformers.ShiftArrayIndexTransformer;
+import com.linkedin.coral.transformers.SingleUnionFieldReferenceTransformer;
 
 
 /**
@@ -21,7 +22,8 @@ public class HiveSqlNodeToCoralSqlNodeConverter extends SqlShuttle {
   private final SqlCallTransformers operatorTransformerList;
 
   public HiveSqlNodeToCoralSqlNodeConverter(SqlValidator sqlValidator) {
-    operatorTransformerList = SqlCallTransformers.of(new ShiftArrayIndexTransformer(sqlValidator));
+    operatorTransformerList = SqlCallTransformers.of(new ShiftArrayIndexTransformer(sqlValidator),
+        new SingleUnionFieldReferenceTransformer(sqlValidator));
   }
 
   @Override

--- a/coral-hive/src/main/java/com/linkedin/coral/transformers/SingleUnionFieldReferenceTransformer.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/transformers/SingleUnionFieldReferenceTransformer.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2023 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.transformers;
+
+import org.apache.calcite.sql.SqlBasicCall;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.validate.SqlValidator;
+
+import com.linkedin.coral.common.functions.FunctionFieldReferenceOperator;
+import com.linkedin.coral.common.transformers.SqlCallTransformer;
+
+
+public class SingleUnionFieldReferenceTransformer extends SqlCallTransformer {
+
+  public SingleUnionFieldReferenceTransformer(SqlValidator sqlValidator) {
+    super(sqlValidator);
+  }
+
+  @Override
+  protected boolean condition(SqlCall sqlCall) {
+    // weed out (`extract_union`(`product`.`value`).`productcategoryurns`).`tag_0`
+    // when productcategoryurns is a single type union
+    // weed out `extract_union`(`product`.`value`).`tag_0`
+    if (FunctionFieldReferenceOperator.DOT.getName().equalsIgnoreCase(sqlCall.getOperator().getName())) {
+      SqlNode firstOperand = sqlCall.operand(0);
+      if (firstOperand instanceof SqlBasicCall) {
+
+        // `extract_union`(`product`.`value`).`productcategoryurns` or (`extract_union`(`product`.`value`).`productcategoryurns`).`tag_0`
+        SqlBasicCall outerSqlBasicCall = (SqlBasicCall) firstOperand;
+        boolean isOperandStruct = getRelDataType(outerSqlBasicCall).isStruct();
+
+        if (!isOperandStruct
+            && FunctionFieldReferenceOperator.fieldNameStripQuotes(sqlCall.operand(1)).equalsIgnoreCase("tag_0")) {
+          return true;
+        }
+
+        // `extract_union`(`product`.`value`) = innerSqlBasicCall
+        //        if (outerSqlBasicCall.operand(0) instanceof SqlBasicCall) {
+        //          SqlBasicCall innerSqlBasicCall = outerSqlBasicCall.operand(0);
+        //          if (innerSqlBasicCall.getOperator().getName().equalsIgnoreCase("extract_union")
+        //              && FunctionFieldReferenceOperator.fieldNameStripQuotes(sqlCall.operand(1)).equalsIgnoreCase("tag_0")
+        //              && !getRelDataType(outerSqlBasicCall).isStruct() ) {
+        //            return true;
+        //          }
+        //        }
+      }
+    }
+    return false;
+  }
+
+  @Override
+  protected SqlCall transform(SqlCall sqlCall) {
+    // convert (`extract_union`(`product`.`value`).`productcategoryurns`).`tag_0`
+    // to `extract_union`(`product`.`value`).`productcategoryurns`
+
+    // convert x.y -> x where x is a sqlBasicCall
+
+    return sqlCall.operand(0);
+  }
+}

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
@@ -65,6 +65,10 @@ class RelDataTypeToAvroType {
 
     if (relDataType instanceof MapSqlType) {
       final MapSqlType mapSqlType = (MapSqlType) relDataType;
+      if (SqlTypeName.NULL == mapSqlType.getKeyType().getSqlTypeName()
+          && SqlTypeName.NULL == mapSqlType.getValueType().getSqlTypeName()) {
+        return Schema.createMap(SchemaUtilities.makeNullable(Schema.create(Schema.Type.STRING), false));
+      }
       if (!SqlTypeName.CHAR_TYPES.contains(mapSqlType.getKeyType().getSqlTypeName())) {
         throw new UnsupportedOperationException(
             "Key of Map can only be a String: " + mapSqlType.getKeyType().getSqlTypeName().getName());

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -393,8 +393,7 @@ public class CoralSparkTest {
   @Test
   public void testSchemaPromotionView() {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT * ", "FROM view_schema_promotion_wrapper"));
-    String targetSql = "SELECT schema_promotion.a, CAST(schema_promotion.b AS ARRAY<INTEGER>) b\n"
-        + "FROM default.schema_promotion schema_promotion";
+    String targetSql = "SELECT *\n" + "FROM default.schema_promotion schema_promotion";
     assertEquals(CoralSpark.create(relNode).getSparkSql(), targetSql);
   }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:
  1. If you are new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you have added and executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
  7. Make sure that the command './gradlew clean build' passes. Resolve any formatting errors by running './gradlew spotlessApply'.
-->

### What changes are proposed in this pull request, and why are they necessary?
<!--
Kindly explain the proposed changes in this section. The goal is to outline the modifications and how this PR addresses the issue. Also, clarify the reasons for these changes. For example,
  1. If a new API is proposed, explain the intended use case.
  2. If a bug is being fixed, describe why it is a bug.
  3. If design documentation is available, please include the link.
-->
This PR includes the following fixes:
(1) Includes changes from https://github.com/linkedin/coral/pull/394 which aimed to remove CAST in [HiveViewTable.toRel](https://github.com/linkedin/coral/blob/master/coral-common/src/main/java/com/linkedin/coral/common/HiveViewTable.java#L49) to solve Nested View Stale Schema Issue.
(2) Enables avro schema generation for a dataset with map field with NULL key
(3) When a field schema is a UnionType of a single data type, such as `uniontype<array<string>>`, surface the underlying field & its schema in Coral's SqlNode RelNode representation, such as `array<string>`. `SingleUnionFieldReferenceTransformer` has been introduced for backward compatibility. 

For a table `t1`: (f1: uniontype<int> ) and a view `v1` defined on top of it `SELECT custom_udf_to_remove_single_type_union(f1) AS f2 FROM t1` 
`v1` has a schema: (f2: int)
The RelNode representation, prior to dropping the CAST operator in the RelNode, would force the derived data type to be `int` for f2, as expected. Hence, the generated avro schema could be analyzed by the Spark engine. However, after dropping the CAST, as documented [here](https://github.com/linkedin/coral/pull/394), the derived type is `Struct<tag_0:int>`. The Avro schema is incorrectly generated and cannot be analysed by the Spark engine.

The resolution is to derive the data type of single uniontype fields like `f1` as the underlying data type (int in this case). 

### How was this patch tested?
<!--
Please describe all the tests conducted.
If new unit tests were included, mention that they were added in this section. Make sure to add test cases that thoroughly examine both negative and positive cases, if possible.
If the testing approach differed from regular unit tests (e.g., regression testing), please explain how it was conducted.
If no tests were added, please explain why they were not included and/or why it was difficult to add them.
-->
./gradlew spotlessApply
./gradlew build
Updated UTs
Thoroughly tested production views across all supported engines. 
