### PR TITLE
[Coral-Trino] Remove characters sets from TrinoSqlDialect

### DIFF
--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoSqlDialect.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoSqlDialect.java
@@ -25,11 +25,6 @@ public class TrinoSqlDialect extends SqlDialect {
     super(context);
   }
 
-  @Override
-  public boolean supportsCharSet() {
-    return false;
-  }
-
   /**
    * Override this method so that so that table alias is prepended to all field references (e.g., "table.column"
    * or "table.struct.filed" instead of "column" or "struct.field"), which is necessary for

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoSqlRewriter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoSqlRewriter.java
@@ -60,6 +60,14 @@ public class TrinoSqlRewriter extends SqlShuttle {
           final SqlBasicTypeNameSpec realTypeName =
               new SqlBasicTypeNameSpec(SqlTypeName.REAL, precision, scale, charSetName, parserPos);
           return new SqlDataTypeSpec(realTypeName, timeZone, parserPos);
+        case "VARCHAR":
+          final SqlBasicTypeNameSpec varcharTypeName =
+              new SqlBasicTypeNameSpec(SqlTypeName.VARCHAR, precision, scale, null, parserPos); // remove CHARACTER SET
+          return new SqlDataTypeSpec(varcharTypeName, timeZone, parserPos);
+        case "CHAR":
+          final SqlBasicTypeNameSpec charTypeName =
+              new SqlBasicTypeNameSpec(SqlTypeName.CHAR, precision, scale, null, parserPos); // remove CHARACTER SET
+          return new SqlDataTypeSpec(charTypeName, timeZone, parserPos);
         default:
           return type;
       }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -381,6 +381,19 @@ public class HiveToTrinoConverterTest {
   }
 
   @Test
+  public void testNestedNamedStructWithArrayWithoutType() {
+    RelNode relNode =
+        TestUtils.getHiveToRelConverter().convertSql("SELECT NAMED_STRUCT('value', NAMED_STRUCT('value2', ARRAY()))");
+    String targetSql =
+        "SELECT CAST(ROW(CAST(ROW(ARRAY[]) AS ROW(\"value2\" ARRAY<VARCHAR(65535)>))) AS ROW(\"value\" ROW(\"value2\" ARRAY<VARCHAR(65535)>)))\n"
+            + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+
+    RelToTrinoConverter relToTrinoConverter = TestUtils.getRelToTrinoConverter();
+    String expandedSql = relToTrinoConverter.convert(relNode);
+    assertEquals(expandedSql, targetSql);
+  }
+
+  @Test
   public void testNamedStructWithStringTypeArray() {
     RelNode relNode =
         TestUtils.getHiveToRelConverter().convertSql("SELECT NAMED_STRUCT('value', ARRAY(CAST('tmp' AS STRING)))");


### PR DESCRIPTION
### What changes are proposed in this pull request, and why are they necessary?
Previously, `charSetName` was dropped from VARCHAR/CHAR fields when a Coral RelNode is being converted to a Trino SqlNode. This happened by overriding `supportsCharSet` to be false in `TrinoSqlDialect`.  As art of merging `TrinoSqlDialect` -> `CoralSqlDialect`, we want `TrinoSqlDialect` to match `CoralSqlDialect` meaning the override needed to be undone.

Now, `charSetName` is instead dropped from VARCHAR/CHAR fields dropped as part of SqlNode rewriting in `TrinoSqlRewriter` by adding a datatype replacement rule.

### How was this patch tested?
1. clean build
2. new unit test to test character sets are removed in `CAST` calls that are nested
3. i-test passed
