### PR TITLE
[Coral-Hive] Simply IN operator

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveConvertletTable.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveConvertletTable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2023 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -8,14 +8,11 @@ package com.linkedin.coral.hive.hive2rel;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.google.common.base.Preconditions;
-
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.fun.SqlCastFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql2rel.ReflectiveConvertletTable;
@@ -23,9 +20,7 @@ import org.apache.calcite.sql2rel.SqlRexContext;
 import org.apache.calcite.sql2rel.SqlRexConvertlet;
 import org.apache.calcite.sql2rel.StandardConvertletTable;
 
-import com.linkedin.coral.com.google.common.collect.ImmutableList;
 import com.linkedin.coral.common.functions.FunctionFieldReferenceOperator;
-import com.linkedin.coral.hive.hive2rel.functions.HiveInOperator;
 import com.linkedin.coral.hive.hive2rel.functions.HiveNamedStructFunction;
 
 
@@ -44,21 +39,6 @@ public class HiveConvertletTable extends ReflectiveConvertletTable {
     RelDataType retType = cx.getValidator().getValidatedNodeType(call);
     RexNode rowNode = cx.getRexBuilder().makeCall(retType, SqlStdOperatorTable.ROW, operandExpressions);
     return cx.getRexBuilder().makeCast(retType, rowNode);
-  }
-
-  @SuppressWarnings("unused")
-  public RexNode convertHiveInOperator(SqlRexContext cx, HiveInOperator operator, SqlCall call) {
-    List<SqlNode> operandList = call.getOperandList();
-    Preconditions.checkState(operandList.size() == 2 && operandList.get(1) instanceof SqlNodeList);
-    RexNode lhs = cx.convertExpression(operandList.get(0));
-    SqlNodeList rhsNodes = (SqlNodeList) operandList.get(1);
-    ImmutableList.Builder<RexNode> rexNodes = ImmutableList.<RexNode> builder().add(lhs);
-    for (int i = 0; i < rhsNodes.size(); i++) {
-      rexNodes.add(cx.convertExpression(rhsNodes.get(i)));
-    }
-
-    RelDataType retType = cx.getValidator().getValidatedNodeType(call);
-    return cx.getRexBuilder().makeCall(retType, HiveInOperator.IN, rexNodes.build());
   }
 
   @SuppressWarnings("unused")

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveFunction.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveFunction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2022 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2023 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -96,18 +96,14 @@ public class HiveFunction {
     @Override
     public SqlCall createCall(SqlNode function, List<SqlNode> operands, SqlLiteral qualifier) {
       checkState(operands.size() >= 2);
-      SqlNode lhs = operands.get(0);
-      SqlNode firstRhs = operands.get(1);
-      if (firstRhs instanceof SqlSelect) {
+      if (operands.get(1) instanceof SqlSelect) {
         // for IN subquery use Calcite IN operator. Calcite IN operator
         // will turn it into inner join, which not ideal but that's better
         // tested.
         return SqlStdOperatorTable.IN.createCall(ZERO, operands);
       } else {
-        // column IN values () clause
-        List<SqlNode> rhsList = operands.subList(1, operands.size());
-        SqlNodeList rhs = new SqlNodeList(rhsList, ZERO);
-        return getSqlOperator().createCall(ZERO, lhs, rhs);
+        // For IN whose operand is a list of values, we use custom IN operator {@link HiveInOperator}.
+        return getSqlOperator().createCall(ZERO, operands);
       }
     }
   };

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveInOperator.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveInOperator.java
@@ -48,8 +48,8 @@ import static org.apache.calcite.util.Static.*;
  *     different from set of OR predicates
  *  2. In some cases, calcite turns IN clause to INNER JOIN query on a set of values. We
  *     again want to prevent this conversion.
- *  Unlike Calcite's IN operator, whose operands are (expr, exprList), this operator's operands
- *  are (expr, exprList[0], expr[1], ...), where (exp) is the expression preceding IN operator.
+ *  Unlike Calcite's IN operator, whose operands are (expr, values), this operator's operands
+ *  are (expr, values[0], values[1], ...), where (exp) is the expression preceding IN operator.
  */
 public class HiveInOperator extends SqlSpecialOperator {
 

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveInOperator.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveInOperator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2021 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2023 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -34,6 +34,7 @@ import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql.validate.SqlValidatorImpl;
 import org.apache.calcite.sql.validate.SqlValidatorScope;
 
+import static org.apache.calcite.sql.parser.SqlParserPos.ZERO;
 import static org.apache.calcite.util.Static.*;
 
 
@@ -47,6 +48,8 @@ import static org.apache.calcite.util.Static.*;
  *     different from set of OR predicates
  *  2. In some cases, calcite turns IN clause to INNER JOIN query on a set of values. We
  *     again want to prevent this conversion.
+ *  Unlike Calcite's IN operator, whose operands are (expr, exprList), this operator's operands
+ *  are (expr, exprList[0], expr[1], ...), where (exp) is the expression preceding IN operator.
  */
 public class HiveInOperator extends SqlSpecialOperator {
 
@@ -73,46 +76,42 @@ public class HiveInOperator extends SqlSpecialOperator {
     writer.endList(listFrame);
   }
 
-  // copied from Calcite' SqlInOperator
+  // Adapts the parent's behavior to allow IN to have any number of arguments (i.e., list elements).
   public RelDataType deriveType(SqlValidator validator, SqlValidatorScope scope, SqlCall call) {
     final List<SqlNode> operands = call.getOperandList();
-    assert operands.size() == 2;
     final SqlNode left = operands.get(0);
-    final SqlNode right = operands.get(1);
+    final SqlNodeList right = new SqlNodeList(ZERO);
+    for (int i = 1; i < operands.size(); i++) {
+      right.add(operands.get(i));
+    }
 
     final RelDataTypeFactory typeFactory = validator.getTypeFactory();
     RelDataType leftType = validator.deriveType(scope, left);
     RelDataType rightType;
 
     // Derive type for RHS.
-    if (right instanceof SqlNodeList) {
-      // Handle the 'IN (expr, ...)' form.
-      List<RelDataType> rightTypeList = new ArrayList<>();
-      SqlNodeList nodeList = (SqlNodeList) right;
-      for (int i = 0; i < nodeList.size(); i++) {
-        SqlNode node = nodeList.get(i);
-        RelDataType nodeType = validator.deriveType(scope, node);
-        rightTypeList.add(nodeType);
-      }
-      rightType = typeFactory.leastRestrictive(rightTypeList);
-
-      // First check that the expressions in the IN list are compatible
-      // with each other. Same rules as the VALUES operator (per
-      // SQL:2003 Part 2 Section 8.4, <in predicate>).
-      if (null == rightType && validator.isTypeCoercionEnabled()) {
-        // Do implicit type cast if it is allowed to.
-        rightType = validator.getTypeCoercion().getWiderTypeFor(rightTypeList, true);
-      }
-      if (null == rightType) {
-        throw validator.newValidationError(right, RESOURCE.incompatibleTypesInList());
-      }
-
-      // Record the RHS type for use by SqlToRelConverter.
-      ((SqlValidatorImpl) validator).setValidatedNodeType(nodeList, rightType);
-    } else {
-      // Handle the 'IN (query)' form.
-      rightType = validator.deriveType(scope, right);
+    List<RelDataType> rightTypeList = new ArrayList<>();
+    for (int i = 1; i < right.size(); i++) {
+      SqlNode node = right.get(i);
+      RelDataType nodeType = validator.deriveType(scope, node);
+      rightTypeList.add(nodeType);
     }
+    rightType = typeFactory.leastRestrictive(rightTypeList);
+
+    // First check that the expressions in the IN list are compatible
+    // with each other. Same rules as the VALUES operator (per
+    // SQL:2003 Part 2 Section 8.4, <in predicate>).
+    if (null == rightType && validator.isTypeCoercionEnabled()) {
+      // Do implicit type cast if it is allowed to.
+      rightType = validator.getTypeCoercion().getWiderTypeFor(rightTypeList, true);
+    }
+    if (null == rightType) {
+      throw validator.newValidationError(right, RESOURCE.incompatibleTypesInList());
+    }
+
+    // Record the RHS type for use by SqlToRelConverter.
+    ((SqlValidatorImpl) validator).setValidatedNodeType(right, rightType);
+
     SqlCallBinding callBinding = new SqlCallBinding(validator, scope, call);
     // Coerce type first.
     if (callBinding.getValidator().isTypeCoercionEnabled()) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:
  1. If you are new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you have added and executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
  7. Make sure that the command './gradlew clean build' passes. Resolve any formatting errors by running './gradlew spotlessApply'.
-->

### What changes are proposed in this pull request, and why are they necessary?
This PR simplifies how Coral handles the `expr IN (values)` operator. 

Previously, the following set of transformations took place:
1- Hive's `ParseTreeBuilder` processes the `IN` operator as part of `visitFunctionInternal`, specifically, passing the list of `(expr, value_0, value_1, ...)` as operands.
2- This maps to `HiveInOperator` when looked up from the function registry. This operator overrides `createCall` in such a way that makes the operands be on the format `(expr, values)` (i.e., instead of N operands, two operands are used with the second being the list of values).
3- `HiveConvertletTable` for `IN` operator converts `IN SqlNode` to a `RexNode` with operands on the format `(expr, value_0, value_1, ...)` again.

This PR sticks to the operand format `(expr, value_0, value_1, ...)` across the board, simplifying the back and forth transformations, and eliminating the need for the `HiveConvertletTable` in the `IN` operator case.
### How was this patch tested?
`./gradlew build`, but will wait for integration tests.