### PR TITLE
Rebrand HiveConvertletTable to CoralConvertletTable

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverter.java
@@ -70,7 +70,7 @@ public class HiveToRelConverter extends ToRelConverter {
 
   @Override
   protected SqlRexConvertletTable getConvertletTable() {
-    return new HiveConvertletTable();
+    return new CoralConvertletTable();
   }
 
   @Override

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/trino2rel/TrinoToRelConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/trino2rel/TrinoToRelConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2024 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -24,8 +24,8 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import com.linkedin.coral.common.HiveMetastoreClient;
 import com.linkedin.coral.common.HiveRelBuilder;
 import com.linkedin.coral.common.ToRelConverter;
+import com.linkedin.coral.hive.hive2rel.CoralConvertletTable;
 import com.linkedin.coral.hive.hive2rel.DaliOperatorTable;
-import com.linkedin.coral.hive.hive2rel.HiveConvertletTable;
 import com.linkedin.coral.hive.hive2rel.HiveSqlValidator;
 import com.linkedin.coral.hive.hive2rel.functions.HiveFunctionResolver;
 import com.linkedin.coral.hive.hive2rel.functions.StaticHiveFunctionRegistry;
@@ -63,7 +63,7 @@ public class TrinoToRelConverter extends ToRelConverter {
 
   @Override
   protected SqlRexConvertletTable getConvertletTable() {
-    return new HiveConvertletTable();
+    return new CoralConvertletTable();
   }
 
   @Override


### PR DESCRIPTION
### What changes are proposed in this pull request, and why are they necessary?
As part of Coral IR improvement work, we want to remove any language specific transformations in the RelNode layer. This PR replaces `HiveConvertletTable` to `CoralConvertletTable`, as we still need RelNode layer transformations to happen in `CoralConvertletTable` that only specific to keeping Coral IR consistent through CoralSqlNode1 ->  CoralRelNode -> CoralSqlNode2.


### How was this patch tested?
clean build
