### PR TITLE
Bump Calcite to preserve LATERALs in LATERAL UNNEST calls

### DIFF
--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -262,6 +262,20 @@ public class CoralSparkTest {
   }
 
   @Test
+  public void testLateralViewOuterWithExtractUnion() {
+    RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT extract_union(ut), t.ccol", "FROM complex",
+        "LATERAL VIEW OUTER explode(complex.c) t as ccol"));
+    String relNodePlan = RelOptUtil.toString(relNode);
+    System.out.println(relNodePlan);
+    String convertToSparkSql = createCoralSpark(relNode).getSparkSql();
+
+    String targetSql =
+        "SELECT coalesce_struct(complex.ut, 'uniontype<int>'), t0.ccol\n"
+            + "FROM default.complex complex LATERAL VIEW OUTER EXPLODE(complex.c) t0 AS ccol";
+    assertEquals(convertToSparkSql, targetSql);
+  }
+
+  @Test
   public void testMultipleLateralView() {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT a, t.ccol, t2.ccol2", "FROM complex ",
         "LATERAL VIEW explode(complex.c) t AS ccol ", "LATERAL VIEW explode(complex.c) t2 AS ccol2 "));
@@ -710,25 +724,25 @@ public class CoralSparkTest {
     assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
   }
 
-  @Test
-  public void testJavaMethodFunction() {
-    RelNode relNode = TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) FROM default.complex");
-    String targetSql = "SELECT reflect('java.lang.String', 'valueOf', 1)\n" + "FROM default.complex complex";
-    assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
-  }
-
-  @Test
-  public void testJavaMethodFunctionReturnType() {
-    RelNode relNode =
-        TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) + 1 FROM default.complex");
-    String targetSql =
-        "SELECT CAST(reflect('java.lang.String', 'valueOf', 1) AS INTEGER) + 1\n" + "FROM default.complex complex";
-    assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
-
-    relNode = TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) || 'a' FROM default.complex");
-    targetSql = "SELECT concat(reflect('java.lang.String', 'valueOf', 1), 'a')\n" + "FROM default.complex complex";
-    assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
-  }
+  //  @Test
+  //  public void testJavaMethodFunction() {
+  //    RelNode relNode = TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) FROM default.complex");
+  //    String targetSql = "SELECT reflect('java.lang.String', 'valueOf', 1)\n" + "FROM default.complex complex";
+  //    assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
+  //  }
+  //
+  //  @Test
+  //  public void testJavaMethodFunctionReturnType() {
+  //    RelNode relNode =
+  //        TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) + 1 FROM default.complex");
+  //    String targetSql =
+  //        "SELECT CAST(reflect('java.lang.String', 'valueOf', 1) AS INTEGER) + 1\n" + "FROM default.complex complex";
+  //    assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
+  //
+  //    relNode = TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) || 'a' FROM default.complex");
+  //    targetSql = "SELECT concat(reflect('java.lang.String', 'valueOf', 1), 'a')\n" + "FROM default.complex complex";
+  //    assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
+  //  }
 
   @Test
   public void testNegationOperator() {

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -724,25 +724,25 @@ public class CoralSparkTest {
     assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
   }
 
-  //  @Test
-  //  public void testJavaMethodFunction() {
-  //    RelNode relNode = TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) FROM default.complex");
-  //    String targetSql = "SELECT reflect('java.lang.String', 'valueOf', 1)\n" + "FROM default.complex complex";
-  //    assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
-  //  }
-  //
-  //  @Test
-  //  public void testJavaMethodFunctionReturnType() {
-  //    RelNode relNode =
-  //        TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) + 1 FROM default.complex");
-  //    String targetSql =
-  //        "SELECT CAST(reflect('java.lang.String', 'valueOf', 1) AS INTEGER) + 1\n" + "FROM default.complex complex";
-  //    assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
-  //
-  //    relNode = TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) || 'a' FROM default.complex");
-  //    targetSql = "SELECT concat(reflect('java.lang.String', 'valueOf', 1), 'a')\n" + "FROM default.complex complex";
-  //    assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
-  //  }
+    @Test
+    public void testJavaMethodFunction() {
+      RelNode relNode = TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) FROM default.complex");
+      String targetSql = "SELECT reflect('java.lang.String', 'valueOf', 1)\n" + "FROM default.complex complex";
+      assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
+    }
+
+    @Test
+    public void testJavaMethodFunctionReturnType() {
+      RelNode relNode =
+          TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) + 1 FROM default.complex");
+      String targetSql =
+          "SELECT CAST(reflect('java.lang.String', 'valueOf', 1) AS INTEGER) + 1\n" + "FROM default.complex complex";
+      assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
+
+      relNode = TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) || 'a' FROM default.complex");
+      targetSql = "SELECT concat(reflect('java.lang.String', 'valueOf', 1), 'a')\n" + "FROM default.complex complex";
+      assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
+    }
 
   @Test
   public void testNegationOperator() {

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -724,25 +724,25 @@ public class CoralSparkTest {
     assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
   }
 
-    @Test
-    public void testJavaMethodFunction() {
-      RelNode relNode = TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) FROM default.complex");
-      String targetSql = "SELECT reflect('java.lang.String', 'valueOf', 1)\n" + "FROM default.complex complex";
-      assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
-    }
+  @Test
+  public void testJavaMethodFunction() {
+    RelNode relNode = TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) FROM default.complex");
+    String targetSql = "SELECT reflect('java.lang.String', 'valueOf', 1)\n" + "FROM default.complex complex";
+    assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
+  }
 
-    @Test
-    public void testJavaMethodFunctionReturnType() {
-      RelNode relNode =
-          TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) + 1 FROM default.complex");
-      String targetSql =
-          "SELECT CAST(reflect('java.lang.String', 'valueOf', 1) AS INTEGER) + 1\n" + "FROM default.complex complex";
-      assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
+  @Test
+  public void testJavaMethodFunctionReturnType() {
+    RelNode relNode =
+        TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) + 1 FROM default.complex");
+    String targetSql =
+        "SELECT CAST(reflect('java.lang.String', 'valueOf', 1) AS INTEGER) + 1\n" + "FROM default.complex complex";
+    assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
 
-      relNode = TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) || 'a' FROM default.complex");
-      targetSql = "SELECT concat(reflect('java.lang.String', 'valueOf', 1), 'a')\n" + "FROM default.complex complex";
-      assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
-    }
+    relNode = TestUtils.toRelNode("SELECT java_method('java.lang.String', 'valueOf', 1) || 'a' FROM default.complex");
+    targetSql = "SELECT concat(reflect('java.lang.String', 'valueOf', 1), 'a')\n" + "FROM default.complex complex";
+    assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
+  }
 
   @Test
   public void testNegationOperator() {

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -265,7 +265,6 @@ public class CoralSparkTest {
   public void testLateralViewOuterWithExtractUnion() {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT extract_union(ut), t.ccol", "FROM complex",
         "LATERAL VIEW OUTER explode(complex.c) t as ccol"));
-    String relNodePlan = RelOptUtil.toString(relNode);
     String convertToSparkSql = createCoralSpark(relNode).getSparkSql();
 
     String targetSql = "SELECT coalesce_struct(complex.ut, 'uniontype<int>'), t0.ccol\n"

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -266,7 +266,6 @@ public class CoralSparkTest {
     RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT extract_union(ut), t.ccol", "FROM complex",
         "LATERAL VIEW OUTER explode(complex.c) t as ccol"));
     String relNodePlan = RelOptUtil.toString(relNode);
-    System.out.println(relNodePlan);
     String convertToSparkSql = createCoralSpark(relNode).getSparkSql();
 
     String targetSql = "SELECT coalesce_struct(complex.ut, 'uniontype<int>'), t0.ccol\n"

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -269,9 +269,8 @@ public class CoralSparkTest {
     System.out.println(relNodePlan);
     String convertToSparkSql = createCoralSpark(relNode).getSparkSql();
 
-    String targetSql =
-        "SELECT coalesce_struct(complex.ut, 'uniontype<int>'), t0.ccol\n"
-            + "FROM default.complex complex LATERAL VIEW OUTER EXPLODE(complex.c) t0 AS ccol";
+    String targetSql = "SELECT coalesce_struct(complex.ut, 'uniontype<int>'), t0.ccol\n"
+        + "FROM default.complex complex LATERAL VIEW OUTER EXPLODE(complex.c) t0 AS ccol";
     assertEquals(convertToSparkSql, targetSql);
   }
 

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
@@ -60,7 +60,7 @@ public class TestUtils {
     run(driver, "CREATE TABLE IF NOT EXISTS baz(`timestamp` int, `select` double)");
     run(driver, "CREATE VIEW IF NOT EXISTS baz_view as select `select`, `timestamp` from baz");
     run(driver,
-        "CREATE TABLE IF NOT EXISTS complex(a int, b string, c array<double>, s struct<name:string, age:int>, m map<string, int>, sarr array<struct<name:string, age:int>>)");
+        "CREATE TABLE IF NOT EXISTS complex(a int, b string, c array<double>, s struct<name:string, age:int>, m map<string, int>, sarr array<struct<name:string, age:int>>, ut uniontype<int>)");
 
     String baseComplexSchema = loadSchema("base-complex.avsc");
     executeCreateTableQuery(driver, "default", "basecomplex", baseComplexSchema);

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ def versions = [
   'jetbrains': '16.0.2',
   'jline': '0.9.94',
   'kryo': '2.22',
-  'linkedin-calcite-core': '1.21.0.262',
+  'linkedin-calcite-core': '1.21.0.264',
   'pig': '0.15.0',
   'spark': '2.4.0',
   'spark3': '3.1.1',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ def versions = [
   'jetbrains': '16.0.2',
   'jline': '0.9.94',
   'kryo': '2.22',
-  'linkedin-calcite-core': '1.21.0.264',
+  'linkedin-calcite-core': '1.21.0.265',
   'pig': '0.15.0',
   'spark': '2.4.0',
   'spark3': '3.1.1',


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:
  1. If you are new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you have added and executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
  7. Make sure that the command './gradlew clean build' passes. Resolve any formatting errors by running './gradlew spotlessApply'.
-->

### What changes are proposed in this pull request, and why are they necessary?
RelNode type derivation on the Coral IR -> Spark SQL path was introduced in #507 in `ExtractUnionFunctionTransformer` [here](https://github.com/linkedin/coral/pull/507/files#diff-12e62c094657b085c3a3c21434cc46aa9e2e9ae32c5633c75072abedf8aa5b00R88). The type derivation requires calling Calcite's `validate` function which was incorrectly dropping the LATERAL keyword, this was previously only fixed for `... LATERAL (SELECT .....` case but has since been fixed for `.. LATERAL (UNNEST ...` [here](https://github.com/linkedin/linkedin-calcite/pull/101).

This PR bumps the Calcite version to include the fix and adds a new unit to ensure LATERALs are not dropped for views with the Coral IR -> Spark SQL type derivation (through `ExtractUnionFunctionTransformer`).


### How was this patch tested?

- `./gradlew clean build`
- new unit test passing when using newest Calcite with fix
-  no regressions when testing on production views
   -  since certain views that were already failing due to this issue, their translation wouldn't be tested in the regression pipeline (since the pipeline is designed is test regressions, we take only the views with valid translations on the coral master branch and run translations on that subset of views only with the feature coral branch), ran adhoc regression tests with those failing views and they now succeed with these changes.