### PR TITLE
Register ExtractCollectionUdf as Trino UDF

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/VersionedSqlUserDefinedFunction.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/VersionedSqlUserDefinedFunction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2024 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2025 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/VersionedSqlUserDefinedFunction.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/VersionedSqlUserDefinedFunction.java
@@ -47,6 +47,7 @@ public class VersionedSqlUserDefinedFunction extends SqlUserDefinedFunction {
       .put("com.linkedin.groot.runtime.udf.spark.RedactFieldIfUDF", "redact_field_if")
       .put("com.linkedin.groot.runtime.udf.spark.RedactSecondarySchemaFieldIfUDF", "redact_secondary_schema_field_if")
       .put("com.linkedin.groot.runtime.udf.spark.GetMappedValueUDF", "get_mapped_value")
+      .put("com.linkedin.groot.runtime.udf.spark.ExtractCollectionUDF", "extract_collection")
       .put("com.linkedin.coral.hive.hive2rel.CoralTestUDF", "coral_test").build();
 
   // The list of dependencies specified found in the view's "dependencies" property.


### PR DESCRIPTION
### What changes are proposed in this pull request, and why are they necessary?
This PR maps the ExtractCollectionUDF UDF to its Trino counterpart, so users can query the Hive views using these UDFs after registering the corresponding Trino function names in Trino.


### How was this patch tested?
` ./gradlew clean build`

No user is currently using this UDF for now so it should not cause any regressions.