### PR TITLE
[Coral-Trino] Fix redundant transforms/casts from GenericProjectTransformer

### DIFF
--- a/coral-common/src/main/java/com/linkedin/coral/common/FuzzyUnionSqlRewriter.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/FuzzyUnionSqlRewriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2024 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -237,7 +237,8 @@ public class FuzzyUnionSqlRewriter extends SqlShuttle {
     if (baseDataType.isStruct()) {
       // Build the common UNION type using the first branch that appears in the query
       final RelDataTypeFactory.Builder builder =
-          new RelDataTypeFactory.Builder(toRelConverter.getRelBuilder().getTypeFactory());
+          new RelDataTypeFactory.Builder(toRelConverter.getRelBuilder().getTypeFactory())
+              .kind(baseDataType.getStructKind());
 
       // Build a set of common fields by name in the given dataTypes
       Set<String> commonFieldNames =

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/GenericProjectTransformer.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/GenericProjectTransformer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2023 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/GenericProjectTransformer.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/GenericProjectTransformer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2023-2024 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -361,7 +361,8 @@ public class GenericProjectTransformer extends SqlCallTransformer {
    * @param toDataType desired map RelDataType
    */
   private boolean areEqual(RelDataType fromDataType, RelDataType toDataType) {
-    String fromDataTypeFullyQualifiedStruct = fromDataType.getFullTypeString().replace("RecordType:peek_no_expand", "RecordType");
+    String fromDataTypeFullyQualifiedStruct =
+        fromDataType.getFullTypeString().replace("RecordType:peek_no_expand", "RecordType");
     return fromDataTypeFullyQualifiedStruct.equals(toDataType.getFullTypeString());
   }
 

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/GenericProjectTransformer.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/GenericProjectTransformer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023-2024 LinkedIn Corporation. All rights reserved.
+ * Copyright 2023-2023 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -10,7 +10,6 @@ import java.util.List;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
-import org.apache.calcite.rel.type.RelDataTypeImpl;
 import org.apache.calcite.rel.type.RelRecordType;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/GenericProjectTransformer.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/GenericProjectTransformer.java
@@ -350,23 +350,6 @@ public class GenericProjectTransformer extends SqlCallTransformer {
   }
 
   /**
-   * Checks the equivalence between fromDataType and toDataType. fromDataType is derived from Coral, which produces
-   * RelRecordTypes using {@link org.apache.calcite.rel.type.StructKind}.PEEK_FIELDS_NO_EXPAND while toDataType is derived
-   * from Calcite which uses {@link org.apache.calcite.rel.type.StructKind}.FULLY_QUALIFIED. We consider the two
-   * StructKinds as equivalent for our purposes here as StructKind is used only as internal data representation.
-   *
-   * Note that this comparison using the full type string is derived from {@link RelDataTypeImpl#equals(Object)}.
-   *
-   * @param fromDataType given map RelDataType
-   * @param toDataType desired map RelDataType
-   */
-  private boolean areEqual(RelDataType fromDataType, RelDataType toDataType) {
-    String fromDataTypeFullyQualifiedStruct =
-        fromDataType.getFullTypeString().replace("RecordType:peek_no_expand", "RecordType");
-    return fromDataTypeFullyQualifiedStruct.equals(toDataType.getFullTypeString());
-  }
-
-  /**
    * Create a struct field access string in the form of:
    *   ROW([selected_col_field_1], [selected_col_field_2], etc.)
    * @param fromDataType given struct RelDataType

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/GenericProjectTransformer.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/GenericProjectTransformer.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rel.type.RelDataTypeImpl;
 import org.apache.calcite.rel.type.RelRecordType;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
@@ -332,7 +333,7 @@ public class GenericProjectTransformer extends SqlCallTransformer {
    */
   private String relDataTypeFieldAccessString(RelDataType fromDataType, RelDataType toDataType,
       String fieldNameReference) {
-    if (fromDataType.equals(toDataType)) {
+    if (areEqual(fromDataType, toDataType)) {
       return fieldNameReference;
     }
 
@@ -346,6 +347,22 @@ public class GenericProjectTransformer extends SqlCallTransformer {
       default:
         return fieldNameReference;
     }
+  }
+
+  /**
+   * Checks the equivalence between fromDataType and toDataType. fromDataType is derived from Coral, which produces
+   * RelRecordTypes using {@link org.apache.calcite.rel.type.StructKind}.PEEK_FIELDS_NO_EXPAND while toDataType is derived
+   * from Calcite which uses {@link org.apache.calcite.rel.type.StructKind}.FULLY_QUALIFIED. We consider the two
+   * StructKinds as equivalent for our purposes here as StructKind is used only as internal data representation.
+   *
+   * Note that this comparison using the full type string is derived from {@link RelDataTypeImpl#equals(Object)}.
+   *
+   * @param fromDataType given map RelDataType
+   * @param toDataType desired map RelDataType
+   */
+  private boolean areEqual(RelDataType fromDataType, RelDataType toDataType) {
+    String fromDataTypeFullyQualifiedStruct = fromDataType.getFullTypeString().replace("RecordType:peek_no_expand", "RecordType");
+    return fromDataTypeFullyQualifiedStruct.equals(toDataType.getFullTypeString());
   }
 
   /**

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/GenericProjectTransformer.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/GenericProjectTransformer.java
@@ -333,7 +333,7 @@ public class GenericProjectTransformer extends SqlCallTransformer {
    */
   private String relDataTypeFieldAccessString(RelDataType fromDataType, RelDataType toDataType,
       String fieldNameReference) {
-    if (areEqual(fromDataType, toDataType)) {
+    if (fromDataType.equals(toDataType)) {
       return fieldNameReference;
     }
 


### PR DESCRIPTION
### What changes are proposed in this pull request, and why are they necessary?
#### Issue
Before #449, a (fuzzy union) view in hive with a column of type `users:array<struct<id:int,name:string>>`, would simply be selected in the final trino translation SQL as `users`.

After #449, the same column in the same view would be rewritten as in the trino translation:
```
transform(users, x -> cast(row("x"."id", "x"."name") as row("id" int, "name" varchar)))
```

The `transform` is redundant as all it's doing is transforming a column into it's own original type. Although it is harmless typing-wise, it could potentially degrade performance by wasting time/resources doing a no-op.

#### Why/How
#449 introduced a change where Coral IR (RelNodes) are generated using `StructKind.PEEK_FIELDS_NO_EXPAND` instead of `StructKind.FULLY_QUALIFIED`. This causes Coral's type derivation on RelNodes to also report back `StructKind.PEEK_FIELDS_NO_EXPAND`  instead of `StructKind.FULLY_QUALIFIED` (since derivation relies on `ToRelConverter` which [uses the new](https://github.com/linkedin/coral/blob/185b9acb7deafb1cc3c555adc2bc3b5cfb9561c4/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverter.java#L55) `TypeFactory` from #449).

In `GenericProjectTransformer` when we now [compare](https://github.com/linkedin/coral/blob/185b9acb7deafb1cc3c555adc2bc3b5cfb9561c4/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/transformers/GenericProjectTransformer.java#L205) `fromDataType` vs `toDataType` to convert the Coral IR function `generic_project` to its Trino compatible representation.`fromDataType` is derived using Coral's type derivation and `toDataType` is derived [here](https://github.com/linkedin/coral/blob/185b9acb7deafb1cc3c555adc2bc3b5cfb9561c4/coral-common/src/main/java/com/linkedin/coral/common/functions/GenericProjectFunction.java#L46) in `GenericProjectFunction`. This causes a difference in `StructKind`s, comparisons here of 2 structs that are actually the same (same fields) then do not return equal. For the purposes of `GenericProjectTransformer`, we should consider the two StructKinds as equivalent since we only care about the struct fields (and whether or not they should be casted/transformed). Once the "inequivalent" structs are reported, the transformer will apply a redundant  `transform` or `cast`.

#### Fix
`fromDataType` is built in `FuzzyUnionSqlRewriter`, however, in this `RelDataType` building process we are missing a necessary declaration to override the default `StructKind` of the `Builder` object. Adding the declaration means `fromDataType` in `GenericProjectTransformer` will now use `StructKind.PEEK_FIELDS_NO_EXPAND`  instead of `StructKind.FULLY_QUALIFIED`, matching `toDataType`.

### How was this patch tested?
- Selectively tested on production views that were regressing for this reason
- i-tested, expected regressions (back to the state before 449) 