### PR TITLE
[WIP] POC for renaming table names

### DIFF
--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RewriteTableNameShuttle.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RewriteTableNameShuttle.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2023 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.trino.rel2trino;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.util.SqlShuttle;
+
+
+public class RewriteTableNameShuttle extends SqlShuttle {
+  private final Set<String> baseTables;
+
+  public RewriteTableNameShuttle(HashSet<String> baseTables) {
+    this.baseTables = baseTables;
+  }
+
+  @Override
+  public SqlNode visit(SqlIdentifier id) {
+    if (baseTables.contains(id.toString())) {
+      String currentTableName = id.names.get(id.names.size() - 1);
+      String newTableName = currentTableName + "_tmp";
+      return id.setName(id.names.size() - 1, newTableName);
+    }
+    return id;
+  }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:
  1. If you are new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you have added and executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
  7. Make sure that the command './gradlew clean build' passes. Resolve any formatting errors by running './gradlew spotlessApply'.
-->

### What changes are proposed in this pull request, and why are they necessary?
<!--
Kindly explain the proposed changes in this section. The goal is to outline the modifications and how this PR addresses the issue. Also, clarify the reasons for these changes. For example,
  1. If a new API is proposed, explain the intended use case.
  2. If a bug is being fixed, describe why it is a bug.
  3. If design documentation is available, please include the link.
-->

During translations, Coral generates SQL where each table name is appended with an alias and this alias is used to reference columns from the table. For example:

```
source SQL:
SELECT * FROM foo
Translated Trino SQL:
SELECT * FROM default.foo AS foo

source SQL:
SELECT a FROM foo UNION ALL SELECT a FROM foo
Translated Trino SQL:
SELECT foo.a FROM default.foo AS foo UNION ALL SELECT foo0.a FROM default.foo AS foo0
```

With this information, altering the table name can be accomplished using a post-processing SqlShuttle. This involves:
(1) Identifying the tables accessed in the RelNode via RelOptUtil.findAllTables()
(2) Using SqlShuttle `RewriteTableNameShuttle` to replace a single reference to the original table name. 

The new translation are:

```
source SQL:
SELECT * FROM foo
Translated Trino SQL:
SELECT * FROM default.foo_tmp AS foo

source SQL:
SELECT a FROM foo UNION ALL SELECT a FROM foo
Translated Trino SQL:
SELECT foo.a FROM default.foo_tmp AS foo UNION ALL SELECT foo0.a FROM default.foo_tmp AS foo0
```

### How was this patch tested?
<!--
Please describe all the tests conducted.
If new unit tests were included, mention that they were added in this section. Make sure to add test cases that thoroughly examine both negative and positive cases, if possible.
If the testing approach differed from regular unit tests (e.g., regression testing), please explain how it was conducted.
If no tests were added, please explain why they were not included and/or why it was difficult to add them.
-->
NA