### PR TITLE
[Coral-Trino] Fix substring start index issue

### DIFF
--- a/coral-common/src/main/java/com/linkedin/coral/common/transformers/JsonTransformSqlCallTransformer.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/transformers/JsonTransformSqlCallTransformer.java
@@ -50,6 +50,8 @@ public class JsonTransformSqlCallTransformer extends SourceOperatorMatchSqlCallT
     OP_MAP.put("/", SqlStdOperatorTable.DIVIDE);
     OP_MAP.put("^", SqlStdOperatorTable.POWER);
     OP_MAP.put("%", SqlStdOperatorTable.MOD);
+    OP_MAP.put("greatest", new SqlUserDefinedFunction(new SqlIdentifier("greatest", SqlParserPos.ZERO), ReturnTypes.ARG0_NULLABLE, null,
+        OperandTypes.SAME_VARIADIC, null, null));
     OP_MAP.put("date", new SqlUserDefinedFunction(new SqlIdentifier("date", SqlParserPos.ZERO), ReturnTypes.DATE, null,
         OperandTypes.STRING, null, null));
     OP_MAP.put("timestamp", new SqlUserDefinedFunction(new SqlIdentifier("timestamp", SqlParserPos.ZERO),

--- a/coral-common/src/main/java/com/linkedin/coral/common/transformers/JsonTransformSqlCallTransformer.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/transformers/JsonTransformSqlCallTransformer.java
@@ -50,8 +50,6 @@ public class JsonTransformSqlCallTransformer extends SourceOperatorMatchSqlCallT
     OP_MAP.put("/", SqlStdOperatorTable.DIVIDE);
     OP_MAP.put("^", SqlStdOperatorTable.POWER);
     OP_MAP.put("%", SqlStdOperatorTable.MOD);
-    OP_MAP.put("greatest", new SqlUserDefinedFunction(new SqlIdentifier("greatest", SqlParserPos.ZERO),
-        ReturnTypes.ARG0_NULLABLE, null, OperandTypes.SAME_VARIADIC, null, null));
     OP_MAP.put("date", new SqlUserDefinedFunction(new SqlIdentifier("date", SqlParserPos.ZERO), ReturnTypes.DATE, null,
         OperandTypes.STRING, null, null));
     OP_MAP.put("timestamp", new SqlUserDefinedFunction(new SqlIdentifier("timestamp", SqlParserPos.ZERO),

--- a/coral-common/src/main/java/com/linkedin/coral/common/transformers/JsonTransformSqlCallTransformer.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/transformers/JsonTransformSqlCallTransformer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2023-2024 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -50,8 +50,8 @@ public class JsonTransformSqlCallTransformer extends SourceOperatorMatchSqlCallT
     OP_MAP.put("/", SqlStdOperatorTable.DIVIDE);
     OP_MAP.put("^", SqlStdOperatorTable.POWER);
     OP_MAP.put("%", SqlStdOperatorTable.MOD);
-    OP_MAP.put("greatest", new SqlUserDefinedFunction(new SqlIdentifier("greatest", SqlParserPos.ZERO), ReturnTypes.ARG0_NULLABLE, null,
-        OperandTypes.SAME_VARIADIC, null, null));
+    OP_MAP.put("greatest", new SqlUserDefinedFunction(new SqlIdentifier("greatest", SqlParserPos.ZERO),
+        ReturnTypes.ARG0_NULLABLE, null, OperandTypes.SAME_VARIADIC, null, null));
     OP_MAP.put("date", new SqlUserDefinedFunction(new SqlIdentifier("date", SqlParserPos.ZERO), ReturnTypes.DATE, null,
         OperandTypes.STRING, null, null));
     OP_MAP.put("timestamp", new SqlUserDefinedFunction(new SqlIdentifier("timestamp", SqlParserPos.ZERO),

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CoralToTrinoSqlCallConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CoralToTrinoSqlCallConverter.java
@@ -34,6 +34,7 @@ import com.linkedin.coral.trino.rel2trino.transformers.MapValueConstructorTransf
 import com.linkedin.coral.trino.rel2trino.transformers.NullOrderingTransformer;
 import com.linkedin.coral.trino.rel2trino.transformers.ReturnTypeAdjustmentTransformer;
 import com.linkedin.coral.trino.rel2trino.transformers.SqlSelectAliasAppenderTransformer;
+import com.linkedin.coral.trino.rel2trino.transformers.SubstrIndexTransformer;
 import com.linkedin.coral.trino.rel2trino.transformers.ToDateOperatorTransformer;
 import com.linkedin.coral.trino.rel2trino.transformers.UnnestOperatorTransformer;
 
@@ -72,17 +73,6 @@ public class CoralToTrinoSqlCallConverter extends SqlShuttle {
             "[{\"op\":\"*\",\"operands\":[{\"input\":1},{\"op\":\"^\",\"operands\":[{\"value\":10},{\"input\":2}]}]}]",
             "{\"op\":\"/\",\"operands\":[{\"input\":0},{\"op\":\"^\",\"operands\":[{\"value\":10},{\"input\":2}]}]}",
             null),
-        // string functions
-        new JsonTransformSqlCallTransformer(SqlStdOperatorTable.SUBSTRING, 2, "substr",
-            "[{\"input\": 1}, {\"op\": \"greatest\", \"operands\": [{\"input\": 2}, {\"value\": 1}]}]", null, null),
-        new JsonTransformSqlCallTransformer(SqlStdOperatorTable.SUBSTRING, 3, "substr",
-            "[{\"input\": 1}, {\"op\": \"greatest\", \"operands\": [{\"input\": 2}, {\"value\": 1}]}, {\"input\": 3}]",
-            null, null),
-        new JsonTransformSqlCallTransformer(hiveToCoralSqlOperator("substr"), 2, "substr",
-            "[{\"input\": 1}, {\"op\": \"greatest\", \"operands\": [{\"input\": 2}, {\"value\": 1}]}]", null, null),
-        new JsonTransformSqlCallTransformer(hiveToCoralSqlOperator("substr"), 3, "substr",
-            "[{\"input\": 1}, {\"op\": \"greatest\", \"operands\": [{\"input\": 2}, {\"value\": 1}]}, {\"input\": 3}]",
-            null, null),
         // JSON functions
         new CoralRegistryOperatorRenameSqlCallTransformer("get_json_object", 2, "json_extract"),
         // map various hive functions
@@ -135,7 +125,7 @@ public class CoralToTrinoSqlCallConverter extends SqlShuttle {
         new GenericCoralRegistryOperatorRenameSqlCallTransformer(),
 
         new ReturnTypeAdjustmentTransformer(configs), new UnnestOperatorTransformer(), new AsOperatorTransformer(),
-        new JoinSqlCallTransformer(), new NullOrderingTransformer());
+        new JoinSqlCallTransformer(), new NullOrderingTransformer(), new SubstrIndexTransformer());
   }
 
   private SqlOperator hiveToCoralSqlOperator(String functionName) {

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CoralToTrinoSqlCallConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CoralToTrinoSqlCallConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2024 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -76,13 +76,13 @@ public class CoralToTrinoSqlCallConverter extends SqlShuttle {
         new JsonTransformSqlCallTransformer(SqlStdOperatorTable.SUBSTRING, 2, "substr",
             "[{\"input\": 1}, {\"op\": \"greatest\", \"operands\": [{\"input\": 2}, {\"value\": 1}]}]", null, null),
         new JsonTransformSqlCallTransformer(SqlStdOperatorTable.SUBSTRING, 3, "substr",
-            "[{\"input\": 1}, {\"op\": \"greatest\", \"operands\": [{\"input\": 2}, {\"value\": 1}]}, {\"input\": 3}]", null,
-            null),
+            "[{\"input\": 1}, {\"op\": \"greatest\", \"operands\": [{\"input\": 2}, {\"value\": 1}]}, {\"input\": 3}]",
+            null, null),
         new JsonTransformSqlCallTransformer(hiveToCoralSqlOperator("substr"), 2, "substr",
             "[{\"input\": 1}, {\"op\": \"greatest\", \"operands\": [{\"input\": 2}, {\"value\": 1}]}]", null, null),
         new JsonTransformSqlCallTransformer(hiveToCoralSqlOperator("substr"), 3, "substr",
-            "[{\"input\": 1}, {\"op\": \"greatest\", \"operands\": [{\"input\": 2}, {\"value\": 1}]}, {\"input\": 3}]", null,
-            null),
+            "[{\"input\": 1}, {\"op\": \"greatest\", \"operands\": [{\"input\": 2}, {\"value\": 1}]}, {\"input\": 3}]",
+            null, null),
         // JSON functions
         new CoralRegistryOperatorRenameSqlCallTransformer("get_json_object", 2, "json_extract"),
         // map various hive functions

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CoralToTrinoSqlCallConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/CoralToTrinoSqlCallConverter.java
@@ -74,14 +74,14 @@ public class CoralToTrinoSqlCallConverter extends SqlShuttle {
             null),
         // string functions
         new JsonTransformSqlCallTransformer(SqlStdOperatorTable.SUBSTRING, 2, "substr",
-            "[{\"input\": 1}, {\"op\": \"+\", \"operands\": [{\"input\": 2}, {\"value\": 1}]}]", null, null),
+            "[{\"input\": 1}, {\"op\": \"greatest\", \"operands\": [{\"input\": 2}, {\"value\": 1}]}]", null, null),
         new JsonTransformSqlCallTransformer(SqlStdOperatorTable.SUBSTRING, 3, "substr",
-            "[{\"input\": 1}, {\"op\": \"+\", \"operands\": [{\"input\": 2}, {\"value\": 1}]}, {\"input\": 3}]", null,
+            "[{\"input\": 1}, {\"op\": \"greatest\", \"operands\": [{\"input\": 2}, {\"value\": 1}]}, {\"input\": 3}]", null,
             null),
         new JsonTransformSqlCallTransformer(hiveToCoralSqlOperator("substr"), 2, "substr",
-            "[{\"input\": 1}, {\"op\": \"+\", \"operands\": [{\"input\": 2}, {\"value\": 1}]}]", null, null),
+            "[{\"input\": 1}, {\"op\": \"greatest\", \"operands\": [{\"input\": 2}, {\"value\": 1}]}]", null, null),
         new JsonTransformSqlCallTransformer(hiveToCoralSqlOperator("substr"), 3, "substr",
-            "[{\"input\": 1}, {\"op\": \"+\", \"operands\": [{\"input\": 2}, {\"value\": 1}]}, {\"input\": 3}]", null,
+            "[{\"input\": 1}, {\"op\": \"greatest\", \"operands\": [{\"input\": 2}, {\"value\": 1}]}, {\"input\": 3}]", null,
             null),
         // JSON functions
         new CoralRegistryOperatorRenameSqlCallTransformer("get_json_object", 2, "json_extract"),

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/SubstrIndexTransformer.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/SubstrIndexTransformer.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2023-2024 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.trino.rel2trino.transformers;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNumericLiteral;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+
+import com.linkedin.coral.common.calcite.CalciteUtil;
+import com.linkedin.coral.common.transformers.SqlCallTransformer;
+
+import static org.apache.calcite.rel.rel2sql.SqlImplementor.*;
+import static org.apache.calcite.sql.fun.SqlStdOperatorTable.*;
+
+
+/**
+ * This class transforms the substr indexing in the input SqlCall to be compatible with Trino engine.
+ * Trino uses 1-based indexing for substr, so the lowest possible index is 1. While other engines like Hive
+ * allow for 0 as a valid index.
+ *
+ * This transformer guarantees that starting index will always 1 or greater.
+ */
+public class SubstrIndexTransformer extends SqlCallTransformer {
+  @Override
+  protected boolean condition(SqlCall sqlCall) {
+    return sqlCall.getOperator().getName().toLowerCase() == "substr"
+        || sqlCall.getOperator().getName().toLowerCase() == "substring";
+  }
+
+  @Override
+  protected SqlCall transform(SqlCall sqlCall) {
+    final List<SqlNode> operandList = sqlCall.getOperandList();
+    SqlNode start = operandList.get(1);
+    if (start instanceof SqlNumericLiteral) {
+      int startInt = ((SqlNumericLiteral) operandList.get(1)).getValueAs(Integer.class);
+
+      if (startInt == 0) {
+        SqlNumericLiteral newStart = SqlNumericLiteral.createExactNumeric(String.valueOf(1), POS);
+        sqlCall.setOperand(1, newStart);
+        return sqlCall;
+      }
+
+    } else if (start instanceof SqlIdentifier) {
+      // If we don't have a literal start index value, we need to use a case statement with the column identifier to ensure the value is always 1 or greater
+      // So instead of just "col_name" as the start index, we have "CASE WHEN col_name = 0 THEN 1 ELSE col_name END"
+      List<SqlNode> whenClauses = Arrays
+          .asList(SqlStdOperatorTable.EQUALS.createCall(POS, start, SqlNumericLiteral.createExactNumeric("0", POS)));
+      List<SqlNode> thenClauses = Arrays.asList(SqlNumericLiteral.createExactNumeric("1", POS));
+
+      sqlCall.setOperand(1,
+          CASE.createCall(null, POS, null, CalciteUtil.createSqlNodeList(whenClauses, POS),
+              CalciteUtil.createSqlNodeList(thenClauses, POS),
+              start // default/else condition
+          ));
+
+      return sqlCall;
+    }
+
+    return sqlCall;
+  }
+}

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/SubstrIndexTransformer.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/SubstrIndexTransformer.java
@@ -7,6 +7,7 @@ package com.linkedin.coral.trino.rel2trino.transformers;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
@@ -14,6 +15,7 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNumericLiteral;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 
+import com.linkedin.coral.com.google.common.collect.ImmutableSet;
 import com.linkedin.coral.common.calcite.CalciteUtil;
 import com.linkedin.coral.common.transformers.SqlCallTransformer;
 
@@ -29,10 +31,10 @@ import static org.apache.calcite.sql.fun.SqlStdOperatorTable.*;
  * This transformer guarantees that starting index will always 1 or greater.
  */
 public class SubstrIndexTransformer extends SqlCallTransformer {
+  private final static Set<String> SUBSTRING_OPERATORS = ImmutableSet.of("substr", "substring");
   @Override
   protected boolean condition(SqlCall sqlCall) {
-    return sqlCall.getOperator().getName().toLowerCase() == "substr"
-        || sqlCall.getOperator().getName().toLowerCase() == "substring";
+    return SUBSTRING_OPERATORS.contains(sqlCall.getOperator().getName().toLowerCase());
   }
 
   @Override

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/SubstrIndexTransformer.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/SubstrIndexTransformer.java
@@ -45,7 +45,6 @@ public class SubstrIndexTransformer extends SqlCallTransformer {
       if (startInt == 0) {
         SqlNumericLiteral newStart = SqlNumericLiteral.createExactNumeric(String.valueOf(1), POS);
         sqlCall.setOperand(1, newStart);
-        return sqlCall;
       }
 
     } else if (start instanceof SqlIdentifier) {
@@ -57,8 +56,6 @@ public class SubstrIndexTransformer extends SqlCallTransformer {
 
       sqlCall.setOperand(1, CASE.createCall(null, POS, null, CalciteUtil.createSqlNodeList(whenClauses, POS),
           CalciteUtil.createSqlNodeList(thenClauses, POS), start));
-
-      return sqlCall;
     }
 
     return sqlCall;

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/SubstrIndexTransformer.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/SubstrIndexTransformer.java
@@ -55,11 +55,8 @@ public class SubstrIndexTransformer extends SqlCallTransformer {
           .asList(SqlStdOperatorTable.EQUALS.createCall(POS, start, SqlNumericLiteral.createExactNumeric("0", POS)));
       List<SqlNode> thenClauses = Arrays.asList(SqlNumericLiteral.createExactNumeric("1", POS));
 
-      sqlCall.setOperand(1,
-          CASE.createCall(null, POS, null, CalciteUtil.createSqlNodeList(whenClauses, POS),
-              CalciteUtil.createSqlNodeList(thenClauses, POS),
-              start // default/else condition
-          ));
+      sqlCall.setOperand(1, CASE.createCall(null, POS, null, CalciteUtil.createSqlNodeList(whenClauses, POS),
+          CalciteUtil.createSqlNodeList(thenClauses, POS), start));
 
       return sqlCall;
     }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -162,7 +162,7 @@ public class HiveToTrinoConverterTest {
         { "test", "view_from_utc_timestamp", "SELECT CAST(\"at_timezone\"(\"from_unixtime_nanos\"(CAST(\"table_from_utc_timestamp\".\"a_tinyint\" AS BIGINT) * 1000000), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime_nanos\"(CAST(\"table_from_utc_timestamp\".\"a_smallint\" AS BIGINT) * 1000000), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime_nanos\"(CAST(\"table_from_utc_timestamp\".\"a_integer\" AS BIGINT) * 1000000), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime_nanos\"(CAST(\"table_from_utc_timestamp\".\"a_bigint\" AS BIGINT) * 1000000), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime\"(CAST(\"table_from_utc_timestamp\".\"a_float\" AS DOUBLE)), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime\"(CAST(\"table_from_utc_timestamp\".\"a_double\" AS DOUBLE)), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime\"(CAST(\"table_from_utc_timestamp\".\"a_decimal_three\" AS DOUBLE)), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime\"(CAST(\"table_from_utc_timestamp\".\"a_decimal_zero\" AS DOUBLE)), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime\"(\"to_unixtime\"(\"with_timezone\"(\"table_from_utc_timestamp\".\"a_timestamp\", 'UTC'))), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime\"(\"to_unixtime\"(\"with_timezone\"(\"table_from_utc_timestamp\".\"a_date\", 'UTC'))), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3))\n"
             + "FROM \"test\".\"table_from_utc_timestamp\" AS \"table_from_utc_timestamp\"" },
 
-        { "test", "date_calculation_view", "SELECT \"date\"(CAST(\"substr\"('2021-08-20', \"greatest\"(1, 1), 10) AS TIMESTAMP)), \"date\"(CAST('2021-08-20' AS TIMESTAMP)), \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP)), \"date_add\"('day', 1, \"date\"(CAST('2021-08-20' AS TIMESTAMP))), \"date_add\"('day', 1, \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP))), \"date_add\"('day', 1 * -1, \"date\"(CAST('2021-08-20' AS TIMESTAMP))), \"date_add\"('day', 1 * -1, \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP))), CAST(\"date_diff\"('day', \"date\"(CAST('2021-08-21' AS TIMESTAMP)), \"date\"(CAST('2021-08-20' AS TIMESTAMP))) AS INTEGER), CAST(\"date_diff\"('day', \"date\"(CAST('2021-08-19' AS TIMESTAMP)), \"date\"(CAST('2021-08-20' AS TIMESTAMP))) AS INTEGER), CAST(\"date_diff\"('day', \"date\"(CAST('2021-08-19 23:59:59' AS TIMESTAMP)), \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP))) AS INTEGER)\n"
+        { "test", "date_calculation_view", "SELECT \"date\"(CAST(\"substr\"('2021-08-20', 1, 10) AS TIMESTAMP)), \"date\"(CAST('2021-08-20' AS TIMESTAMP)), \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP)), \"date_add\"('day', 1, \"date\"(CAST('2021-08-20' AS TIMESTAMP))), \"date_add\"('day', 1, \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP))), \"date_add\"('day', 1 * -1, \"date\"(CAST('2021-08-20' AS TIMESTAMP))), \"date_add\"('day', 1 * -1, \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP))), CAST(\"date_diff\"('day', \"date\"(CAST('2021-08-21' AS TIMESTAMP)), \"date\"(CAST('2021-08-20' AS TIMESTAMP))) AS INTEGER), CAST(\"date_diff\"('day', \"date\"(CAST('2021-08-19' AS TIMESTAMP)), \"date\"(CAST('2021-08-20' AS TIMESTAMP))) AS INTEGER), CAST(\"date_diff\"('day', \"date\"(CAST('2021-08-19 23:59:59' AS TIMESTAMP)), \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP))) AS INTEGER)\n"
             + "FROM \"test\".\"tablea\" AS \"tablea\"" },
 
         { "test", "pmod_view", "SELECT MOD(MOD(- 9, 4) + 4, 4)\n" + "FROM \"test\".\"tablea\" AS \"tablea\"" },
@@ -349,9 +349,8 @@ public class HiveToTrinoConverterTest {
   public void testAvoidTransformToDate() {
     RelNode relNode = TestUtils.getHiveToRelConverter()
         .convertSql("SELECT to_date(substr('2021-08-20', 1, 10)), to_date('2021-08-20')" + "FROM test.tableA");
-    String targetSql =
-        "SELECT \"to_date\"(\"substr\"('2021-08-20', \"greatest\"(1, 1), 10)), \"to_date\"('2021-08-20')\n"
-            + "FROM \"test\".\"tablea\" AS \"tablea\"";
+    String targetSql = "SELECT \"to_date\"(\"substr\"('2021-08-20', 1, 10)), \"to_date\"('2021-08-20')\n"
+        + "FROM \"test\".\"tablea\" AS \"tablea\"";
 
     RelToTrinoConverter relToTrinoConverter =
         TestUtils.getRelToTrinoConverter(ImmutableMap.of(AVOID_TRANSFORM_TO_DATE_UDF, true));
@@ -574,7 +573,7 @@ public class HiveToTrinoConverterTest {
     RelNode relNode = TestUtils.getHiveToRelConverter().convertSql(
         "SELECT substring(from_utc_timestamp(a_bigint,'PST'),1,10) AS d\nFROM test.table_from_utc_timestamp");
     String targetSql =
-        "SELECT \"substr\"(CAST(CAST(\"at_timezone\"(\"from_unixtime_nanos\"(CAST(\"table_from_utc_timestamp\".\"a_bigint\" AS BIGINT) * 1000000), \"$canonicalize_hive_timezone_id\"('PST')) AS TIMESTAMP(3)) AS VARCHAR(65535)), \"greatest\"(1, 1), 10) AS \"d\"\n"
+        "SELECT \"substr\"(CAST(CAST(\"at_timezone\"(\"from_unixtime_nanos\"(CAST(\"table_from_utc_timestamp\".\"a_bigint\" AS BIGINT) * 1000000), \"$canonicalize_hive_timezone_id\"('PST')) AS TIMESTAMP(3)) AS VARCHAR(65535)), 1, 10) AS \"d\"\n"
             + "FROM \"test\".\"table_from_utc_timestamp\" AS \"table_from_utc_timestamp\"";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
@@ -582,7 +581,7 @@ public class HiveToTrinoConverterTest {
     relNode = TestUtils.getHiveToRelConverter().convertSql(
         "SELECT substring(from_utc_timestamp(a_decimal_three,'PST'),1,10) AS d\nFROM test.table_from_utc_timestamp");
     targetSql =
-        "SELECT \"substr\"(CAST(CAST(\"at_timezone\"(\"from_unixtime\"(CAST(\"table_from_utc_timestamp0\".\"a_decimal_three\" AS DOUBLE)), \"$canonicalize_hive_timezone_id\"('PST')) AS TIMESTAMP(3)) AS VARCHAR(65535)), \"greatest\"(1, 1), 10) AS \"d\"\n"
+        "SELECT \"substr\"(CAST(CAST(\"at_timezone\"(\"from_unixtime\"(CAST(\"table_from_utc_timestamp0\".\"a_decimal_three\" AS DOUBLE)), \"$canonicalize_hive_timezone_id\"('PST')) AS TIMESTAMP(3)) AS VARCHAR(65535)), 1, 10) AS \"d\"\n"
             + "FROM \"test\".\"table_from_utc_timestamp\" AS \"table_from_utc_timestamp0\"";
     expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
@@ -590,7 +589,7 @@ public class HiveToTrinoConverterTest {
     relNode = TestUtils.getHiveToRelConverter().convertSql(
         "SELECT substring(from_utc_timestamp(a_timestamp,'PST'),1,10) AS d\nFROM test.table_from_utc_timestamp");
     targetSql =
-        "SELECT \"substr\"(CAST(CAST(\"at_timezone\"(\"from_unixtime\"(\"to_unixtime\"(\"with_timezone\"(\"table_from_utc_timestamp1\".\"a_timestamp\", 'UTC'))), \"$canonicalize_hive_timezone_id\"('PST')) AS TIMESTAMP(3)) AS VARCHAR(65535)), \"greatest\"(1, 1), 10) AS \"d\"\n"
+        "SELECT \"substr\"(CAST(CAST(\"at_timezone\"(\"from_unixtime\"(\"to_unixtime\"(\"with_timezone\"(\"table_from_utc_timestamp1\".\"a_timestamp\", 'UTC'))), \"$canonicalize_hive_timezone_id\"('PST')) AS TIMESTAMP(3)) AS VARCHAR(65535)), 1, 10) AS \"d\"\n"
             + "FROM \"test\".\"table_from_utc_timestamp\" AS \"table_from_utc_timestamp1\"";
     expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
@@ -726,7 +725,7 @@ public class HiveToTrinoConverterTest {
     RelNode relNode = TestUtils.getHiveToRelConverter()
         .convertSql("SELECT SUBSTR(a_timestamp, 12, 8) AS d\nFROM test.table_from_utc_timestamp");
     String targetSql =
-        "SELECT \"substr\"(CAST(\"table_from_utc_timestamp\".\"a_timestamp\" AS VARCHAR(65535)), \"greatest\"(12, 1), 8) AS \"d\"\n"
+        "SELECT \"substr\"(CAST(\"table_from_utc_timestamp\".\"a_timestamp\" AS VARCHAR(65535)), 12, 8) AS \"d\"\n"
             + "FROM \"test\".\"table_from_utc_timestamp\" AS \"table_from_utc_timestamp\"";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
@@ -734,7 +733,7 @@ public class HiveToTrinoConverterTest {
     relNode = TestUtils.getHiveToRelConverter()
         .convertSql("SELECT SUBSTRING(a_timestamp, 12, 8) AS d\nFROM test.table_from_utc_timestamp");
     targetSql =
-        "SELECT \"substr\"(CAST(\"table_from_utc_timestamp0\".\"a_timestamp\" AS VARCHAR(65535)), \"greatest\"(12, 1), 8) AS \"d\"\n"
+        "SELECT \"substr\"(CAST(\"table_from_utc_timestamp0\".\"a_timestamp\" AS VARCHAR(65535)), 12, 8) AS \"d\"\n"
             + "FROM \"test\".\"table_from_utc_timestamp\" AS \"table_from_utc_timestamp0\"";
     expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
@@ -747,9 +746,8 @@ public class HiveToTrinoConverterTest {
     RelNode relNode = TestUtils.getHiveToRelConverter()
         .convertSql("SELECT a, SUBSTR(b, 1, 1) AS aliased_column, c FROM test.tabler ORDER BY aliased_column DESC");
     String targetSql =
-        "SELECT \"tabler\".\"a\" AS \"a\", \"substr\"(\"tabler\".\"b\", \"greatest\"(1, 1), 1) AS \"aliased_column\", \"tabler\".\"c\" AS \"c\"\n"
-            + "FROM \"test\".\"tabler\" AS \"tabler\"\n"
-            + "ORDER BY \"substr\"(\"tabler\".\"b\", \"greatest\"(1, 1), 1) DESC";
+        "SELECT \"tabler\".\"a\" AS \"a\", \"substr\"(\"tabler\".\"b\", 1, 1) AS \"aliased_column\", \"tabler\".\"c\" AS \"c\"\n"
+            + "FROM \"test\".\"tabler\" AS \"tabler\"\n" + "ORDER BY \"substr\"(\"tabler\".\"b\", 1, 1) DESC";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
@@ -761,9 +759,9 @@ public class HiveToTrinoConverterTest {
     RelNode relNode = TestUtils.getHiveToRelConverter().convertSql(
         "SELECT a, SUBSTR(b, 1, 1) AS aliased_column, c FROM test.tabler ORDER BY aliased_column DESC, a DESC, c DESC");
     String targetSql =
-        "SELECT \"tabler\".\"a\" AS \"a\", \"substr\"(\"tabler\".\"b\", \"greatest\"(1, 1), 1) AS \"aliased_column\", \"tabler\".\"c\" AS \"c\"\n"
+        "SELECT \"tabler\".\"a\" AS \"a\", \"substr\"(\"tabler\".\"b\", 1, 1) AS \"aliased_column\", \"tabler\".\"c\" AS \"c\"\n"
             + "FROM \"test\".\"tabler\" AS \"tabler\"\n"
-            + "ORDER BY \"substr\"(\"tabler\".\"b\", \"greatest\"(1, 1), 1) DESC, \"tabler\".\"a\" DESC, \"tabler\".\"c\" DESC";
+            + "ORDER BY \"substr\"(\"tabler\".\"b\", 1, 1) DESC, \"tabler\".\"a\" DESC, \"tabler\".\"c\" DESC";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
@@ -789,9 +787,8 @@ public class HiveToTrinoConverterTest {
         .convertSql("SELECT a, SUBSTR(b, 1, 1) AS aliased_column, c FROM test.tabler ORDER BY aliased_column ASC");
     // We want NULLS FIRST since we're translating from Hive and that is the default null ordering for ASC in Hive
     String targetSql =
-        "SELECT \"tabler\".\"a\" AS \"a\", \"substr\"(\"tabler\".\"b\", \"greatest\"(1, 1), 1) AS \"aliased_column\", \"tabler\".\"c\" AS \"c\"\n"
-            + "FROM \"test\".\"tabler\" AS \"tabler\"\n"
-            + "ORDER BY \"substr\"(\"tabler\".\"b\", \"greatest\"(1, 1), 1) NULLS FIRST";
+        "SELECT \"tabler\".\"a\" AS \"a\", \"substr\"(\"tabler\".\"b\", 1, 1) AS \"aliased_column\", \"tabler\".\"c\" AS \"c\"\n"
+            + "FROM \"test\".\"tabler\" AS \"tabler\"\n" + "ORDER BY \"substr\"(\"tabler\".\"b\", 1, 1) NULLS FIRST";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
@@ -802,10 +799,9 @@ public class HiveToTrinoConverterTest {
 
     RelNode relNode = TestUtils.getHiveToRelConverter().convertSql(
         "SELECT a, SUBSTR(b, 1, 1) AS aliased_column FROM test.tabler GROUP BY a, b HAVING aliased_column in ('dummy_value')");
-    String targetSql =
-        "SELECT \"tabler\".\"a\" AS \"a\", \"substr\"(\"tabler\".\"b\", \"greatest\"(1, 1), 1) AS \"aliased_column\"\n"
-            + "FROM \"test\".\"tabler\" AS \"tabler\"\n" + "GROUP BY \"tabler\".\"a\", \"tabler\".\"b\"\n"
-            + "HAVING \"substr\"(\"tabler\".\"b\", \"greatest\"(1, 1), 1)\n" + "IN ('dummy_value')";
+    String targetSql = "SELECT \"tabler\".\"a\" AS \"a\", \"substr\"(\"tabler\".\"b\", 1, 1) AS \"aliased_column\"\n"
+        + "FROM \"test\".\"tabler\" AS \"tabler\"\n" + "GROUP BY \"tabler\".\"a\", \"tabler\".\"b\"\n"
+        + "HAVING \"substr\"(\"tabler\".\"b\", 1, 1)\n" + "IN ('dummy_value')";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -162,7 +162,7 @@ public class HiveToTrinoConverterTest {
         { "test", "view_from_utc_timestamp", "SELECT CAST(\"at_timezone\"(\"from_unixtime_nanos\"(CAST(\"table_from_utc_timestamp\".\"a_tinyint\" AS BIGINT) * 1000000), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime_nanos\"(CAST(\"table_from_utc_timestamp\".\"a_smallint\" AS BIGINT) * 1000000), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime_nanos\"(CAST(\"table_from_utc_timestamp\".\"a_integer\" AS BIGINT) * 1000000), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime_nanos\"(CAST(\"table_from_utc_timestamp\".\"a_bigint\" AS BIGINT) * 1000000), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime\"(CAST(\"table_from_utc_timestamp\".\"a_float\" AS DOUBLE)), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime\"(CAST(\"table_from_utc_timestamp\".\"a_double\" AS DOUBLE)), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime\"(CAST(\"table_from_utc_timestamp\".\"a_decimal_three\" AS DOUBLE)), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime\"(CAST(\"table_from_utc_timestamp\".\"a_decimal_zero\" AS DOUBLE)), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime\"(\"to_unixtime\"(\"with_timezone\"(\"table_from_utc_timestamp\".\"a_timestamp\", 'UTC'))), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3)), CAST(\"at_timezone\"(\"from_unixtime\"(\"to_unixtime\"(\"with_timezone\"(\"table_from_utc_timestamp\".\"a_date\", 'UTC'))), \"$canonicalize_hive_timezone_id\"('America/Los_Angeles')) AS TIMESTAMP(3))\n"
             + "FROM \"test\".\"table_from_utc_timestamp\" AS \"table_from_utc_timestamp\"" },
 
-        { "test", "date_calculation_view", "SELECT \"date\"(CAST(\"substr\"('2021-08-20', 1 + 1, 10) AS TIMESTAMP)), \"date\"(CAST('2021-08-20' AS TIMESTAMP)), \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP)), \"date_add\"('day', 1, \"date\"(CAST('2021-08-20' AS TIMESTAMP))), \"date_add\"('day', 1, \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP))), \"date_add\"('day', 1 * -1, \"date\"(CAST('2021-08-20' AS TIMESTAMP))), \"date_add\"('day', 1 * -1, \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP))), CAST(\"date_diff\"('day', \"date\"(CAST('2021-08-21' AS TIMESTAMP)), \"date\"(CAST('2021-08-20' AS TIMESTAMP))) AS INTEGER), CAST(\"date_diff\"('day', \"date\"(CAST('2021-08-19' AS TIMESTAMP)), \"date\"(CAST('2021-08-20' AS TIMESTAMP))) AS INTEGER), CAST(\"date_diff\"('day', \"date\"(CAST('2021-08-19 23:59:59' AS TIMESTAMP)), \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP))) AS INTEGER)\n"
+        { "test", "date_calculation_view", "SELECT \"date\"(CAST(\"substr\"('2021-08-20', \"greatest\"(1, 1), 10) AS TIMESTAMP)), \"date\"(CAST('2021-08-20' AS TIMESTAMP)), \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP)), \"date_add\"('day', 1, \"date\"(CAST('2021-08-20' AS TIMESTAMP))), \"date_add\"('day', 1, \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP))), \"date_add\"('day', 1 * -1, \"date\"(CAST('2021-08-20' AS TIMESTAMP))), \"date_add\"('day', 1 * -1, \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP))), CAST(\"date_diff\"('day', \"date\"(CAST('2021-08-21' AS TIMESTAMP)), \"date\"(CAST('2021-08-20' AS TIMESTAMP))) AS INTEGER), CAST(\"date_diff\"('day', \"date\"(CAST('2021-08-19' AS TIMESTAMP)), \"date\"(CAST('2021-08-20' AS TIMESTAMP))) AS INTEGER), CAST(\"date_diff\"('day', \"date\"(CAST('2021-08-19 23:59:59' AS TIMESTAMP)), \"date\"(CAST('2021-08-20 00:00:00' AS TIMESTAMP))) AS INTEGER)\n"
             + "FROM \"test\".\"tablea\" AS \"tablea\"" },
 
         { "test", "pmod_view", "SELECT MOD(MOD(- 9, 4) + 4, 4)\n" + "FROM \"test\".\"tablea\" AS \"tablea\"" },
@@ -349,7 +349,7 @@ public class HiveToTrinoConverterTest {
   public void testAvoidTransformToDate() {
     RelNode relNode = TestUtils.getHiveToRelConverter()
         .convertSql("SELECT to_date(substr('2021-08-20', 1, 10)), to_date('2021-08-20')" + "FROM test.tableA");
-    String targetSql = "SELECT \"to_date\"(\"substr\"('2021-08-20', 1 + 1, 10)), \"to_date\"('2021-08-20')\n"
+    String targetSql = "SELECT \"to_date\"(\"substr\"('2021-08-20', \"greatest\"(1, 1), 10)), \"to_date\"('2021-08-20')\n"
         + "FROM \"test\".\"tablea\" AS \"tablea\"";
 
     RelToTrinoConverter relToTrinoConverter =
@@ -573,7 +573,7 @@ public class HiveToTrinoConverterTest {
     RelNode relNode = TestUtils.getHiveToRelConverter().convertSql(
         "SELECT substring(from_utc_timestamp(a_bigint,'PST'),1,10) AS d\nFROM test.table_from_utc_timestamp");
     String targetSql =
-        "SELECT \"substr\"(CAST(CAST(\"at_timezone\"(\"from_unixtime_nanos\"(CAST(\"table_from_utc_timestamp\".\"a_bigint\" AS BIGINT) * 1000000), \"$canonicalize_hive_timezone_id\"('PST')) AS TIMESTAMP(3)) AS VARCHAR(65535)), 1 + 1, 10) AS \"d\"\n"
+        "SELECT \"substr\"(CAST(CAST(\"at_timezone\"(\"from_unixtime_nanos\"(CAST(\"table_from_utc_timestamp\".\"a_bigint\" AS BIGINT) * 1000000), \"$canonicalize_hive_timezone_id\"('PST')) AS TIMESTAMP(3)) AS VARCHAR(65535)), \"greatest\"(1, 1), 10) AS \"d\"\n"
             + "FROM \"test\".\"table_from_utc_timestamp\" AS \"table_from_utc_timestamp\"";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
@@ -581,7 +581,7 @@ public class HiveToTrinoConverterTest {
     relNode = TestUtils.getHiveToRelConverter().convertSql(
         "SELECT substring(from_utc_timestamp(a_decimal_three,'PST'),1,10) AS d\nFROM test.table_from_utc_timestamp");
     targetSql =
-        "SELECT \"substr\"(CAST(CAST(\"at_timezone\"(\"from_unixtime\"(CAST(\"table_from_utc_timestamp0\".\"a_decimal_three\" AS DOUBLE)), \"$canonicalize_hive_timezone_id\"('PST')) AS TIMESTAMP(3)) AS VARCHAR(65535)), 1 + 1, 10) AS \"d\"\n"
+        "SELECT \"substr\"(CAST(CAST(\"at_timezone\"(\"from_unixtime\"(CAST(\"table_from_utc_timestamp0\".\"a_decimal_three\" AS DOUBLE)), \"$canonicalize_hive_timezone_id\"('PST')) AS TIMESTAMP(3)) AS VARCHAR(65535)), \"greatest\"(1, 1), 10) AS \"d\"\n"
             + "FROM \"test\".\"table_from_utc_timestamp\" AS \"table_from_utc_timestamp0\"";
     expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
@@ -589,7 +589,7 @@ public class HiveToTrinoConverterTest {
     relNode = TestUtils.getHiveToRelConverter().convertSql(
         "SELECT substring(from_utc_timestamp(a_timestamp,'PST'),1,10) AS d\nFROM test.table_from_utc_timestamp");
     targetSql =
-        "SELECT \"substr\"(CAST(CAST(\"at_timezone\"(\"from_unixtime\"(\"to_unixtime\"(\"with_timezone\"(\"table_from_utc_timestamp1\".\"a_timestamp\", 'UTC'))), \"$canonicalize_hive_timezone_id\"('PST')) AS TIMESTAMP(3)) AS VARCHAR(65535)), 1 + 1, 10) AS \"d\"\n"
+        "SELECT \"substr\"(CAST(CAST(\"at_timezone\"(\"from_unixtime\"(\"to_unixtime\"(\"with_timezone\"(\"table_from_utc_timestamp1\".\"a_timestamp\", 'UTC'))), \"$canonicalize_hive_timezone_id\"('PST')) AS TIMESTAMP(3)) AS VARCHAR(65535)), \"greatest\"(1, 1), 10) AS \"d\"\n"
             + "FROM \"test\".\"table_from_utc_timestamp\" AS \"table_from_utc_timestamp1\"";
     expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
@@ -725,7 +725,7 @@ public class HiveToTrinoConverterTest {
     RelNode relNode = TestUtils.getHiveToRelConverter()
         .convertSql("SELECT SUBSTR(a_timestamp, 12, 8) AS d\nFROM test.table_from_utc_timestamp");
     String targetSql =
-        "SELECT \"substr\"(CAST(\"table_from_utc_timestamp\".\"a_timestamp\" AS VARCHAR(65535)), 12 + 1, 8) AS \"d\"\n"
+        "SELECT \"substr\"(CAST(\"table_from_utc_timestamp\".\"a_timestamp\" AS VARCHAR(65535)), \"greatest\"(12, 1), 8) AS \"d\"\n"
             + "FROM \"test\".\"table_from_utc_timestamp\" AS \"table_from_utc_timestamp\"";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
@@ -733,7 +733,7 @@ public class HiveToTrinoConverterTest {
     relNode = TestUtils.getHiveToRelConverter()
         .convertSql("SELECT SUBSTRING(a_timestamp, 12, 8) AS d\nFROM test.table_from_utc_timestamp");
     targetSql =
-        "SELECT \"substr\"(CAST(\"table_from_utc_timestamp0\".\"a_timestamp\" AS VARCHAR(65535)), 12 + 1, 8) AS \"d\"\n"
+        "SELECT \"substr\"(CAST(\"table_from_utc_timestamp0\".\"a_timestamp\" AS VARCHAR(65535)), \"greatest\"(12, 1), 8) AS \"d\"\n"
             + "FROM \"test\".\"table_from_utc_timestamp\" AS \"table_from_utc_timestamp0\"";
     expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
@@ -746,8 +746,8 @@ public class HiveToTrinoConverterTest {
     RelNode relNode = TestUtils.getHiveToRelConverter()
         .convertSql("SELECT a, SUBSTR(b, 1, 1) AS aliased_column, c FROM test.tabler ORDER BY aliased_column DESC");
     String targetSql =
-        "SELECT \"tabler\".\"a\" AS \"a\", \"substr\"(\"tabler\".\"b\", 1 + 1, 1) AS \"aliased_column\", \"tabler\".\"c\" AS \"c\"\n"
-            + "FROM \"test\".\"tabler\" AS \"tabler\"\n" + "ORDER BY \"substr\"(\"tabler\".\"b\", 1 + 1, 1) DESC";
+        "SELECT \"tabler\".\"a\" AS \"a\", \"substr\"(\"tabler\".\"b\", \"greatest\"(1, 1), 1) AS \"aliased_column\", \"tabler\".\"c\" AS \"c\"\n"
+            + "FROM \"test\".\"tabler\" AS \"tabler\"\n" + "ORDER BY \"substr\"(\"tabler\".\"b\", \"greatest\"(1, 1), 1) DESC";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
@@ -759,9 +759,9 @@ public class HiveToTrinoConverterTest {
     RelNode relNode = TestUtils.getHiveToRelConverter().convertSql(
         "SELECT a, SUBSTR(b, 1, 1) AS aliased_column, c FROM test.tabler ORDER BY aliased_column DESC, a DESC, c DESC");
     String targetSql =
-        "SELECT \"tabler\".\"a\" AS \"a\", \"substr\"(\"tabler\".\"b\", 1 + 1, 1) AS \"aliased_column\", \"tabler\".\"c\" AS \"c\"\n"
+        "SELECT \"tabler\".\"a\" AS \"a\", \"substr\"(\"tabler\".\"b\", \"greatest\"(1, 1), 1) AS \"aliased_column\", \"tabler\".\"c\" AS \"c\"\n"
             + "FROM \"test\".\"tabler\" AS \"tabler\"\n"
-            + "ORDER BY \"substr\"(\"tabler\".\"b\", 1 + 1, 1) DESC, \"tabler\".\"a\" DESC, \"tabler\".\"c\" DESC";
+            + "ORDER BY \"substr\"(\"tabler\".\"b\", \"greatest\"(1, 1), 1) DESC, \"tabler\".\"a\" DESC, \"tabler\".\"c\" DESC";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
@@ -787,9 +787,9 @@ public class HiveToTrinoConverterTest {
         .convertSql("SELECT a, SUBSTR(b, 1, 1) AS aliased_column, c FROM test.tabler ORDER BY aliased_column ASC");
     // We want NULLS FIRST since we're translating from Hive and that is the default null ordering for ASC in Hive
     String targetSql =
-        "SELECT \"tabler\".\"a\" AS \"a\", \"substr\"(\"tabler\".\"b\", 1 + 1, 1) AS \"aliased_column\", \"tabler\".\"c\" AS \"c\"\n"
+        "SELECT \"tabler\".\"a\" AS \"a\", \"substr\"(\"tabler\".\"b\", \"greatest\"(1, 1), 1) AS \"aliased_column\", \"tabler\".\"c\" AS \"c\"\n"
             + "FROM \"test\".\"tabler\" AS \"tabler\"\n"
-            + "ORDER BY \"substr\"(\"tabler\".\"b\", 1 + 1, 1) NULLS FIRST";
+            + "ORDER BY \"substr\"(\"tabler\".\"b\", \"greatest\"(1, 1), 1) NULLS FIRST";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }
@@ -801,9 +801,9 @@ public class HiveToTrinoConverterTest {
     RelNode relNode = TestUtils.getHiveToRelConverter().convertSql(
         "SELECT a, SUBSTR(b, 1, 1) AS aliased_column FROM test.tabler GROUP BY a, b HAVING aliased_column in ('dummy_value')");
     String targetSql =
-        "SELECT \"tabler\".\"a\" AS \"a\", \"substr\"(\"tabler\".\"b\", 1 + 1, 1) AS \"aliased_column\"\n"
+        "SELECT \"tabler\".\"a\" AS \"a\", \"substr\"(\"tabler\".\"b\", \"greatest\"(1, 1), 1) AS \"aliased_column\"\n"
             + "FROM \"test\".\"tabler\" AS \"tabler\"\n" + "GROUP BY \"tabler\".\"a\", \"tabler\".\"b\"\n"
-            + "HAVING \"substr\"(\"tabler\".\"b\", 1 + 1, 1)\n" + "IN ('dummy_value')";
+            + "HAVING \"substr\"(\"tabler\".\"b\", \"greatest\"(1, 1), 1)\n" + "IN ('dummy_value')";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -349,8 +349,9 @@ public class HiveToTrinoConverterTest {
   public void testAvoidTransformToDate() {
     RelNode relNode = TestUtils.getHiveToRelConverter()
         .convertSql("SELECT to_date(substr('2021-08-20', 1, 10)), to_date('2021-08-20')" + "FROM test.tableA");
-    String targetSql = "SELECT \"to_date\"(\"substr\"('2021-08-20', \"greatest\"(1, 1), 10)), \"to_date\"('2021-08-20')\n"
-        + "FROM \"test\".\"tablea\" AS \"tablea\"";
+    String targetSql =
+        "SELECT \"to_date\"(\"substr\"('2021-08-20', \"greatest\"(1, 1), 10)), \"to_date\"('2021-08-20')\n"
+            + "FROM \"test\".\"tablea\" AS \"tablea\"";
 
     RelToTrinoConverter relToTrinoConverter =
         TestUtils.getRelToTrinoConverter(ImmutableMap.of(AVOID_TRANSFORM_TO_DATE_UDF, true));
@@ -747,7 +748,8 @@ public class HiveToTrinoConverterTest {
         .convertSql("SELECT a, SUBSTR(b, 1, 1) AS aliased_column, c FROM test.tabler ORDER BY aliased_column DESC");
     String targetSql =
         "SELECT \"tabler\".\"a\" AS \"a\", \"substr\"(\"tabler\".\"b\", \"greatest\"(1, 1), 1) AS \"aliased_column\", \"tabler\".\"c\" AS \"c\"\n"
-            + "FROM \"test\".\"tabler\" AS \"tabler\"\n" + "ORDER BY \"substr\"(\"tabler\".\"b\", \"greatest\"(1, 1), 1) DESC";
+            + "FROM \"test\".\"tabler\" AS \"tabler\"\n"
+            + "ORDER BY \"substr\"(\"tabler\".\"b\", \"greatest\"(1, 1), 1) DESC";
     String expandedSql = relToTrinoConverter.convert(relNode);
     assertEquals(expandedSql, targetSql);
   }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2024 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverterTest.java
@@ -357,6 +357,13 @@ public class RelToTrinoConverterTest {
   }
 
   @Test
+  public void testSubString1() {
+    String sql = "SELECT SUBSTRING(scol, 0) FROM test.tableOne";
+    String expectedSql = "SELECT \"substr\"(\"tableone\".\"scol\", 1)\n" + "FROM \"test\".\"tableone\" AS \"tableone\"";
+    testConversion(sql, expectedSql);
+  }
+
+  @Test
   public void testSubStr1() {
     String sql = "SELECT SUBSTR(scol, 0) FROM test.tableOne";
     String expectedSql = "SELECT \"substr\"(\"tableone\".\"scol\", 1)\n" + "FROM \"test\".\"tableone\" AS \"tableone\"";
@@ -392,6 +399,13 @@ public class RelToTrinoConverterTest {
     String expectedSql =
         "SELECT \"substr\"(\"tableone\".\"scol\", CASE WHEN \"tableone\".\"icol\" = 0 THEN 1 ELSE \"tableone\".\"icol\" END, 3)\n"
             + "FROM \"test\".\"tableone\" AS \"tableone\"";
+    testConversion(sql, expectedSql);
+  }
+
+  @Test
+  public void testSubStr4() {
+    String sql = "SELECT SUBSTR('123', 0, 3)";
+    String expectedSql = "SELECT \"substr\"('123', 1, 3)\n" + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
     testConversion(sql, expectedSql);
   }
 

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverterTest.java
@@ -357,10 +357,18 @@ public class RelToTrinoConverterTest {
   }
 
   @Test
+  public void testSubStr1() {
+    String sql = "SELECT SUBSTR(scol, 0) FROM test.tableOne";
+    String expectedSql =
+        "SELECT \"substr\"(\"tableone\".\"scol\", \"greatest\"(0, 1))\n" + "FROM \"test\".\"tableone\" AS \"tableone\"";
+    testConversion(sql, expectedSql);
+  }
+
+  @Test
   public void testSubStr2() {
     String sql = "SELECT SUBSTR(scol, 1) FROM test.tableOne";
     String expectedSql =
-        "SELECT \"substr\"(\"tableone\".\"scol\", 1 + 1)\n" + "FROM \"test\".\"tableone\" AS \"tableone\"";
+        "SELECT \"substr\"(\"tableone\".\"scol\", \"greatest\"(1, 1))\n" + "FROM \"test\".\"tableone\" AS \"tableone\"";
     testConversion(sql, expectedSql);
   }
 
@@ -368,14 +376,14 @@ public class RelToTrinoConverterTest {
   public void testSubString2() {
     String sql = "SELECT SUBSTRING(scol, 1) FROM test.tableOne";
     String expectedSql =
-        "SELECT \"substr\"(\"tableone\".\"scol\", 1 + 1)\n" + "FROM \"test\".\"tableone\" AS \"tableone\"";
+        "SELECT \"substr\"(\"tableone\".\"scol\", \"greatest\"(1, 1))\n" + "FROM \"test\".\"tableone\" AS \"tableone\"";
     testConversion(sql, expectedSql);
   }
 
   @Test
   public void testSubStr3() {
     String sql = "SELECT SUBSTR(scol, icol, 3) FROM test.tableOne";
-    String expectedSql = "SELECT \"substr\"(\"tableone\".\"scol\", \"tableone\".\"icol\" + 1, 3)\n"
+    String expectedSql = "SELECT \"substr\"(\"tableone\".\"scol\", \"greatest\"(\"tableone\".\"icol\", 1), 3)\n"
         + "FROM \"test\".\"tableone\" AS \"tableone\"";
     testConversion(sql, expectedSql);
   }
@@ -383,7 +391,7 @@ public class RelToTrinoConverterTest {
   @Test
   public void testSubString3() {
     String sql = "SELECT SUBSTRING(scol, icol, 3) FROM test.tableOne";
-    String expectedSql = "SELECT \"substr\"(\"tableone\".\"scol\", \"tableone\".\"icol\" + 1, 3)\n"
+    String expectedSql = "SELECT \"substr\"(\"tableone\".\"scol\", \"greatest\"(\"tableone\".\"icol\", 1), 3)\n"
         + "FROM \"test\".\"tableone\" AS \"tableone\"";
     testConversion(sql, expectedSql);
   }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverterTest.java
@@ -397,6 +397,13 @@ public class RelToTrinoConverterTest {
   }
 
   @Test
+  public void testSubString4() {
+    String sql = "SELECT SUBSTRING('123', 0, 3)";
+    String expectedSql = "SELECT \"substr\"('123', \"greatest\"(0, 1), 3)\n" + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+    testConversion(sql, expectedSql);
+  }
+
+  @Test
   public void testLimit() {
     String sql = "SELECT icol " + "FROM test.tableOne" + " LIMIT 100";
     String expectedSql =

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverterTest.java
@@ -359,6 +359,8 @@ public class RelToTrinoConverterTest {
   @Test
   public void testSubString1() {
     String sql = "SELECT SUBSTRING(scol, 0) FROM test.tableOne";
+
+    // Trino is 1-based
     String expectedSql = "SELECT \"substr\"(\"tableone\".\"scol\", 1)\n" + "FROM \"test\".\"tableone\" AS \"tableone\"";
     testConversion(sql, expectedSql);
   }
@@ -366,6 +368,8 @@ public class RelToTrinoConverterTest {
   @Test
   public void testSubStr1() {
     String sql = "SELECT SUBSTR(scol, 0) FROM test.tableOne";
+
+    // Trino is 1-based
     String expectedSql = "SELECT \"substr\"(\"tableone\".\"scol\", 1)\n" + "FROM \"test\".\"tableone\" AS \"tableone\"";
     testConversion(sql, expectedSql);
   }

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverterTest.java
@@ -359,47 +359,46 @@ public class RelToTrinoConverterTest {
   @Test
   public void testSubStr1() {
     String sql = "SELECT SUBSTR(scol, 0) FROM test.tableOne";
-    String expectedSql =
-        "SELECT \"substr\"(\"tableone\".\"scol\", \"greatest\"(0, 1))\n" + "FROM \"test\".\"tableone\" AS \"tableone\"";
+    String expectedSql = "SELECT \"substr\"(\"tableone\".\"scol\", 1)\n" + "FROM \"test\".\"tableone\" AS \"tableone\"";
     testConversion(sql, expectedSql);
   }
 
   @Test
   public void testSubStr2() {
     String sql = "SELECT SUBSTR(scol, 1) FROM test.tableOne";
-    String expectedSql =
-        "SELECT \"substr\"(\"tableone\".\"scol\", \"greatest\"(1, 1))\n" + "FROM \"test\".\"tableone\" AS \"tableone\"";
+    String expectedSql = "SELECT \"substr\"(\"tableone\".\"scol\", 1)\n" + "FROM \"test\".\"tableone\" AS \"tableone\"";
     testConversion(sql, expectedSql);
   }
 
   @Test
   public void testSubString2() {
     String sql = "SELECT SUBSTRING(scol, 1) FROM test.tableOne";
-    String expectedSql =
-        "SELECT \"substr\"(\"tableone\".\"scol\", \"greatest\"(1, 1))\n" + "FROM \"test\".\"tableone\" AS \"tableone\"";
+    String expectedSql = "SELECT \"substr\"(\"tableone\".\"scol\", 1)\n" + "FROM \"test\".\"tableone\" AS \"tableone\"";
     testConversion(sql, expectedSql);
   }
 
   @Test
   public void testSubStr3() {
     String sql = "SELECT SUBSTR(scol, icol, 3) FROM test.tableOne";
-    String expectedSql = "SELECT \"substr\"(\"tableone\".\"scol\", \"greatest\"(\"tableone\".\"icol\", 1), 3)\n"
-        + "FROM \"test\".\"tableone\" AS \"tableone\"";
+    String expectedSql =
+        "SELECT \"substr\"(\"tableone\".\"scol\", CASE WHEN \"tableone\".\"icol\" = 0 THEN 1 ELSE \"tableone\".\"icol\" END, 3)\n"
+            + "FROM \"test\".\"tableone\" AS \"tableone\"";
     testConversion(sql, expectedSql);
   }
 
   @Test
   public void testSubString3() {
     String sql = "SELECT SUBSTRING(scol, icol, 3) FROM test.tableOne";
-    String expectedSql = "SELECT \"substr\"(\"tableone\".\"scol\", \"greatest\"(\"tableone\".\"icol\", 1), 3)\n"
-        + "FROM \"test\".\"tableone\" AS \"tableone\"";
+    String expectedSql =
+        "SELECT \"substr\"(\"tableone\".\"scol\", CASE WHEN \"tableone\".\"icol\" = 0 THEN 1 ELSE \"tableone\".\"icol\" END, 3)\n"
+            + "FROM \"test\".\"tableone\" AS \"tableone\"";
     testConversion(sql, expectedSql);
   }
 
   @Test
   public void testSubString4() {
     String sql = "SELECT SUBSTRING('123', 0, 3)";
-    String expectedSql = "SELECT \"substr\"('123', \"greatest\"(0, 1), 3)\n" + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
+    String expectedSql = "SELECT \"substr\"('123', 1, 3)\n" + "FROM (VALUES  (0)) AS \"t\" (\"ZERO\")";
     testConversion(sql, expectedSql);
   }
 


### PR DESCRIPTION
### What changes are proposed in this pull request, and why are they necessary?
https://github.com/linkedin/coral/pull/434 suggested that Hive `substring` function start index is 0-based, while Trino is 1-based. Upon further investigation, we found that both Hive and Trino indexes are actually 1-based (this was the behavior before #434). The only difference is that Hive also allows 0 as a starting substring index and treats it as 1 (this was not the behavior before #434, where 0 in Hive simply mapped to 0 in Trino). https://github.com/linkedin/coral/pull/434 was reverted in https://github.com/linkedin/coral/pull/492 but the revert was released in a hot fix branch. This PR corrects the behavior to the expected semantics.

```
hive (u_kge)> select substr('123', 0, 3) as a;
OK
123

hive (u_kge)> select substr('123', 1, 3) as a;
OK
123

trino> select substr('123', 0, 3) as a;
 a 
---
   
(1 row)

trino> select substr('123', 1, 3) as a;
  a  
-----
 123 
(1 row)
```

To fix this, when translating from Hive to Trino, we ensure that if the hive starting substring index is 0, we change it to 1, while leaving any other index number the same. Use `CASE WHEN` if start index is another column (we don't know the actual value).

### How was this patch tested?
<!--
Please describe all the tests conducted.
If new unit tests were included, mention that they were added in this section. Make sure to add test cases that thoroughly examine both negative and positive cases, if possible.
If the testing approach differed from regular unit tests (e.g., regression testing), please explain how it was conducted.
If no tests were added, please explain why they were not included and/or why it was difficult to add them.
-->
./gradlew build
updated + New unit tests
regression tests pending, Update: all regressions expected