### PR TITLE
[Coral-hive] Enable parsing spark created views without quoted keywords

### DIFF
--- a/coral-hive/src/main/antlr/roots/com/linkedin/coral/hive/hive2rel/parsetree/parser/HiveParser.g
+++ b/coral-hive/src/main/antlr/roots/com/linkedin/coral/hive/hive2rel/parsetree/parser/HiveParser.g
@@ -658,7 +658,12 @@ import org.slf4j.LoggerFactory;
   }
   protected boolean useSQL11ReservedKeywordsForIdentifier() {
     try {
-      return !HiveConf.getBoolVar(hiveConf, HiveConf.ConfVars.HIVE_SUPPORT_SQL11_RESERVED_KEYWORDS);
+      /*
+       * Use the config string hive.support.sql11.reserved.keywords directly as
+       * HiveConf.ConfVars.HIVE_SUPPORT_SQL11_RESERVED_KEYWORDS might not be available in the hive-common present in the
+       * classpath during translation triggering the exception path defaulting to false
+       */
+      return !hiveConf.get("hive.support.sql11.reserved.keywords").equalsIgnoreCase("true");
     } catch (Throwable throwable) {
       LOG.warn(throwable.getMessage());
       return false;

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2024 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverter.java
@@ -96,7 +96,7 @@ public class HiveToRelConverter extends ToRelConverter {
   }
 
   @Override
-  protected SqlNode toSqlNode(String sql, Table hiveView) {
+  public SqlNode toSqlNode(String sql, Table hiveView) {
     final SqlNode sqlNode = parseTreeBuilder.process(trimParenthesis(sql), hiveView);
     if (hiveView != null) {
       sqlNode.accept(new FuzzyUnionSqlRewriter(hiveView.getTableName(), this));

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2024 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -8,6 +8,7 @@ package com.linkedin.coral.hive.hive2rel.parsetree;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -104,8 +105,20 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
     return process(sql, null);
   }
 
+  /**
+   * Returns true if the view is created using spark sql. This relies on the presence of the
+   * spark.sql.create.version property in the views when created using spark sql.
+   *
+   * @param hiveView
+   * @return true if the view is created using spark sql
+   */
+  private static boolean isCreatedUsingSpark(Table hiveView) {
+    Map<String, String> tableParams = hiveView.getParameters();
+    return tableParams != null && tableParams.containsKey("spark.sql.create.version");
+  }
+
   public SqlNode process(String sql, @Nullable Table hiveView) {
-    ParseDriver pd = new CoralParseDriver();
+    ParseDriver pd = new CoralParseDriver(hiveView != null && isCreatedUsingSpark(hiveView));
     try {
       ASTNode root = pd.parse(sql);
       return processAST(root, hiveView);

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/parser/CoralParseDriver.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/parser/CoralParseDriver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021-2022 LinkedIn Corporation. All rights reserved.
+ * Copyright 2021-2024 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/parser/CoralParseDriver.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/parser/CoralParseDriver.java
@@ -13,12 +13,25 @@ import org.antlr.runtime.RecognitionException;
 import org.antlr.runtime.TokenRewriteStream;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.hive.conf.HiveConf;
 
 
 public class CoralParseDriver extends ParseDriver {
 
   private static final Log LOG =
       LogFactory.getLog("com.linkedin.coral.hive.hive2rel.parsetree.parser.CoralParseDriver");
+
+  private boolean useSQL11ReservedKeywordsForIdentifier;
+
+  public CoralParseDriver(boolean useSQL11ReservedKeywordsForIdentifier) {
+    super();
+    this.useSQL11ReservedKeywordsForIdentifier = useSQL11ReservedKeywordsForIdentifier;
+  }
+
+  public CoralParseDriver() {
+    super();
+    this.useSQL11ReservedKeywordsForIdentifier = false;
+  }
 
   @Override
   public ASTNode parse(String command) throws ParseException {
@@ -29,6 +42,17 @@ public class CoralParseDriver extends ParseDriver {
     HiveLexerCoral lexer = new HiveLexerCoral(new ANTLRNoCaseStringStream(command));
     TokenRewriteStream tokens = new TokenRewriteStream(lexer);
     HiveParser parser = new HiveParser(tokens);
+    HiveConf hiveConf = new HiveConf();
+    /*
+     * This enables usage of keywords as column names without adding backquotes. This is required for translating views
+     * created using spark engine as certain keywords in hive like timestamp are not keywords in spark. This will
+     * result in creation of views without backquoting those keywords. This will be removed when coral-spark becomes
+     * a supported LHS for translations.
+     */
+    if (useSQL11ReservedKeywordsForIdentifier) {
+      hiveConf.set("hive.support.sql11.reserved.keywords", "false");
+      parser.setHiveConf(hiveConf);
+    }
     parser.setTreeAdaptor(adaptor);
     HiveParser.statement_return r = null;
     try {

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/TestUtils.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/TestUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2024 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/TestUtils.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/TestUtils.java
@@ -172,6 +172,10 @@ public class TestUtils {
       driver.run("CREATE VIEW IF NOT EXISTS view_schema_evolve_wrapper AS SELECT * from view_schema_evolve");
       driver.run("ALTER TABLE schema_evolve CHANGE COLUMN b b array<struct<b1:string, b2:double, b3:int>>");
 
+      driver.run("CREATE OR REPLACE VIEW test.spark_created_view AS SELECT 1 AS `timestamp` FROM test.tableOne");
+      // Simulate the creation of view using spark by setting the corresponding table property of the view.
+      driver.run("ALTER VIEW test.spark_created_view SET TBLPROPERTIES ('spark.sql.create.version'='3.1.1')");
+
       CommandProcessorResponse response = driver
           .run("create function test_tableOneView_LessThanHundred as 'com.linkedin.coral.hive.hive2rel.CoralTestUDF'");
       response = driver.run(

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
@@ -20,6 +20,7 @@ import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
@@ -232,5 +233,19 @@ public class ParseTreeBuilderTest {
     String expected = "";
     SqlNode sqlNode = convert(input);
     assertEquals(sqlNode.toString().toLowerCase().replaceAll("\n", " "), expected.toLowerCase());
+  }
+
+  /**
+   * Validates if coral-hive can translate views with unquoted reserved keywords when the views are created using spark.
+   */
+  @Test
+  public void testUnquotedKeywordAsColumnName() {
+    HiveToRelConverter hiveToRelConverter = new HiveToRelConverter(msc);
+    Table table = msc.getTable("test", "spark_created_view");
+    // Remove the backquotes associated with the view text
+    String input = table.getViewExpandedText().replaceAll("`","");
+    SqlNode sqlNode = hiveToRelConverter.toSqlNode(input, table);
+    // Validate if the translation is successful
+    assertEquals(sqlNode.toString().replaceAll("\\r?\\n", " "), table.getViewExpandedText());
   }
 }

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2024 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -243,7 +243,7 @@ public class ParseTreeBuilderTest {
     HiveToRelConverter hiveToRelConverter = new HiveToRelConverter(msc);
     Table table = msc.getTable("test", "spark_created_view");
     // Remove the backquotes associated with the view text
-    String input = table.getViewExpandedText().replaceAll("`","");
+    String input = table.getViewExpandedText().replaceAll("`", "");
     SqlNode sqlNode = hiveToRelConverter.toSqlNode(input, table);
     // Validate if the translation is successful
     assertEquals(sqlNode.toString().replaceAll("\\r?\\n", " "), table.getViewExpandedText());


### PR DESCRIPTION
## Summary
[Coral-hive] Enable parsing spark created views without quoted keywords

## Description
There are a subset of reserved words like `timestamp` which are keywords in hive but not in spark. When views are created using spark engine and these reserved words are used as column name alias, the expanded view text does not have them backquoted. This results in translation errors like

```
FailedPredicateException(identifier,{useSQL11ReservedKeywordsForIdentifier()}?)
        at com.linkedin.coral.hive.hive2rel.parsetree.parser.HiveParser_IdentifiersParser.identifier(HiveParser_IdentifiersParser.java:10351)
        at com.linkedin.coral.hive.hive2rel.parsetree.parser.HiveParser.identifier(HiveParser.java:40450)
        at com.linkedin.coral.hive.hive2rel.parsetree.parser.HiveParser_SelectClauseParser.selectItem(HiveParser_SelectClauseParser.java:2451)
        at com.linkedin.coral.hive.hive2rel.parsetree.parser.HiveParser_SelectClauseParser.selectList(HiveParser_SelectClauseParser.java:1148)
        at com.linkedin.coral.hive.hive2rel.parsetree.parser.HiveParser_SelectClauseParser.selectClause(HiveParser_SelectClauseParser.java:877)
        at com.linkedin.coral.hive.hive2rel.parsetree.parser.HiveParser.selectClause(HiveParser.java:40433)
        at com.linkedin.coral.hive.hive2rel.parsetree.parser.HiveParser.selectStatement(HiveParser.java:36241)
        at com.linkedin.coral.hive.hive2rel.parsetree.parser.HiveParser.regularBody(HiveParser.java:36148)
        at com.linkedin.coral.hive.hive2rel.parsetree.parser.HiveParser.queryStatementExpressionBody(HiveParser.java:35180)
        at com.linkedin.coral.hive.hive2rel.parsetree.parser.HiveParser.queryStatementExpression(HiveParser.java:35057)
        at com.linkedin.coral.hive.hive2rel.parsetree.parser.HiveParser.execStatement(HiveParser.java:1529)
        at com.linkedin.coral.hive.hive2rel.parsetree.parser.HiveParser.statement(HiveParser.java:1089)
        at com.linkedin.coral.hive.hive2rel.parsetree.parser.CoralParseDriver.parse(CoralParseDriver.java:35)
        at com.linkedin.coral.hive.hive2rel.parsetree.ParseTreeBuilder.process(ParseTreeBuilder.java:108)
        at com.linkedin.coral.hive.hive2rel.HiveToRelConverter.toSqlNode(HiveToRelConverter.java:100)
        at com.linkedin.coral.common.ToRelConverter.processView(ToRelConverter.java:152)
        at com.linkedin.coral.common.ToRelConverter.convertView(ToRelConverter.java:123)
        at com.linkedin.coral.tools.SparkValidator.getCoralSparkTranslation(SparkValidator.java:59)
        at com.linkedin.coral.tools.SparkValidator.convertAndValidate(SparkValidator.java:39)
        at com.linkedin.coral.tools.SingleViewTranslation.translateTable(SingleViewTranslation.java:63)
        at com.linkedin.coral.tools.SingleViewTranslation.main(SingleViewTranslation.java:55)
Exception in thread "main" java.lang.RuntimeException: com.linkedin.coral.hive.hive2rel.parsetree.parser.ParseException: line 1:25 Failed to recognize predicate 'timestamp'. Failed rule: 'identifier' in selection target
        at com.linkedin.coral.hive.hive2rel.parsetree.ParseTreeBuilder.process(ParseTreeBuilder.java:111)
        at com.linkedin.coral.hive.hive2rel.HiveToRelConverter.toSqlNode(HiveToRelConverter.java:100)
        at com.linkedin.coral.common.ToRelConverter.processView(ToRelConverter.java:152)
        at com.linkedin.coral.common.ToRelConverter.convertView(ToRelConverter.java:123)
        at com.linkedin.coral.tools.SparkValidator.getCoralSparkTranslation(SparkValidator.java:59)
        at com.linkedin.coral.tools.SparkValidator.convertAndValidate(SparkValidator.java:39)
        at com.linkedin.coral.tools.SingleViewTranslation.translateTable(SingleViewTranslation.java:63)
        at com.linkedin.coral.tools.SingleViewTranslation.main(SingleViewTranslation.java:55)
Caused by: com.linkedin.coral.hive.hive2rel.parsetree.parser.ParseException: line 1:25 Failed to recognize predicate 'timestamp'. Failed rule: 'identifier' in selection target
        at com.linkedin.coral.hive.hive2rel.parsetree.parser.CoralParseDriver.parse(CoralParseDriver.java:38)
        at com.linkedin.coral.hive.hive2rel.parsetree.ParseTreeBuilder.process(ParseTreeBuilder.java:108)
```
This patch attempts to fix this error by checking the tableproperties of the view to get hints on if the view is created using spark and sets `hive.support.sql11.reserved.keywords` appropriately so that translation of these views will succeed.

Note that this patch intentionally uses the config string `hive.support.sql11.reserved.keywords` instead of the variable `HiveConf.ConfVars.HIVE_SUPPORT_SQL11_RESERVED_KEYWORDS`. This is because the `HiveParser.g` here is copied from Hive `1.2.4` and assumes the presence of this conf but this conf has been removed in later releases triggering 
`java.lang.NoSuchFieldError: HIVE_SUPPORT_SQL11_RESERVED_KEYWORDS` when `hive-common` from latest hive versions is found in the classpath during translation.

## Testing Done
Added unit tests and validates that the unit test fails without fix and passes with fix.
Validates that all the existing unit test passes.
Validated a custom build of this coral fix in spark-shell against a view with keyword `timestamp` and was able to get successful translation.
Tested on current production views and did not find any regression.