### PR TITLE
Change the single quotes with Chinese input method

### DIFF
--- a/coral-common/src/main/java/com/linkedin/coral/common/transformers/SqlCallTransformer.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/transformers/SqlCallTransformer.java
@@ -39,7 +39,7 @@ public abstract class SqlCallTransformer {
   }
 
   /**
-   * Condition of the transformer, it’s used to determine if the SqlCall should be transformed or not
+   * Condition of the transformer, it's used to determine if the SqlCall should be transformed or not
    */
   protected abstract boolean condition(SqlCall sqlCall);
 

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CoralTrinoConfigKeys.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CoralTrinoConfigKeys.java
@@ -13,7 +13,7 @@ public class CoralTrinoConfigKeys {
    * SQL standard (which Trino follows) defines that when we do CROSS JOIN UNNEST over ARRAY(ROW(...)), both ARRAY and ROW are unnested.
    * This is not what Hive's LATERAL VIEW EXPLODE does, which only unnests ARRAY.
    * Therefore, https://github.com/linkedin/coral/pull/93 adds extra ROW wrapping (translating ARRAY(ROW(...)) to ARRAY(ROW(ROW(...)))) on purpose.
-   * However, LinkedIn's internal Trino is still extending the support for Hive’s legacy behavior of unnest, which only unnests ARRAY.
+   * However, LinkedIn's internal Trino is still extending the support for Hive's legacy behavior of unnest, which only unnests ARRAY.
    * Therefore, we add this config for LinkedIn's internal use, if the value is set to true, we don't add extra ROW wrapping.
    */
   public static final String SUPPORT_LEGACY_UNNEST_ARRAY_OF_STRUCT = "SUPPORT_LEGACY_UNNEST_ARRAY_OF_STRUCT";
@@ -22,7 +22,7 @@ public class CoralTrinoConfigKeys {
    * https://github.com/linkedin/coral/pull/132 converts `to_date(xxx)` (returns string type pre Hive 2.1.0, returns date type on or after Hive 2.1.0)
    * to `date(cast(xxx as timestamp))` (returns date type).
    * Since LinkedIn is using Hive 1.x, our users expect `to_date(xxx)` function to return `string` type instead of `date` type.
-   * And we have registered `to_date` UDF in Trino which returns `string` type to meet the users’ needs.
+   * And we have registered `to_date` UDF in Trino which returns `string` type to meet the users' needs.
    * Therefore, we add this config for LinkedIn's internal use, if the value is set to true, we don't convert `to_date(xxx)` to `date(cast(xxx as timestamp))`.
    */
   public static final String AVOID_TRANSFORM_TO_DATE_UDF = "AVOID_TRANSFORM_TO_DATE_UDF";


### PR DESCRIPTION
### What changes are proposed in this pull request, and why are they necessary?
When I compile coral on windows, I run the following command:
```
git clone https://github.com/linkedin/coral.git
./gradlew clean build
```
Because I am a Chinese user, the default encoding of the windows command line is GBK, so I encountered the following error
![image](https://github.com/linkedin/coral/assets/51987547/4b9e82d1-dc35-44f2-a9e2-f1396250aaca)
The single quotes `’` that are currently reported as errors are input using the Chinese input method. I think change to English single quotes `'` can reduce compilation failures caused by encoding.