### PR TITLE
[Coral-Hive] Loose UDF format requirement

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveFunctionResolver.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveFunctionResolver.java
@@ -172,7 +172,7 @@ public class HiveFunctionResolver {
     Preconditions.checkNotNull(table);
     String functionPrefix = String.format("%s_%s_", table.getDbName(), table.getTableName());
     if (!functionName.toLowerCase().startsWith(functionPrefix.toLowerCase())) {
-      // If the it is not in `databaseName_tableName_udfName` format, we don't require the `databaseName_tableName_` prefix
+      // if functionName is not in `databaseName_tableName_udfName` format, we don't require the `databaseName_tableName_` prefix
       functionPrefix = "";
     }
     String funcBaseName = functionName.substring(functionPrefix.length());

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveFunctionResolver.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveFunctionResolver.java
@@ -164,17 +164,16 @@ public class HiveFunctionResolver {
    * @param table Hive metastore table handle
    * @param numOfOperands number of operands this function takes. This is needed to
    *                      create SqlOperandTypeChecker to resolve Dali function dynamically
-   * @return list of matching Functions or empty list if the function name is not in the
-   *   dali function name format of db_tableName_functionName
+   * @return list of matching Functions or empty list if the function name is not in the dali function name format
+   * of `databaseName_tableName_udfName` or `udfName` (without `databaseName_tableName_` prefix)
    * @throws UnknownSqlFunctionException if the function name is in Dali function name format but there is no mapping
    */
   public Collection<Function> tryResolveAsDaliFunction(String functionName, @Nonnull Table table, int numOfOperands) {
     Preconditions.checkNotNull(table);
     String functionPrefix = String.format("%s_%s_", table.getDbName(), table.getTableName());
     if (!functionName.toLowerCase().startsWith(functionPrefix.toLowerCase())) {
-      // Don't throw UnknownSqlFunctionException here because this is not a dali function
-      // and this method is trying to resolve only Dali functions
-      return ImmutableList.of();
+      // If the it is not in `databaseName_tableName_udfName` format, we don't require the `databaseName_tableName_` prefix
+      functionPrefix = "";
     }
     String funcBaseName = functionName.substring(functionPrefix.length());
     HiveTable hiveTable = new HiveTable(table);

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -853,6 +853,14 @@ public class CoralSparkTest {
     assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
   }
 
+  @Test
+  public void testUdfWithoutDatabaseTableNamePrefix() {
+    RelNode relNode = TestUtils.toRelNode("default", "foo_dali_udf_no_prefix");
+
+    String targetSql = "SELECT LessThanHundred(foo.a)\n" + "FROM default.foo foo";
+    assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
+  }
+
   private String getCoralSparkTranslatedSqlWithAliasFromCoralSchema(String db, String view) {
     RelNode relNode = TestUtils.toRelNode(db, view);
     Schema schema = TestUtils.getAvroSchemaForView(db, view, false);

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
@@ -79,6 +79,7 @@ public class TestUtils {
         "create function default_foo_lateral_udtf_CountOfRow as 'com.linkedin.coral.hive.hive2rel.CoralTestUDTF'");
     run(driver,
         "create function default_foo_duplicate_udf_LessThanHundred as 'com.linkedin.coral.hive.hive2rel.CoralTestUDF'");
+    run(driver, "CREATE FUNCTION LessThanHundred as 'com.linkedin.coral.hive.hive2rel.CoralTestUDF'");
 
     run(driver, String.join("\n", "", "CREATE VIEW IF NOT EXISTS foo_view", "AS", "SELECT b AS bcol, sum(c) AS sum_c",
         "FROM foo", "GROUP BY b"));
@@ -114,6 +115,10 @@ public class TestUtils {
             "tblproperties('functions' = 'UnsupportedUDF:com.linkedin.coral.hive.hive2rel.CoralTestUnsupportedUDF',",
             "              'dependencies' = 'com.linkedin:udf:1.0')", "AS",
             "SELECT default_foo_dali_udf5_UnsupportedUDF(a)", "FROM foo"));
+
+    run(driver, String.join("\n", "", "CREATE VIEW IF NOT EXISTS foo_dali_udf_no_prefix",
+        "tblproperties('functions' = 'LessThanHundred:com.linkedin.coral.hive.hive2rel.CoralTestUDF',",
+        "              'dependencies' = 'ivy://com.linkedin:udf:1.0')", "AS", "SELECT LessThanHundred(a)", "FROM foo"));
 
     run(driver,
         String.join("\n", "", "CREATE VIEW IF NOT EXISTS foo_lateral_udtf",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:
  1. If you are new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you have added and executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
  7. Make sure that the command './gradlew clean build' passes. Resolve any formatting errors by running './gradlew spotlessApply'.
-->

### What changes are proposed in this pull request, and why are they necessary?
<!--
Kindly explain the proposed changes in this section. The goal is to outline the modifications and how this PR addresses the issue. Also, clarify the reasons for these changes. For example,
  1. If a new API is proposed, explain the intended use case.
  2. If a bug is being fixed, describe why it is a bug.
  3. If design documentation is available, please include the link.
-->
Previously, Coral requires `com.linkedin.xxx` UDFs to be in `databaseName_tableName_udfName` format, this PR is to loose this requirement, so that `udfName` can also be resolved. The change is backward compatible.

### How was this patch tested?
<!--
Please describe all the tests conducted.
If new unit tests were included, mention that they were added in this section. Make sure to add test cases that thoroughly examine both negative and positive cases, if possible.
If the testing approach differed from regular unit tests (e.g., regression testing), please explain how it was conducted.
If no tests were added, please explain why they were not included and/or why it was difficult to add them.
-->
1. new UT
2. tested on Spark shell for the affected production view