### PR TITLE
[Coral-Visualization] Select list edges/nodes not rendering for incrementally rewritten SqlNodes

### DIFF
--- a/coral-visualization/src/main/java/com/linkedin/coral/vis/SqlNodeVisualizationVisitor.java
+++ b/coral-visualization/src/main/java/com/linkedin/coral/vis/SqlNodeVisualizationVisitor.java
@@ -6,6 +6,7 @@
 package com.linkedin.coral.vis;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
@@ -20,6 +21,7 @@ import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.util.SqlVisitor;
 
 import guru.nidi.graphviz.attribute.Label;
@@ -28,6 +30,7 @@ import guru.nidi.graphviz.model.Link;
 import guru.nidi.graphviz.model.LinkTarget;
 import guru.nidi.graphviz.model.Node;
 
+import static com.linkedin.coral.common.calcite.CalciteUtil.*;
 import static guru.nidi.graphviz.model.Factory.*;
 
 
@@ -59,6 +62,8 @@ public class SqlNodeVisualizationVisitor implements SqlVisitor<Node> {
       }
       if (sqlSelect.getSelectList() != null) {
         edges.add(edge(sqlSelect.getSelectList(), "select_list"));
+      } else {
+        edges.add(edge(createSelectStarSqlNodeList(), "select_list"));
       }
       if (sqlSelect.getOrderList() != null) {
         edges.add(edge(sqlSelect.getOrderList(), "order_by_list"));
@@ -121,5 +126,12 @@ public class SqlNodeVisualizationVisitor implements SqlVisitor<Node> {
 
   private static Node node(String label) {
     return Factory.node(UUID.randomUUID().toString()).with(Label.of(label));
+  }
+
+  private static SqlNodeList createSelectStarSqlNodeList() {
+    Collection<SqlNode> sqlNodeList = new ArrayList();
+    sqlNodeList.add(createStarIdentifier(SqlParserPos.ZERO));
+    SqlNodeList selectStar = createSqlNodeList(sqlNodeList);
+    return selectStar;
   }
 }


### PR DESCRIPTION
### What changes are proposed in this pull request, and why are they necessary?
**Issue:** For `select *` statements, passing a SqlNode (that was converted from a incremental RelNode using `CoralRelToSqlNodeConverter`) into the coral graph visualizer results in a graph without a select_list edge. For example:
![Screenshot 2023-10-02 at 6 36 36 PM](https://github.com/linkedin/coral/assets/46853779/b14661c2-9f9f-4fab-8c06-70f6e41f32e2)
**Cause:** During the conversion of a CoralRelNode to its CoralSqlNode representation, `select *` [nodes are "wrapped"
 in a SELECT statement that has no clauses](https://github.com/linkedin/linkedin-calcite/blob/1b04e27f1e59a5d36e327e3eeeb6686623b44d8f/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java#L423), leading to a `select *` `SqlNode` with null `selectList` even though there is an implicit `*` clause. Which in turn, the implicit * is not picked up by the coral visualizer.
 
  
### How was this patch tested?
Test `select *` queries in `SqlNodeVisualizationUtilTest` and make sure the graphs generated have a select_list edge where list_item is *.
![test0](https://github.com/linkedin/coral/assets/46853779/989076d4-f54a-469e-9573-74b43cf63f53)
