### PR TITLE
[Coral-Hive] Create new object for ShiftArrayIndexTransformer

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/transformers/ShiftArrayIndexTransformer.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/transformers/ShiftArrayIndexTransformer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2022-2024 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -42,16 +42,16 @@ public class ShiftArrayIndexTransformer extends SqlCallTransformer {
   @Override
   public SqlCall transform(SqlCall sqlCall) {
     final SqlNode itemNode = sqlCall.getOperandList().get(1);
+    SqlNode newIndex;
     if (itemNode instanceof SqlNumericLiteral
         && deriveRelDatatype(itemNode).getSqlTypeName().equals(SqlTypeName.INTEGER)) {
       final Integer value = ((SqlNumericLiteral) itemNode).getValueAs(Integer.class);
-      sqlCall.setOperand(1,
-          SqlNumericLiteral.createExactNumeric(new BigDecimal(value + 1).toString(), itemNode.getParserPosition()));
+      newIndex =
+          SqlNumericLiteral.createExactNumeric(new BigDecimal(value + 1).toString(), itemNode.getParserPosition());
     } else {
-      final SqlCall oneBasedIndex = SqlStdOperatorTable.PLUS.createCall(itemNode.getParserPosition(), itemNode,
+      newIndex = SqlStdOperatorTable.PLUS.createCall(itemNode.getParserPosition(), itemNode,
           SqlNumericLiteral.createExactNumeric("1", SqlParserPos.ZERO));
-      sqlCall.setOperand(1, oneBasedIndex);
     }
-    return sqlCall;
+    return SqlStdOperatorTable.ITEM.createCall(SqlParserPos.ZERO, sqlCall.getOperandList().get(0), newIndex);
   }
 }

--- a/coral-hive/src/main/java/com/linkedin/coral/transformers/ShiftArrayIndexTransformer.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/transformers/ShiftArrayIndexTransformer.java
@@ -52,6 +52,8 @@ public class ShiftArrayIndexTransformer extends SqlCallTransformer {
       newIndex = SqlStdOperatorTable.PLUS.createCall(itemNode.getParserPosition(), itemNode,
           SqlNumericLiteral.createExactNumeric("1", SqlParserPos.ZERO));
     }
+    // Create new object instead of modifying the old SqlCall to avoid transforming the same object
+    // multiple times if it appears multiple times in SqlNode
     return SqlStdOperatorTable.ITEM.createCall(SqlParserPos.ZERO, sqlCall.getOperandList().get(0), newIndex);
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:
  1. If you are new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you have added and executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
  7. Make sure that the command './gradlew clean build' passes. Resolve any formatting errors by running './gradlew spotlessApply'.
-->

### What changes are proposed in this pull request, and why are they necessary?
<!--
Kindly explain the proposed changes in this section. The goal is to outline the modifications and how this PR addresses the issue. Also, clarify the reasons for these changes. For example,
  1. If a new API is proposed, explain the intended use case.
  2. If a bug is being fixed, describe why it is a bug.
  3. If design documentation is available, please include the link.
-->
Prior to this PR, `ShiftArrayIndexTransformer` modifies the index of the SqlCall directly, which might transform the same object multiple times if it appears multiple times in SqlNode and generate the wrong index. This PR fixes this issue by creating new object for ShiftArrayIndexTransformer.

### How was this patch tested?
<!--
Please describe all the tests conducted.
If new unit tests were included, mention that they were added in this section. Make sure to add test cases that thoroughly examine both negative and positive cases, if possible.
If the testing approach differed from regular unit tests (e.g., regression testing), please explain how it was conducted.
If no tests were added, please explain why they were not included and/or why it was difficult to add them.
-->
1. Tested on the affected prod view, worked as expected
2. Regression test on all prod views, no regression
3. Note: I couldn't reproduce the issue by UT somehow, still investigating the reason. If it still can't be reproduced by UT locally after spending much time, the PR can be merged and we can make UT as a follow-up work.