### PR TITLE
[Coral-Schema] Add DATE type support in RelDataTypeToAvroType

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
@@ -115,8 +115,7 @@ class RelDataTypeToAvroType {
         schema.addProp("logicalType", "timestamp-millis");
         return schema;
       case DATE:
-        // Spark recognizes the data type of {"type": "int", "logicalType": "date"} as a date type:
-        // https://github.com/apache/spark/blob/master/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala#L145
+        // In Avro, "date" type is represented as {"type": "int", "logicalType": "date"}.
         schema = Schema.create(Schema.Type.INT);
         schema.addProp("logicalType", "date");
         return schema;

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2024 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -90,6 +90,7 @@ class RelDataTypeToAvroType {
   }
 
   private static Schema basicSqlTypeToAvroType(BasicSqlType relDataType) {
+    Schema schema;
     switch (relDataType.getSqlTypeName()) {
       case BOOLEAN:
         return Schema.create(Schema.Type.BOOLEAN);
@@ -110,8 +111,12 @@ class RelDataTypeToAvroType {
       case NULL:
         return Schema.create(Schema.Type.NULL);
       case TIMESTAMP:
-        Schema schema = Schema.create(Schema.Type.LONG);
+        schema = Schema.create(Schema.Type.LONG);
         schema.addProp("logicalType", "timestamp-millis");
+        return schema;
+      case DATE:
+        schema = Schema.create(Schema.Type.INT);
+        schema.addProp("logicalType", "date");
         return schema;
       case DECIMAL:
         JsonNodeFactory factory = JsonNodeFactory.instance;

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
@@ -115,6 +115,8 @@ class RelDataTypeToAvroType {
         schema.addProp("logicalType", "timestamp-millis");
         return schema;
       case DATE:
+        // Spark recognizes the data type of {"type": "int", "logicalType": "date"} as a date type:
+        // https://github.com/apache/spark/blob/master/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala#L145
         schema = Schema.create(Schema.Type.INT);
         schema.addProp("logicalType", "date");
         return schema;

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroTypeTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroTypeTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2020-2024 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -77,5 +77,18 @@ public class RelDataTypeToAvroTypeTests {
 
     Assert.assertEquals(actualAvroType.toString(true),
         TestUtils.loadSchema("rel2avro-testTimestampTypeField-expected.avsc"));
+  }
+
+  @Test
+  public void testDateTypeField() {
+    String viewSql = "CREATE VIEW v AS SELECT * FROM basedatetypefield";
+
+    TestUtils.executeCreateViewQuery("default", "v", viewSql);
+    RelNode relNode = hiveToRelConverter.convertView("default", "v");
+    Schema actualAvroType =
+        RelDataTypeToAvroType.relDataTypeToAvroTypeNonNullable(relNode.getRowType(), "dateTypeField");
+
+    Assert.assertEquals(actualAvroType.toString(true),
+        TestUtils.loadSchema("rel2avro-testDateTypeField-expected.avsc"));
   }
 }

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2024 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -96,6 +96,7 @@ public class TestUtils {
     String baseNestedComplexSchema = loadSchema("base-nested-complex.avsc");
     String baseNullTypeFieldSchema = loadSchema("base-null-type-field.avsc");
     String baseTimestampTypeFieldSchema = loadSchema("base-timestamp-type-field.avsc");
+    String baseDateTypeFieldSchema = loadSchema("base-date-type-field.avsc");
     String baseComplexUnionTypeSchema = loadSchema("base-complex-union-type.avsc");
     String baseNestedUnionSchema = loadSchema("base-nested-union.avsc");
     String baseComplexLowercase = loadSchema("base-complex-lowercase.avsc");
@@ -113,6 +114,7 @@ public class TestUtils {
     executeCreateTableQuery("default", "basenullability", baseNullabilitySchema);
     executeCreateTableQuery("default", "basenulltypefield", baseNullTypeFieldSchema);
     executeCreateTableQuery("default", "basetimestamptypefield", baseTimestampTypeFieldSchema);
+    executeCreateTableQuery("default", "basedatetypefield", baseDateTypeFieldSchema);
     executeCreateTableQuery("default", "basecomplexuniontype", baseComplexUnionTypeSchema);
     executeCreateTableQuery("default", "basenestedunion", baseNestedUnionSchema);
     executeCreateTableQuery("default", "basecomplexlowercase", baseComplexLowercase);

--- a/coral-schema/src/test/resources/base-date-type-field.avsc
+++ b/coral-schema/src/test/resources/base-date-type-field.avsc
@@ -1,0 +1,12 @@
+{
+  "type" : "record",
+  "name" : "basedatetypefield",
+  "namespace" : "coral.schema.avro.base.date.type.field",
+  "fields" : [ {
+    "name" : "Date_Field",
+    "type" : [ "null", {
+      "type" : "int",
+      "logicalType" : "date"
+    } ]
+  } ]
+}

--- a/coral-schema/src/test/resources/rel2avro-testDateTypeField-expected.avsc
+++ b/coral-schema/src/test/resources/rel2avro-testDateTypeField-expected.avsc
@@ -1,0 +1,13 @@
+{
+  "type" : "record",
+  "name" : "dateTypeField",
+  "namespace" : "rel_avro",
+  "fields" : [ {
+    "name" : "date_field",
+    "type" : [ "null", {
+      "type" : "int",
+      "logicalType" : "date"
+    } ],
+    "default" : null
+  } ]
+}

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2024 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:
  1. If you are new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you have added and executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
  7. Make sure that the command './gradlew clean build' passes. Resolve any formatting errors by running './gradlew spotlessApply'.
-->

### What changes are proposed in this pull request, and why are they necessary?
<!--
Kindly explain the proposed changes in this section. The goal is to outline the modifications and how this PR addresses the issue. Also, clarify the reasons for these changes. For example,
  1. If a new API is proposed, explain the intended use case.
  2. If a bug is being fixed, describe why it is a bug.
  3. If design documentation is available, please include the link.
-->
This patch added the `DATE` type support in `RelDataTypeToAvroType` to prevent the exception `java.lang.UnsupportedOperationException: DATE is not supported.`


### How was this patch tested?
<!--
Please describe all the tests conducted.
If new unit tests were included, mention that they were added in this section. Make sure to add test cases that thoroughly examine both negative and positive cases, if possible.
If the testing approach differed from regular unit tests (e.g., regression testing), please explain how it was conducted.
If no tests were added, please explain why they were not included and/or why it was difficult to add them.
-->
1. Unit test
2. Tested on the affected production view, which could be translated well with this PR
3. Tested on Spark shell, the affected production view can be queried well with this PR