### PR TITLE
[Coral-Spark] Add quoting for reserved keywords

### DIFF
--- a/coral-spark/src/main/java/com/linkedin/coral/spark/dialect/SparkSqlDialect.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/dialect/SparkSqlDialect.java
@@ -6,6 +6,8 @@
 package com.linkedin.coral.spark.dialect;
 
 import org.apache.calcite.avatica.util.Casing;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import org.apache.calcite.config.NullCollation;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDialect;
@@ -34,7 +36,7 @@ public class SparkSqlDialect extends SqlDialect {
   public static final SqlDialect.Context DEFAULT_CONTEXT =
       SqlDialect.EMPTY_CONTEXT.withDatabaseProduct(DatabaseProduct.SPARK).withLiteralQuoteString("'")
           .withLiteralEscapedQuoteString("\\'").withNullCollation(NullCollation.LOW)
-          .withUnquotedCasing(Casing.UNCHANGED).withQuotedCasing(Casing.UNCHANGED).withCaseSensitive(false);
+          .withUnquotedCasing(Casing.UNCHANGED).withQuotedCasing(Casing.UNCHANGED).withCaseSensitive(false).withIdentifierQuoteString("`");
 
   public static final SparkSqlDialect INSTANCE = new SparkSqlDialect(DEFAULT_CONTEXT);
 
@@ -134,6 +136,20 @@ public class SparkSqlDialect extends SqlDialect {
   public boolean supportsCharSet() {
     return false;
   }
+
+  public String quoteIdentifier(String val) {
+    List<String> reservedKeywords = ImmutableList.of("select", "timestamp");
+    if (reservedKeywords.contains(val.toLowerCase())) {
+      String val2 =
+          val.replaceAll(
+              identifierEndQuoteString,
+              identifierEscapedQuote);
+      return identifierQuoteString + val2 + identifierEndQuoteString;
+    } else {
+      return val;
+    }
+  }
+
 
   public void unparseOffsetFetch(SqlWriter writer, SqlNode offset, SqlNode fetch) {
     unparseFetchUsingLimit(writer, offset, fetch);

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -424,7 +424,7 @@ public class CoralSparkTest {
   @Test
   public void testDateFunction() {
     RelNode relNode = TestUtils.toRelNode("SELECT date('2021-01-02') as a FROM foo");
-    String targetSql = "SELECT date('2021-01-02') a\n" + "FROM default.foo foo";
+    String targetSql = "SELECT `date`('2021-01-02') a\n" + "FROM default.foo foo";
     assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
   }
 
@@ -579,7 +579,7 @@ public class CoralSparkTest {
   public void testIfWithNullAsSecondParameter() {
     RelNode relNode = TestUtils.toRelNode("SELECT if(FALSE, NULL, named_struct('a', ''))");
 
-    String targetSql = "SELECT if(FALSE, NULL, named_struct('a', ''))\n" + "FROM (VALUES  (0)) t (ZERO)";
+    String targetSql = "SELECT `if`(FALSE, NULL, named_struct('a', ''))\n" + "FROM (VALUES  (0)) t (ZERO)";
     assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
   }
 
@@ -587,7 +587,7 @@ public class CoralSparkTest {
   public void testIfWithNullAsThirdParameter() {
     RelNode relNode = TestUtils.toRelNode("SELECT if(FALSE, named_struct('a', ''), NULL)");
 
-    String targetSql = "SELECT if(FALSE, named_struct('a', ''), NULL)\n" + "FROM (VALUES  (0)) t (ZERO)";
+    String targetSql = "SELECT `if`(FALSE, named_struct('a', ''), NULL)\n" + "FROM (VALUES  (0)) t (ZERO)";
     assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
   }
 

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -73,6 +73,13 @@ public class CoralSparkTest {
   }
 
   @Test
+  public void testTimestamp() {
+    RelNode relNode = TestUtils.toRelNode("default", "baz_view");
+    CoralSpark coralSpark = createCoralSpark(relNode);
+    assertEquals(coralSpark.getSparkSql(), "SELECT baz.`select`, baz.`timestamp`\n" + "FROM default.baz baz");
+  }
+
+  @Test
   public void testLiteralColumnsFromView() {
     // use date literal in view definition
     String targetSql = "SELECT '2013-01-01', '2017-08-22 01:02:03', CAST(123 AS SMALLINT), CAST(123 AS TINYINT)\n"

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -73,7 +73,7 @@ public class CoralSparkTest {
   }
 
   @Test
-  public void testTimestamp() {
+  public void testQuotingKeywords() {
     RelNode relNode = TestUtils.toRelNode("default", "baz_view");
     CoralSpark coralSpark = createCoralSpark(relNode);
     assertEquals(coralSpark.getSparkSql(), "SELECT baz.`select`, baz.`timestamp`\n" + "FROM default.baz baz");

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
@@ -57,6 +57,8 @@ public class TestUtils {
     viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);
     run(driver, "CREATE TABLE IF NOT EXISTS foo(a int, b varchar(30), c double)");
     run(driver, "CREATE TABLE IF NOT EXISTS bar(x int, y double)");
+    run(driver, "CREATE TABLE IF NOT EXISTS baz(`timestamp` int, `select` double)");
+    run(driver, "CREATE VIEW IF NOT EXISTS baz_view as select `select`, `timestamp` from baz");
     run(driver,
         "CREATE TABLE IF NOT EXISTS complex(a int, b string, c array<double>, s struct<name:string, age:int>, m map<string, int>, sarr array<struct<name:string, age:int>>)");
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ def versions = [
   'jetbrains': '16.0.2',
   'jline': '0.9.94',
   'kryo': '2.22',
-  'linkedin-calcite-core': '1.21.0.259',
+  'linkedin-calcite-core': '1.21.0.260',
   'pig': '0.15.0',
   'spark': '2.4.0',
   'spark3': '3.1.1',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:
  1. If you are new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you have added and executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
  7. Make sure that the command './gradlew clean build' passes. Resolve any formatting errors by running './gradlew spotlessApply'.
-->

### What changes are proposed in this pull request, and why are they necessary?
<!--
Kindly explain the proposed changes in this section. The goal is to outline the modifications and how this PR addresses the issue. Also, clarify the reasons for these changes. For example,
  1. If a new API is proposed, explain the intended use case.
  2. If a bug is being fixed, describe why it is a bug.
  3. If design documentation is available, please include the link.
-->
This PR adds quoting for reserved keywords to the generated spark-sql string from coral-spark, using the quoting character "`". The complete list of sql keywords are defined here: https://cwiki.apache.org/confluence/display/hive/languagemanual+ddl#LanguageManualDDL-Keywords,Non-reservedKeywordsandReservedKeywords

This is implemented via overriding the `identifierNeedsQuote` method from SqlDialect class, and calcite internally will hook this into its sql writer to write quoted identifier if it contains a reserved keyword.
### How was this patch tested?
<!--
Please describe all the tests conducted.
If new unit tests were included, mention that they were added in this section. Make sure to add test cases that thoroughly examine both negative and positive cases, if possible.
If the testing approach differed from regular unit tests (e.g., regression testing), please explain how it was conducted.
If no tests were added, please explain why they were not included and/or why it was difficult to add them.
-->
tested via existing unit tests (with modifying 3 unit tests to have backticks since they have keywords in the statements), and the added unit test `testQuotingKeywords`
