### PR TITLE
Account for LinkedIn Spark versioning

### DIFF
--- a/coral-spark/src/main/java/com/linkedin/coral/spark/transformers/TransportUDFTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/transformers/TransportUDFTransformer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2024 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2025 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/transformers/TransportUDFTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/transformers/TransportUDFTransformer.java
@@ -88,7 +88,7 @@ public class TransportUDFTransformer extends SqlCallTransformer {
       String sparkVersion = SparkSession.active().version();
       if (sparkVersion.matches("2\\.[\\d\\.]*")) {
         return ScalaVersion.SCALA_2_11;
-      } else if (sparkVersion.matches("3\\.[\\d\\.]*")) {
+      } else if (sparkVersion.matches("3\\d*\\.[\\d\\.]*")) {
         return ScalaVersion.SCALA_2_12;
       } else {
         throw new IllegalStateException(String.format("Unsupported Spark Version %s", sparkVersion));


### PR DESCRIPTION
### What changes are proposed in this pull request, and why are they necessary?

In `TransportUDFTransformer` we have a function which decides the Scala version to use for a given Spark version. In LinkedIn we have changed the versioning scheme we use internally for Spark 3.5+, where the major version of the internal Spark distribution denotes the full OSS Spark version. E.g. For Spark 3.5.2, this would be 352.x.y (where x and y are internal versions). This PR accounts for this new versioning format.

### How was this patch tested?
Existing unit tests.
Tested the regex separately via regex101
<img width="231" alt="image" src="https://github.com/user-attachments/assets/779eb267-b839-4329-8925-a86900b7467f" />
