### PR TITLE
[Coral-Spark] Modify coral hive parser and coral spark writer dialect to generate spark compliant escaped string literal

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
@@ -690,12 +692,34 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
     return new SqlIdentifier(node.getText(), ZERO);
   }
 
+  /** See {@link #removeBackslashBeforeSingleQuote}
+   * We use removeBackslashBeforeSingleQuote to remove the backslash before single quote,
+   * so that we maintain patterns like {@code I'm} or {@code won't} as is in the java object in memory,
+   * the escaped literal string representation will be generated when the SqlNode is written to string
+   * by the SqlWriter, which can be controlled by the SqlDialect to decide the choice of escaping mechanism.
+   * */
   @Override
   protected SqlNode visitStringLiteral(ASTNode node, ParseContext ctx) {
     // TODO: Add charset here. UTF-8 is not supported by calcite
     String text = node.getText();
     checkState(text.length() >= 2);
-    return SqlLiteral.createCharString(text.substring(1, text.length() - 1), ZERO);
+    return SqlLiteral.createCharString(
+        removeBackslashBeforeSingleQuote(text.substring(1, text.length() - 1)), ZERO);
+  }
+
+  private String removeBackslashBeforeSingleQuote(String input) {
+    // matches a \' literal pattern
+    Pattern pattern = Pattern.compile("\\\\'");
+    Matcher matcher = pattern.matcher(input);
+
+    StringBuffer res = new StringBuffer();
+    while (matcher.find()) {
+      String replacement = matcher.group().substring(1);
+      matcher.appendReplacement(res, replacement);
+    }
+    matcher.appendTail(res);
+
+    return res.toString();
   }
 
   @Override

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -703,8 +703,7 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
     // TODO: Add charset here. UTF-8 is not supported by calcite
     String text = node.getText();
     checkState(text.length() >= 2);
-    return SqlLiteral.createCharString(
-        removeBackslashBeforeSingleQuote(text.substring(1, text.length() - 1)), ZERO);
+    return SqlLiteral.createCharString(removeBackslashBeforeSingleQuote(text.substring(1, text.length() - 1)), ZERO);
   }
 
   private String removeBackslashBeforeSingleQuote(String input) {

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -692,9 +692,9 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
     return new SqlIdentifier(node.getText(), ZERO);
   }
 
-  /** See {@link #removeBackslashBeforeSingleQuote}
-   * We use removeBackslashBeforeSingleQuote to remove the backslash before single quote,
-   * so that we maintain patterns like {@code I'm} or {@code won't} as is in the java object in memory,
+  /** See {@link #removeBackslashBeforeQuotes}
+   * We use removeBackslashBeforeQuotes to remove the backslash before quotes,
+   * so that we maintain patterns like {@code I'm} or {@code abc"xyz} as is in the java object in memory,
    * the escaped literal string representation will be generated when the SqlNode is written to string
    * by the SqlWriter, which can be controlled by the SqlDialect to decide the choice of escaping mechanism.
    * */
@@ -703,12 +703,12 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
     // TODO: Add charset here. UTF-8 is not supported by calcite
     String text = node.getText();
     checkState(text.length() >= 2);
-    return SqlLiteral.createCharString(removeBackslashBeforeSingleQuote(text.substring(1, text.length() - 1)), ZERO);
+    return SqlLiteral.createCharString(removeBackslashBeforeQuotes(text.substring(1, text.length() - 1)), ZERO);
   }
 
-  private String removeBackslashBeforeSingleQuote(String input) {
+  private String removeBackslashBeforeQuotes(String input) {
     // matches a \' literal pattern
-    Pattern pattern = Pattern.compile("\\\\'");
+    Pattern pattern = Pattern.compile("\\\\['\"]");
     Matcher matcher = pattern.matcher(input);
 
     StringBuffer res = new StringBuffer();

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -707,7 +707,7 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
   }
 
   private String removeBackslashBeforeQuotes(String input) {
-    // matches a \' literal pattern
+    // matches a \' or \" literal pattern
     Pattern pattern = Pattern.compile("\\\\['\"]");
     Matcher matcher = pattern.matcher(input);
 

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/dialect/SparkSqlDialect.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/dialect/SparkSqlDialect.java
@@ -1,10 +1,10 @@
 /**
- * Copyright 2018-2023 LinkedIn Corporation. All rights reserved.
- * Licensed under the BSD-2 Clause license.
- * See LICENSE in the project root for license information.
+ * Copyright 2018-2023 LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause
+ * license. See LICENSE in the project root for license information.
  */
 package com.linkedin.coral.spark.dialect;
 
+import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.config.NullCollation;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDialect;
@@ -30,8 +30,17 @@ import com.linkedin.coral.common.functions.CoralSqlUnnestOperator;
  */
 public class SparkSqlDialect extends SqlDialect {
 
-  public static final SparkSqlDialect INSTANCE = new SparkSqlDialect(
-      emptyContext().withDatabaseProduct(DatabaseProduct.HIVE).withNullCollation(NullCollation.HIGH));
+  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
+      .withDatabaseProduct(DatabaseProduct.SPARK)
+      .withLiteralQuoteString("'")
+      .withLiteralEscapedQuoteString("\\'")
+      .withNullCollation(NullCollation.LOW)
+      .withUnquotedCasing(Casing.UNCHANGED)
+      .withQuotedCasing(Casing.UNCHANGED)
+      .withCaseSensitive(false);
+
+
+  public static final SparkSqlDialect INSTANCE = new SparkSqlDialect(DEFAULT_CONTEXT);
 
   private SparkSqlDialect(Context context) {
     super(context);

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/dialect/SparkSqlDialect.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/dialect/SparkSqlDialect.java
@@ -1,6 +1,7 @@
 /**
- * Copyright 2018-2023 LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause
- * license. See LICENSE in the project root for license information.
+ * Copyright 2018-2023 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
  */
 package com.linkedin.coral.spark.dialect;
 
@@ -30,15 +31,10 @@ import com.linkedin.coral.common.functions.CoralSqlUnnestOperator;
  */
 public class SparkSqlDialect extends SqlDialect {
 
-  public static final SqlDialect.Context DEFAULT_CONTEXT = SqlDialect.EMPTY_CONTEXT
-      .withDatabaseProduct(DatabaseProduct.SPARK)
-      .withLiteralQuoteString("'")
-      .withLiteralEscapedQuoteString("\\'")
-      .withNullCollation(NullCollation.LOW)
-      .withUnquotedCasing(Casing.UNCHANGED)
-      .withQuotedCasing(Casing.UNCHANGED)
-      .withCaseSensitive(false);
-
+  public static final SqlDialect.Context DEFAULT_CONTEXT =
+      SqlDialect.EMPTY_CONTEXT.withDatabaseProduct(DatabaseProduct.SPARK).withLiteralQuoteString("'")
+          .withLiteralEscapedQuoteString("\\'").withNullCollation(NullCollation.LOW)
+          .withUnquotedCasing(Casing.UNCHANGED).withQuotedCasing(Casing.UNCHANGED).withCaseSensitive(false);
 
   public static final SparkSqlDialect INSTANCE = new SparkSqlDialect(DEFAULT_CONTEXT);
 

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -893,6 +893,42 @@ public class CoralSparkTest {
     assertEquals(expectedSql, targetSql);
   }
 
+  @Test
+  public void testUnescapedSingleQuote() {
+    RelNode relNode = TestUtils.toRelNode("SELECT 'abc' col1 FROM default.complex");
+    String targetSql = createCoralSpark(relNode).getSparkSql();
+
+    String expectedSql = "SELECT 'abc' col1\n" + "FROM default.complex complex";
+    assertEquals(targetSql, expectedSql);
+  }
+
+  @Test
+  public void testUnescapedDoubleQuote() {
+    RelNode relNode = TestUtils.toRelNode("SELECT \"abc\" col1 FROM default.complex");
+    String targetSql = createCoralSpark(relNode).getSparkSql();
+
+    String expectedSql = "SELECT 'abc' col1\n" + "FROM default.complex complex";
+    assertEquals(targetSql, expectedSql);
+  }
+
+  @Test
+  public void testSingleQuoteInsideSingleQuote() {
+    RelNode relNode = TestUtils.toRelNode("SELECT 'abc[\\'xyz\\']' col1 FROM default.complex");
+    String targetSql = createCoralSpark(relNode).getSparkSql();
+
+    String expectedSql = "SELECT 'abc[\\'xyz\\']' col1\n" + "FROM default.complex complex";
+    assertEquals(targetSql, expectedSql);
+  }
+
+  @Test
+  public void testSingleQuoteInsideDoubleQuote() {
+    RelNode relNode = TestUtils.toRelNode("SELECT \"abc['xyz']\" col1 FROM default.complex");
+    String targetSql = createCoralSpark(relNode).getSparkSql();
+
+    String expectedSql = "SELECT 'abc[\\'xyz\\']' col1\n" + "FROM default.complex complex";
+    assertEquals(targetSql, expectedSql);
+  }
+
   private String getCoralSparkTranslatedSqlWithAliasFromCoralSchema(String db, String view) {
     RelNode relNode = TestUtils.toRelNode(db, view);
     Schema schema = TestUtils.getAvroSchemaForView(db, view, false);

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -929,6 +929,24 @@ public class CoralSparkTest {
     assertEquals(targetSql, expectedSql);
   }
 
+  @Test
+  public void testDoubleQuoteInsideDoubleQuote() {
+    RelNode relNode = TestUtils.toRelNode("SELECT \"abc[\\\"xyz\\\"]\" col1 FROM default.complex");
+    String targetSql = createCoralSpark(relNode).getSparkSql();
+
+    String expectedSql = "SELECT 'abc[\"xyz\"]' col1\n" + "FROM default.complex complex";
+    assertEquals(targetSql, expectedSql);
+  }
+
+  @Test
+  public void testDoubleQuoteInsideSingleQuote() {
+    RelNode relNode = TestUtils.toRelNode("SELECT 'abc[\"xyz\"]' col1 FROM default.complex");
+    String targetSql = createCoralSpark(relNode).getSparkSql();
+
+    String expectedSql = "SELECT 'abc[\"xyz\"]' col1\n" + "FROM default.complex complex";
+    assertEquals(targetSql, expectedSql);
+  }
+
   private String getCoralSparkTranslatedSqlWithAliasFromCoralSchema(String db, String view) {
     RelNode relNode = TestUtils.toRelNode(db, view);
     Schema schema = TestUtils.getAvroSchemaForView(db, view, false);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:
  1. If you are new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you have added and executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
  7. Make sure that the command './gradlew clean build' passes. Resolve any formatting errors by running './gradlew spotlessApply'.
-->

### What changes are proposed in this pull request, and why are they necessary?
<!--
Kindly explain the proposed changes in this section. The goal is to outline the modifications and how this PR addresses the issue. Also, clarify the reasons for these changes. For example,
  1. If a new API is proposed, explain the intended use case.
  2. If a bug is being fixed, describe why it is a bug.
  3. If design documentation is available, please include the link.
-->
Without this patch, a string literal of `select 'I'm'` will be re-written in spark-sql output of `select I''m`, the `''` double single quote escaping is a ANSI sql escaping standard but is not what is recognized by the spark sql parser. Instead, spark uses the backslash for escaping quotes inside quotes in sql string, i.e. the correct output should be `select 'I\'m'`.

This patch adds the customizations in the `SparkSqlDialect` to make the generated output sql consistency use single quote for quoting a outermost level string literal and use `\'` to quote internal literals occurences of `'`, for `"`, it will appear as-is since it will never need to be escaped because the outermost quote is always single quote.
### How was this patch tested?
<!--
Please describe all the tests conducted.
If new unit tests were included, mention that they were added in this section. Make sure to add test cases that thoroughly examine both negative and positive cases, if possible.
If the testing approach differed from regular unit tests (e.g., regression testing), please explain how it was conducted.
If no tests were added, please explain why they were not included and/or why it was difficult to add them.
-->

Added 6 unit tests to demonstrate the new behavior:
| hive | spark |
| --- | --- |
| select 'abc' | select 'abc' |
| select "abc" | select 'abc' |
| select 'abc[\\'xyz\\']' | select 'abc[\\'xyz\\']' |
| select "abc['xyz']" | select 'abc[\\'xyz\\']' |
| select 'abc["xyz"]' | select 'abc[\\'xyz\\']' |
| select "abc[\\"xyz\\"]" | select 'abc["xyz"]' |

Run regression tests against all views and results looks fine. Also tested against the view sql which exposed this issue on spark, the spark read result literals are correct now.


