### PR TITLE
Always allow unquoted keywords as column names

### DIFF
--- a/coral-hive/src/main/antlr/roots/com/linkedin/coral/hive/hive2rel/parsetree/parser/HiveParser.g
+++ b/coral-hive/src/main/antlr/roots/com/linkedin/coral/hive/hive2rel/parsetree/parser/HiveParser.g
@@ -657,17 +657,7 @@ import org.slf4j.LoggerFactory;
     this.hiveConf = hiveConf;
   }
   protected boolean useSQL11ReservedKeywordsForIdentifier() {
-    try {
-      /*
-       * Use the config string hive.support.sql11.reserved.keywords directly as
-       * HiveConf.ConfVars.HIVE_SUPPORT_SQL11_RESERVED_KEYWORDS might not be available in the hive-common present in the
-       * classpath during translation triggering the exception path defaulting to false
-       */
-      return !hiveConf.get("hive.support.sql11.reserved.keywords").equalsIgnoreCase("true");
-    } catch (Throwable throwable) {
-      LOG.warn(throwable.getMessage());
-      return false;
-    }
+    return true;
   }
 }
 

--- a/coral-hive/src/main/antlr/roots/com/linkedin/coral/hive/hive2rel/parsetree/parser/HiveParser.g
+++ b/coral-hive/src/main/antlr/roots/com/linkedin/coral/hive/hive2rel/parsetree/parser/HiveParser.g
@@ -657,6 +657,12 @@ import org.slf4j.LoggerFactory;
     this.hiveConf = hiveConf;
   }
   protected boolean useSQL11ReservedKeywordsForIdentifier() {
+    /*
+     * This enables the translation of keywords as column names without adding backquotes. This is required for translating views
+     * created using spark engine as certain keywords in hive like timestamp are not keywords in spark. This will
+     * result in creation of views without backquoting those keywords. This should return false when coral-spark becomes
+     * a supported LHS for translations.
+     */
     return true;
   }
 }

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilder.java
@@ -8,7 +8,6 @@ package com.linkedin.coral.hive.hive2rel.parsetree;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -105,20 +104,8 @@ public class ParseTreeBuilder extends AbstractASTVisitor<SqlNode, ParseTreeBuild
     return process(sql, null);
   }
 
-  /**
-   * Returns true if the view is created using spark sql. This relies on the presence of the
-   * spark.sql.create.version property in the views when created using spark sql.
-   *
-   * @param hiveView
-   * @return true if the view is created using spark sql
-   */
-  private static boolean isCreatedUsingSpark(Table hiveView) {
-    Map<String, String> tableParams = hiveView.getParameters();
-    return tableParams != null && tableParams.containsKey("spark.sql.create.version");
-  }
-
   public SqlNode process(String sql, @Nullable Table hiveView) {
-    ParseDriver pd = new CoralParseDriver(hiveView != null && isCreatedUsingSpark(hiveView));
+    ParseDriver pd = new CoralParseDriver();
     try {
       ASTNode root = pd.parse(sql);
       return processAST(root, hiveView);

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/parser/CoralParseDriver.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/parsetree/parser/CoralParseDriver.java
@@ -13,25 +13,12 @@ import org.antlr.runtime.RecognitionException;
 import org.antlr.runtime.TokenRewriteStream;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.hadoop.hive.conf.HiveConf;
 
 
 public class CoralParseDriver extends ParseDriver {
 
   private static final Log LOG =
       LogFactory.getLog("com.linkedin.coral.hive.hive2rel.parsetree.parser.CoralParseDriver");
-
-  private boolean useSQL11ReservedKeywordsForIdentifier;
-
-  public CoralParseDriver(boolean useSQL11ReservedKeywordsForIdentifier) {
-    super();
-    this.useSQL11ReservedKeywordsForIdentifier = useSQL11ReservedKeywordsForIdentifier;
-  }
-
-  public CoralParseDriver() {
-    super();
-    this.useSQL11ReservedKeywordsForIdentifier = false;
-  }
 
   @Override
   public ASTNode parse(String command) throws ParseException {
@@ -42,17 +29,6 @@ public class CoralParseDriver extends ParseDriver {
     HiveLexerCoral lexer = new HiveLexerCoral(new ANTLRNoCaseStringStream(command));
     TokenRewriteStream tokens = new TokenRewriteStream(lexer);
     HiveParser parser = new HiveParser(tokens);
-    HiveConf hiveConf = new HiveConf();
-    /*
-     * This enables usage of keywords as column names without adding backquotes. This is required for translating views
-     * created using spark engine as certain keywords in hive like timestamp are not keywords in spark. This will
-     * result in creation of views without backquoting those keywords. This will be removed when coral-spark becomes
-     * a supported LHS for translations.
-     */
-    if (useSQL11ReservedKeywordsForIdentifier) {
-      hiveConf.set("hive.support.sql11.reserved.keywords", "false");
-      parser.setHiveConf(hiveConf);
-    }
     parser.setTreeAdaptor(adaptor);
     HiveParser.statement_return r = null;
     try {

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/TestUtils.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/TestUtils.java
@@ -174,9 +174,8 @@ public class TestUtils {
       driver.run("CREATE VIEW IF NOT EXISTS view_schema_evolve_wrapper AS SELECT * from view_schema_evolve");
       driver.run("ALTER TABLE schema_evolve CHANGE COLUMN b b array<struct<b1:string, b2:double, b3:int>>");
 
-      driver.run("CREATE OR REPLACE VIEW test.spark_created_view AS SELECT 1 AS `timestamp` FROM test.tableOne");
-      // Simulate the creation of view using spark by setting the corresponding table property of the view.
-      driver.run("ALTER VIEW test.spark_created_view SET TBLPROPERTIES ('spark.sql.create.version'='3.1.1')");
+      driver.run(
+          "CREATE OR REPLACE VIEW test.quoted_reserved_keyword_view AS SELECT 1 AS `timestamp` FROM test.tableOne");
 
       CommandProcessorResponse response = driver
           .run("create function test_tableOneView_LessThanHundred as 'com.linkedin.coral.hive.hive2rel.CoralTestUDF'");

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
@@ -236,12 +236,12 @@ public class ParseTreeBuilderTest {
   }
 
   /**
-   * Validates if coral-hive can translate views with unquoted reserved keywords when the views are created using spark.
+   * Validates if coral-hive can translate views with unquoted reserved keywords as column names.
    */
   @Test
   public void testUnquotedKeywordAsColumnName() {
     HiveToRelConverter hiveToRelConverter = new HiveToRelConverter(msc);
-    Table table = msc.getTable("test", "spark_created_view");
+    Table table = msc.getTable("test", "quoted_reserved_keyword_view");
     // Remove the backquotes associated with the view text
     String input = table.getViewExpandedText().replaceAll("`", "");
     SqlNode sqlNode = hiveToRelConverter.toSqlNode(input, table);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:
  1. If you are new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you have added and executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
  7. Make sure that the command './gradlew clean build' passes. Resolve any formatting errors by running './gradlew spotlessApply'.
-->

### What changes are proposed in this pull request, and why are they necessary?
This PR is a follow up to #503 and fix for #534. During integration testing with a Trino environment, the [instantiation](https://github.com/linkedin/coral/pull/503/files#diff-5ce0eb8b6a4253d2b0bcca99ad4ea2f1dab11aa124ddebf767d3981a77509f5fR45) of the new `HiveConf` object threw `failure to login: javax.security.auth.login.LoginException: java.lang.NullPointerException: invalid null input: name`. This is due to the false assumption for the presence of Hive configuration files  such as `hive-site.xml` in Trino environments, which `new HiveConf()` will try to look for. This PR fixes this false assumption by removing `new HiveConf()` and forces leniency for unquote keyword columns when parsing hive views. A long term solution will involve an engine-agnostic KV config map used ubiquitously across coral.

### How was this patch tested?
- clean build
- `testUnquotedKeywordAsColumnName` passes when `useSQL11ReservedKeywordsForIdentifier` returns true and fails when `useSQL11ReservedKeywordsForIdentifier` returns false
- tested translation of view with unquoted keyword column on spark-shell with these coral changes
- set up local trino cluster with these coral changes, successfully ran translation for view with unquoted keyword column
- regression tests for spark and trino passes