### PR TITLE
[Coral-Schema] Fix incorrect type derivation for repeated field reference on UDF calls

### DIFF
--- a/coral-common/src/main/java/com/linkedin/coral/common/TypeConverter.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/TypeConverter.java
@@ -140,7 +140,6 @@ public class TypeConverter {
   // The schema of output Struct conforms to https://github.com/trinodb/trino/pull/3483
   // except we adopted "integer" for the type of "tag" field instead of "tinyint" in the Trino patch
   // for compatibility with other platforms that Iceberg currently doesn't support tinyint type.
-  // When the field count inside UnionTypeInfo is one, we surface the underlying RelDataType instead.
 
   // Note: this is subject to change in the future pending on the discussion in
   // https://mail-archives.apache.org/mod_mbox/iceberg-dev/202112.mbox/browser

--- a/coral-common/src/main/java/com/linkedin/coral/common/TypeConverter.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/TypeConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2024 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -147,9 +147,6 @@ public class TypeConverter {
   public static RelDataType convert(UnionTypeInfo unionType, RelDataTypeFactory dtFactory) {
     List<RelDataType> fTypes = unionType.getAllUnionObjectTypeInfos().stream()
         .map(typeInfo -> convert(typeInfo, dtFactory)).collect(Collectors.toList());
-    if (fTypes.size() == 1) {
-      return dtFactory.createTypeWithNullability(fTypes.get(0), true);
-    }
     List<String> fNames = IntStream.range(0, unionType.getAllUnionObjectTypeInfos().size()).mapToObj(i -> "field" + i)
         .collect(Collectors.toList());
     fTypes.add(0, dtFactory.createSqlType(SqlTypeName.INTEGER));

--- a/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionFieldReferenceOperator.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/functions/FunctionFieldReferenceOperator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2024 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -73,15 +73,6 @@ public class FunctionFieldReferenceOperator extends SqlBinaryOperator {
       RelDataType funcType = validator.deriveType(scope, firstOperand);
       if (funcType.isStruct()) {
         return funcType.getField(fieldNameStripQuotes(call.operand(1)), false, false).getType();
-      }
-
-      // When the first operand is a SqlBasicCall with a non-struct RelDataType and the second operand is `tag_0`,
-      // such as `extract_union`(`product`.`value`).`tag_0` or (`extract_union`(`product`.`value`).`id`).`tag_0`,
-      // derived data type is first operand's RelDataType.
-      // This strategy ensures that RelDataType derivation remains successful for the specified sqlCalls while maintaining backward compatibility.
-      // Such SqlCalls are transformed {@link com.linkedin.coral.transformers.SingleUnionFieldReferenceTransformer}
-      if (FunctionFieldReferenceOperator.fieldNameStripQuotes(call.operand(1)).equalsIgnoreCase("tag_0")) {
-        return funcType;
       }
     }
     return super.deriveType(validator, scope, call);

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
@@ -491,6 +491,7 @@ public class RelToAvroSchemaConverter {
       return super.visitRangeRef(rexRangeRef);
     }
 
+    @Override
     public RexNode visitFieldAccess(RexFieldAccess rexFieldAccess) {
       RexNode referenceExpr = rexFieldAccess.getReferenceExpr();
 

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2024 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -491,48 +491,49 @@ public class RelToAvroSchemaConverter {
       return super.visitRangeRef(rexRangeRef);
     }
 
-    @Override
     public RexNode visitFieldAccess(RexFieldAccess rexFieldAccess) {
       RexNode referenceExpr = rexFieldAccess.getReferenceExpr();
 
-      if (referenceExpr instanceof RexCall
-          && ((RexCall) referenceExpr).getOperator() instanceof SqlUserDefinedFunction) {
-        String oldFieldName = rexFieldAccess.getField().getName();
-        String suggestNewFieldName = suggestedFieldNames.poll();
-        String newFieldName = SchemaUtilities.getFieldName(oldFieldName, suggestNewFieldName);
+      Deque<String> innerRecordNames = new LinkedList<>();
+      while (!(referenceExpr instanceof RexInputRef)) {
+        if (referenceExpr instanceof RexCall
+            && ((RexCall) referenceExpr).getOperator().getName().equalsIgnoreCase("ITEM")) {
+          // While selecting `int_field` from `array_col:array<struct<int_field:int>>` using `array_col[x].int_field`,
+          // `rexFieldAccess` is like `ITEM($1, 1).int_field`, we need to set `referenceExpr` to be the first operand (`$1`) of `ITEM` function
+          referenceExpr = ((RexCall) referenceExpr).getOperands().get(0);
+        } else if (referenceExpr instanceof RexCall
+            && ((RexCall) referenceExpr).getOperator() instanceof SqlUserDefinedFunction) {
+          // UDFs calls could potentially be doubly (or more) field-referenced, for example, `extract_union(baz).single.tag_0`
+          // where baz is a struct containing a uniontype field. In this case, we simply need to use derived type of the entire
+          // call. Note that this also takes care of the simple one layer field reference on a UDF call.
+          String oldFieldName = rexFieldAccess.getField().getName();
+          String suggestNewFieldName = suggestedFieldNames.poll();
+          String newFieldName = SchemaUtilities.getFieldName(oldFieldName, suggestNewFieldName);
 
-        RelDataType fieldType = rexFieldAccess.getType();
-        boolean isNullable = SchemaUtilities.isFieldNullable((RexCall) referenceExpr, inputSchema);
-        // TODO: add field documentation
-        SchemaUtilities.appendField(newFieldName, fieldType, null, fieldAssembler, isNullable);
-      } else {
-        Deque<String> innerRecordNames = new LinkedList<>();
-        while (!(referenceExpr instanceof RexInputRef)) {
-          if (referenceExpr instanceof RexCall
-              && ((RexCall) referenceExpr).getOperator().getName().equalsIgnoreCase("ITEM")) {
-            // While selecting `int_field` from `array_col:array<struct<int_field:int>>` using `array_col[x].int_field`,
-            // `rexFieldAccess` is like `ITEM($1, 1).int_field`, we need to set `referenceExpr` to be the first operand (`$1`) of `ITEM` function
-            referenceExpr = ((RexCall) referenceExpr).getOperands().get(0);
-          } else if (referenceExpr instanceof RexFieldAccess) {
-            // While selecting `int_field` from `struct_col:struct<inner_struct_col:struct<int_field:int>>` using `struct_col.inner_struct_col.int_field`,
-            // `rexFieldAccess` is like `$3.inner_struct_col.int_field`, we need to set `referenceExpr` to be the expr (`$3`) of itself.
-            // Besides, we need to store the field name (`inner_struct_col`) in `fieldNames` so that we can retrieve the correct inner struct from `topSchema` afterwards
-            innerRecordNames.push(((RexFieldAccess) referenceExpr).getField().getName());
-            referenceExpr = ((RexFieldAccess) referenceExpr).getReferenceExpr();
-          } else {
-            return super.visitFieldAccess(rexFieldAccess);
-          }
+          RelDataType fieldType = rexFieldAccess.getType();
+          boolean isNullable = SchemaUtilities.isFieldNullable((RexCall) referenceExpr, inputSchema);
+          // TODO: add field documentation
+          SchemaUtilities.appendField(newFieldName, fieldType, null, fieldAssembler, isNullable);
+          return rexFieldAccess;
+        } else if (referenceExpr instanceof RexFieldAccess) {
+          // While selecting `int_field` from `struct_col:struct<inner_struct_col:struct<int_field:int>>` using `struct_col.inner_struct_col.int_field`,
+          // `rexFieldAccess` is like `$3.inner_struct_col.int_field`, we need to set `referenceExpr` to be the expr (`$3`) of itself.
+          // Besides, we need to store the field name (`inner_struct_col`) in `fieldNames` so that we can retrieve the correct inner struct from `topSchema` afterwards
+          innerRecordNames.push(((RexFieldAccess) referenceExpr).getField().getName());
+          referenceExpr = ((RexFieldAccess) referenceExpr).getReferenceExpr();
+        } else {
+          return super.visitFieldAccess(rexFieldAccess);
         }
-
-        String oldFieldName = rexFieldAccess.getField().getName();
-        String suggestNewFieldName = suggestedFieldNames.poll();
-        String newFieldName = SchemaUtilities.getFieldName(oldFieldName, suggestNewFieldName);
-        Schema topSchema = inputSchema.getFields().get(((RexInputRef) referenceExpr).getIndex()).schema();
-
-        Schema.Field accessedField = getFieldFromTopSchema(topSchema, oldFieldName, innerRecordNames);
-        assert accessedField != null;
-        SchemaUtilities.appendField(newFieldName, accessedField, fieldAssembler);
       }
+
+      String oldFieldName = rexFieldAccess.getField().getName();
+      String suggestNewFieldName = suggestedFieldNames.poll();
+      String newFieldName = SchemaUtilities.getFieldName(oldFieldName, suggestNewFieldName);
+      Schema topSchema = inputSchema.getFields().get(((RexInputRef) referenceExpr).getIndex()).schema();
+
+      Schema.Field accessedField = getFieldFromTopSchema(topSchema, oldFieldName, innerRecordNames);
+      assert accessedField != null;
+      SchemaUtilities.appendField(newFieldName, accessedField, fieldAssembler);
 
       return rexFieldAccess;
     }

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
@@ -144,6 +144,9 @@ public class TestUtils {
 
     executeQuery("DROP TABLE IF EXISTS basedecimal");
     executeQuery("CREATE TABLE IF NOT EXISTS basedecimal(decimal_col decimal(2,1))");
+
+    executeQuery(
+        "CREATE TABLE IF NOT EXISTS single_uniontypes(single uniontype<string>, struct_col struct<single:uniontype<string>>)");
   }
 
   private static void initializeUdfs() {

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/ViewToAvroSchemaConverterTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2024 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -558,6 +558,17 @@ public class ViewToAvroSchemaConverterTests {
     Schema actual = viewToAvroSchemaConverter.toAvroSchema(sql);
 
     Assert.assertEquals(actual.toString(true), TestUtils.loadSchema("testNullabilityExtractUnionUDF-expected.avsc"));
+  }
+
+  @Test
+  public void testSingleUnionFieldReference() {
+    String sql =
+        "select extract_union(struct_col).single.tag_0 as single_in_struct, extract_union(single).tag_0 as single from single_uniontypes";
+    ViewToAvroSchemaConverter viewToAvroSchemaConverter = ViewToAvroSchemaConverter.create(hiveMetastoreClient);
+
+    Schema actual = viewToAvroSchemaConverter.toAvroSchema(sql);
+
+    Assert.assertEquals(actual.toString(true), TestUtils.loadSchema("testSingleUnionFieldReference-expected.avsc"));
   }
 
   @Test(enabled = false)

--- a/coral-schema/src/test/resources/testSingleUnionFieldReference-expected.avsc
+++ b/coral-schema/src/test/resources/testSingleUnionFieldReference-expected.avsc
@@ -1,0 +1,12 @@
+{
+  "type" : "record",
+  "name" : "SingleUniontypes",
+  "namespace" : "default.single_uniontypes",
+  "fields" : [ {
+    "name" : "single_in_struct",
+    "type" : [ "null", "string" ]
+  }, {
+    "name" : "single",
+    "type" : [ "null", "string" ]
+  } ]
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:
  1. If you are new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you have added and executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
  7. Make sure that the command './gradlew clean build' passes. Resolve any formatting errors by running './gradlew spotlessApply'.
-->

### What changes are proposed in this pull request, and why are they necessary?
This is a continuation of [#507](https://github.com/linkedin/coral/pull/507). #507 reverts some of the effects of #409 (namely, around single union type handling), and this PR reverts more effects (see below). Note this PR includes those same reverts.

**Incorrect behavior after [reverting #409 changes](https://github.com/linkedin/coral/compare/master...KevinGe00:coral:double-field-access-bug?expand=1#diff-1513cf0b5cf70e78bb5b4008b15a7545a5513ec18b72997557e92eaf04add357L150-L152):**
In Hive,
```
Table t1 that has the columns:
struct_col           	struct<union_field:uniontype<string>>

View v1: select extract_union(struct_col).union_field.tag_0 as b from t1
b: string
Schema for col b produced by coral-schema represents:
struct<tag_0:string>
```

In the above scenario, we expect that produced schema (by coral-schema) for `col b` to be simply a string, however, what we get back is of type struct<tag_0:string>. 

Although https://github.com/linkedin/coral/pull/409 mitigates this issue by detecting and unwrapping structs with field `tag_0`, it doesn't address the root cause. Which is a bug in SchemaRexShuttle.visitFieldAccess that doesn't handle nested field references on UDF calls introduced in https://github.com/linkedin/coral/pull/203, and is fixed in this PR here.

### How was this patch tested?
Unit tests
Regression tests
