### PR TITLE
Use Sonatype token username and token password

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: ./gradlew githubRelease publishToSonatype closeAndReleaseStagingRepository --stacktrace
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          SONATYPE_USER: ${{secrets.SONATYPE_USER}}
-          SONATYPE_PWD: ${{secrets.SONATYPE_PWD}}
+          SONATYPE_TOKEN_USERNAME: ${{secrets.SONATYPE_TOKEN_USERNAME}}
+          SONATYPE_TOKEN_PASSWORD: ${{secrets.SONATYPE_TOKEN_PASSWORD}}
           PGP_KEY: ${{secrets.PGP_KEY}}
           PGP_PWD: ${{secrets.PGP_PWD}}

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -21,10 +21,10 @@ tasks.named("githubRelease") {
 apply plugin: "io.github.gradle-nexus.publish-plugin" //https://github.com/gradle-nexus/publish-plugin/
 nexusPublishing {
   repositories {
-    if (System.getenv("SONATYPE_PWD")) {
+    if (System.getenv("SONATYPE_TOKEN_PASSWORD")) {
       sonatype {
-        username = System.getenv("SONATYPE_USER")
-        password = System.getenv("SONATYPE_PWD")
+        username = System.getenv("SONATYPE_TOKEN_USERNAME")
+        password = System.getenv("SONATYPE_TOKEN_PASSWORD")
         nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
         snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
       }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:
  1. If you are new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you have added and executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
  7. Make sure that the command './gradlew clean build' passes. Resolve any formatting errors by running './gradlew spotlessApply'.
-->

### What changes are proposed in this pull request, and why are they necessary?
<!--
Kindly explain the proposed changes in this section. The goal is to outline the modifications and how this PR addresses the issue. Also, clarify the reasons for these changes. For example,
  1. If a new API is proposed, explain the intended use case.
  2. If a bug is being fixed, describe why it is a bug.
  3. If design documentation is available, please include the link.
-->
At present, we use Nexus UI sonatype username and password for release, which doesn't work now due to the recent maven central migration:
```
Caused by: org.gradle.internal.resource.transport.http.HttpErrorStatusCodeException: Could not PUT 'https://s01.oss.sonatype.org/service/local/staging/deployByRepositoryId/comlinkedincoral-1181/com/linkedin/coral/coral-common/2.2.34/coral-common-2.2.34.jar'. Received status code 401 from server: Content access is protected by token
```
To configure a publisher's plugin authentication we would need to update the plugin settings to use a user token instead of the Nexus UI username and password login. This PR modifies the configs with the newly added github secrets `SONATYPE_TOKEN_USERNAME` and `SONATYPE_TOKEN_PASSWORD`.

### How was this patch tested?
<!--
Please describe all the tests conducted.
If new unit tests were included, mention that they were added in this section. Make sure to add test cases that thoroughly examine both negative and positive cases, if possible.
If the testing approach differed from regular unit tests (e.g., regression testing), please explain how it was conducted.
If no tests were added, please explain why they were not included and/or why it was difficult to add them.
-->
NA