### PR TITLE
[bugfix] ConcurrentHashMap<String, Function> can't contain values of type String

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveFunctionResolver.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/HiveFunctionResolver.java
@@ -209,14 +209,14 @@ public class HiveFunctionResolver {
   }
 
   public void addDynamicFunctionToTheRegistry(String functionClassName, Function function) {
-    if (!dynamicFunctionRegistry.contains(functionClassName)) {
+    if (!dynamicFunctionRegistry.containsKey(functionClassName)) {
       dynamicFunctionRegistry.put(functionClassName, function);
     }
   }
 
   private @Nonnull Collection<Function> resolveDaliFunctionDynamically(String originalViewTextFunctionName,
       String functionClassName, HiveTable hiveTable, int numOfOperands) {
-    if (dynamicFunctionRegistry.contains(functionClassName)) {
+    if (dynamicFunctionRegistry.containsKey(functionClassName)) {
       return ImmutableList.of(dynamicFunctionRegistry.get(originalViewTextFunctionName));
     }
     Function function = new Function(functionClassName,


### PR DESCRIPTION
ConcurrentHashMap<String, Function> can't contain values of type String.
Need to use containsKey() instead of contains()
