### PR TITLE
[CORAL-TRINO] Bug: Showcase nested subquery translation failure

### DIFF
--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -236,7 +236,9 @@ public class HiveToTrinoConverterTest {
         { "test", "view_union_no_casting", "SELECT \"table_with_mixed_columns\".\"a_tinyint\" AS \"a_tinyint\", \"table_with_mixed_columns\".\"a_smallint\" AS \"a_smallint\", \"table_with_mixed_columns\".\"a_integer\" AS \"a_integer\", \"table_with_mixed_columns\".\"a_bigint\" AS \"a_bigint\", \"table_with_mixed_columns\".\"a_float\" AS \"a_float\"\n"
             + "FROM \"test\".\"table_with_mixed_columns\" AS \"table_with_mixed_columns\"\n" + "UNION ALL\n"
             + "SELECT \"table_with_mixed_columns0\".\"a_tinyint\" AS \"a_tinyint\", \"table_with_mixed_columns0\".\"a_smallint\" AS \"a_smallint\", \"table_with_mixed_columns0\".\"a_integer\" AS \"a_integer\", \"table_with_mixed_columns0\".\"a_bigint\" AS \"a_bigint\", \"table_with_mixed_columns0\".\"a_float\" AS \"a_float\"\n"
-            + "FROM \"test\".\"table_with_mixed_columns\" AS \"table_with_mixed_columns0\"" } };
+            + "FROM \"test\".\"table_with_mixed_columns\" AS \"table_with_mixed_columns0\"" },
+        { "test", "view_max_values", "SELECT value FROM \"test\".\"table_id_value\"  WHERE id IN (SELECT MAX(id) FROM \"test\".\"table_id_value\")" } };
+
   }
 
   @Test

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
@@ -413,6 +413,9 @@ public class TestUtils {
             + "UNION ALL\n"
             + "SELECT a_tinyint, a_smallint, a_integer, a_bigint, a_float FROM test.table_with_mixed_columns");
 
+    run(driver, "CREATE TABLE test.table_id_value (id int, value varchar(255))");
+    run(driver, "CREATE VIEW IF NOT EXISTS test.view_max_values AS \n"
+            + "SELECT value FROM test.table_id_value  WHERE id IN (SELECT MAX(id) FROM test.table_id_value)");
     // Tables used in RelToTrinoConverterTest
     run(driver,
         "CREATE TABLE IF NOT EXISTS test.tableOne(icol int, dcol double, scol string, tcol timestamp, acol array<string>)");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:
  1. If you are new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you have added and executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
  7. Make sure that the command './gradlew clean build' passes. Resolve any formatting errors by running './gradlew spotlessApply'.
-->

### What changes are proposed in this pull request, and why are they necessary?
<!--
Kindly explain the proposed changes in this section. The goal is to outline the modifications and how this PR addresses the issue. Also, clarify the reasons for these changes. For example,
  1. If a new API is proposed, explain the intended use case.
  2. If a bug is being fixed, describe why it is a bug.
  3. If design documentation is available, please include the link.
-->

The translation of a nested subquery causes inexistent table references in the output query.

Table

```
CREATE TABLE test.table_id_value (id int, value varchar(255))
```

Hive View

```
CREATE VIEW IF NOT EXISTS test.view_max_values AS
SELECT value FROM test.table_id_value  WHERE id IN (SELECT MAX(id) FROM test.table_id_value)
```

Coral to Trino Translation outcome
```
SELECT "table_id_value"."value" AS "value"
FROM "test"."table_id_value" AS "table_id_value"
INNER JOIN (
        SELECT MAX("table_id_value0"."id")
        FROM (
                SELECT MAX("table_id_value0"."id")
                FROM "test"."table_id_value" AS "table_id_value0") AS "t0"
                GROUP BY MAX("table_id_value0"."id")
        ) AS "t1"
  ON "table_id_value"."id" = MAX("table_id_value0"."id")
```

The JOIN expression `ON "table_id_value"."id" = MAX("table_id_value0"."id")` is referencing an inexistent table - `table_id_value0`.

### How was this patch tested?
<!--
Please describe all the tests conducted.
If new unit tests were included, mention that they were added in this section. Make sure to add test cases that thoroughly examine both negative and positive cases, if possible.
If the testing approach differed from regular unit tests (e.g., regression testing), please explain how it was conducted.
If no tests were added, please explain why they were not included and/or why it was difficult to add them.
-->
