### PR TITLE
[Coral-schema] Generalize operand schema inference on ordinal return type UDF calls

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2024 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2025 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
@@ -448,8 +448,11 @@ public class RelToAvroSchemaConverter {
 
         if (operand instanceof RexInputRef) {
           appendRexInputRefField((RexInputRef) operand);
-          return rexCall;
+        } else if (operand instanceof RexCall) {
+          // If the operand is a call, we need to visit the call to get the field schema
+          visitCall((RexCall) operand);
         }
+        return rexCall;
       }
 
       RelDataType fieldType = rexCall.getType();

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelToAvroSchemaConverter.java
@@ -433,7 +433,7 @@ public class RelToAvroSchemaConverter {
     @Override
     public RexNode visitCall(RexCall rexCall) {
       /**
-       * For SqlUserDefinedFunction and SqlOperator RexCall, no need to handle it recursively
+       * For SqlUserDefinedFunction and SqlOperator RexCall, no need to handle it recursively (in most cases)
        * and only return type of udf or sql operator is relevant
        */
 
@@ -445,13 +445,13 @@ public class RelToAvroSchemaConverter {
       if (rexCall.getOperator().getReturnTypeInference() instanceof OrdinalReturnTypeInferenceV2) {
         int index = ((OrdinalReturnTypeInferenceV2) rexCall.getOperator().getReturnTypeInference()).getOrdinal();
         RexNode operand = rexCall.operands.get(index);
-
-        if (operand instanceof RexInputRef) {
-          appendRexInputRefField((RexInputRef) operand);
-        } else if (operand instanceof RexCall) {
-          // If the operand is a call, we need to visit the call to get the field schema
-          visitCall((RexCall) operand);
-        }
+        operand.accept(this);
+        //        if (operand instanceof RexInputRef) {
+        //          appendRexInputRefField((RexInputRef) operand);
+        //        } else if (operand instanceof RexCall) {
+        //          // If the operand is another call, we need to visit the call to get the field schema
+        //          visitCall((RexCall) operand);
+        //        }
         return rexCall;
       }
 

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TestUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2024 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2025 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -177,7 +177,7 @@ public class TestUtils {
     executeCreateFunctionQuery("default", Collections.singletonList("foo_udf_return_struct"), "FuncIsEven",
         "com.linkedin.coral.hive.hive2rel.CoralTestUDFReturnStruct");
 
-    executeCreateFunctionQuery("default", Collections.singletonList("innerfield_with_udf"), "ReturnInnerStuct",
+    executeCreateFunctionQuery("default", Collections.singletonList("innerfield_with_udf"), "ReturnInnerStruct",
         "com.linkedin.coral.hive.hive2rel.CoralTestUDFReturnSecondArg");
   }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:
  1. If you are new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you have added and executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
  7. Make sure that the command './gradlew clean build' passes. Resolve any formatting errors by running './gradlew spotlessApply'.
-->

### What changes are proposed in this pull request, and why are they necessary?
Currently, coral-schema is only set up to correctly infer schemas for UDFs with an ordinal return type, only if the ordinal operand is a reference to an input column. However, this is limiting and we have since encountered views with nested calls on UDFs with an ordinal return type. For example, `UDF_A('foo', UDF_A('foo', colA))`, where the return type of `UDF_A` is whatever the return type of it's second operand is.

We correct this by using the `SchemaRexShuttle` to visit the ordinal operand, which will infer the schema of the operand and add it to the final schema as a field. This way, we leverage the shuttle to categorize and process the operand for us so we don't have to manually categorize the operand.

 
### How was this patch tested?

- New unit test to schema inference on nested UDF calls with ordinal return types
- `./gradlew clean build`
- regression test passes
- tested schema produced on spark-shell for a view with previously incorrect schema (due to incorrect nullabilites)
