### PR TITLE
[Coral-Trino] Use CoralSqlDialect during CoralRelNode to CoralSqlNode conversion

### DIFF
--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
@@ -5,7 +5,6 @@
  */
 package com.linkedin.coral.trino.rel2trino;
 
-import com.linkedin.coral.transformers.CoralRelToSqlNodeConverter;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -33,9 +32,9 @@ import com.linkedin.coral.com.google.common.collect.ImmutableList;
 import com.linkedin.coral.common.HiveMetastoreClient;
 import com.linkedin.coral.common.functions.CoralSqlUnnestOperator;
 import com.linkedin.coral.common.functions.FunctionFieldReferenceOperator;
+import com.linkedin.coral.transformers.CoralRelToSqlNodeConverter;
 
 import static com.google.common.base.Preconditions.*;
-import static com.linkedin.coral.transformers.CoralRelToSqlNodeConverter.INSTANCE;
 import static com.linkedin.coral.trino.rel2trino.CoralTrinoConfigKeys.*;
 
 
@@ -62,7 +61,7 @@ public class RelToTrinoConverter extends RelToSqlConverter {
    * @param mscClient client interface used to interact with the Hive Metastore service.
    */
   public RelToTrinoConverter(HiveMetastoreClient mscClient) {
-    super(INSTANCE);
+    super(CoralRelToSqlNodeConverter.INSTANCE);
     _hiveMetastoreClient = mscClient;
   }
 
@@ -72,7 +71,7 @@ public class RelToTrinoConverter extends RelToSqlConverter {
    * @param configs configs
    */
   public RelToTrinoConverter(HiveMetastoreClient mscClient, Map<String, Boolean> configs) {
-    super(INSTANCE);
+    super(CoralRelToSqlNodeConverter.INSTANCE);
     checkNotNull(configs);
     this.configs = configs;
     _hiveMetastoreClient = mscClient;

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
@@ -5,6 +5,7 @@
  */
 package com.linkedin.coral.trino.rel2trino;
 
+import com.linkedin.coral.transformers.CoralRelToSqlNodeConverter;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -34,6 +35,7 @@ import com.linkedin.coral.common.functions.CoralSqlUnnestOperator;
 import com.linkedin.coral.common.functions.FunctionFieldReferenceOperator;
 
 import static com.google.common.base.Preconditions.*;
+import static com.linkedin.coral.transformers.CoralRelToSqlNodeConverter.INSTANCE;
 import static com.linkedin.coral.trino.rel2trino.CoralTrinoConfigKeys.*;
 
 
@@ -60,7 +62,7 @@ public class RelToTrinoConverter extends RelToSqlConverter {
    * @param mscClient client interface used to interact with the Hive Metastore service.
    */
   public RelToTrinoConverter(HiveMetastoreClient mscClient) {
-    super(TrinoSqlDialect.INSTANCE);
+    super(INSTANCE);
     _hiveMetastoreClient = mscClient;
   }
 
@@ -70,7 +72,7 @@ public class RelToTrinoConverter extends RelToSqlConverter {
    * @param configs configs
    */
   public RelToTrinoConverter(HiveMetastoreClient mscClient, Map<String, Boolean> configs) {
-    super(TrinoSqlDialect.INSTANCE);
+    super(INSTANCE);
     checkNotNull(configs);
     this.configs = configs;
     _hiveMetastoreClient = mscClient;

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoSqlDialect.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoSqlDialect.java
@@ -76,7 +76,11 @@ public class TrinoSqlDialect extends SqlDialect {
         unparseMapValueConstructor(writer, call, leftPrec, rightPrec);
         break;
       default:
-        super.unparseCall(writer, call, leftPrec, rightPrec);
+        if (call.getOperator().getName().equals("timestamp_from_unixtime")) {
+          TIMESTAMP_FROM_UNIXTIME.unparse(writer, call, leftPrec, rightPrec);
+        } else {
+          super.unparseCall(writer, call, leftPrec, rightPrec);
+        }
     }
   }
 

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoSqlDialect.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoSqlDialect.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2024 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2023 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoSqlDialect.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/TrinoSqlDialect.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2024 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -76,11 +76,7 @@ public class TrinoSqlDialect extends SqlDialect {
         unparseMapValueConstructor(writer, call, leftPrec, rightPrec);
         break;
       default:
-        if (call.getOperator().getName().equals("timestamp_from_unixtime")) {
-          TIMESTAMP_FROM_UNIXTIME.unparse(writer, call, leftPrec, rightPrec);
-        } else {
-          super.unparseCall(writer, call, leftPrec, rightPrec);
-        }
+        super.unparseCall(writer, call, leftPrec, rightPrec);
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:
  1. If you are new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you have added and executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
  7. Make sure that the command './gradlew clean build' passes. Resolve any formatting errors by running './gradlew spotlessApply'.
-->

### What changes are proposed in this pull request, and why are they necessary?
As part of the new Coral IR, we want all language-specific transformations to exist in the SqlNode layer, meaning we have to replace `TrinoSqlDialect` used during the RelNode -> SqlNode phase of Coral-Trino's right hand side translation with `CoralSqlDialect` (the `SqlDialect` to represent Coral IR). This is only possible now after PRs such as #450 and #460, which made `TrinoSqlDialect` a superset of `CoralSqlDialect` with no conflicting diffs.

Note that `TrinoSqlDialect` still exists and is used at the final stage of Coral-Trino's right hand side. This is fine as it is language-specific transformations existing in the SqlNode layer.

### How was this patch tested?
clean build
regression tested
