### PR TITLE
[Coral-Schema] handle single-element unions when the supplied column schema does not specify <uniontype>

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/HiveSchemaWithPartnerVisitor.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/HiveSchemaWithPartnerVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021-2022 LinkedIn Corporation. All rights reserved.
+ * Copyright 2021-2025 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -115,12 +115,12 @@ public abstract class HiveSchemaWithPartnerVisitor<P, FP, R, FR> {
       default:
         throw new UnsupportedOperationException(typeInfo + " not supported");
     }
-    
+
     // Rewrap in single-element union if the partner was originally wrapped
     if (partnerWrapped) {
       resultSchema = (R) SchemaUtilities.wrapInSingleElementUnion((Schema) resultSchema);
     }
-    
+
     return resultSchema;
   }
 

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2025 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2020-2025 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -254,13 +254,12 @@ public class MergeHiveSchemaWithAvroTests {
     String hive = "struct<id:bigint,name:string,active:boolean,"
         + "items:array<struct<fooconfiguration:struct<name:string,urlvalue:string,source:string>,"
         + "barconfiguration:struct<name:string,domain:string>>>,"
-        + "metadata:map<string,struct<category:string,priority:int>>,"
-        + "tags:array<string>>";
+        + "metadata:map<string,struct<category:string,priority:int>>," + "tags:array<string>>";
 
     // Nested record schemas
-    Schema fooConfigSchema = struct("FooConfiguration", "doc-foo", "com.example.data",
-        required("name", Schema.Type.STRING), required("urlValue", Schema.Type.STRING),
-        required("source", Schema.Type.STRING));
+    Schema fooConfigSchema =
+        struct("FooConfiguration", "doc-foo", "com.example.data", required("name", Schema.Type.STRING),
+            required("urlValue", Schema.Type.STRING), required("source", Schema.Type.STRING));
 
     Schema barConfigSchema = struct("BarConfiguration", "doc-bar", "com.example.data",
         required("name", Schema.Type.STRING), required("domain", Schema.Type.STRING));
@@ -273,8 +272,10 @@ public class MergeHiveSchemaWithAvroTests {
 
     // Construct Avro schema with single-element unions for primitives, array items, and map values
     Schema avro = struct("test_complex_array_table", "doc-test", "com.example.test", optional("id", Schema.Type.LONG),
-        field("name", SchemaUtilities.wrapInSingleElementUnion(Schema.create(Schema.Type.STRING)), null, "unknown", null),
-        field("active", SchemaUtilities.wrapInSingleElementUnion(Schema.create(Schema.Type.BOOLEAN)), null, false, null),
+        field("name", SchemaUtilities.wrapInSingleElementUnion(Schema.create(Schema.Type.STRING)), null, "unknown",
+            null),
+        field("active", SchemaUtilities.wrapInSingleElementUnion(Schema.create(Schema.Type.BOOLEAN)), null, false,
+            null),
         optional("items", array(SchemaUtilities.wrapInSingleElementUnion(seu_arrayItemConfigSchema))),
         optional("metadata", map(SchemaUtilities.wrapInSingleElementUnion(seu_mapValueMetadataSchema))),
         optional("tags", array(SchemaUtilities.wrapInSingleElementUnion(Schema.create(Schema.Type.STRING)))));
@@ -299,13 +300,10 @@ public class MergeHiveSchemaWithAvroTests {
     // in nested structures even when the Hive schema uses uniontype format.
 
     // seu = single-element union
-    String hive = "struct<id:bigint,"
-        + "status:uniontype<string,int>,"
-        + "items:array<uniontype<struct<value:string>>>,"
-        + "metadata:map<string,uniontype<struct<priority:int>>>>";
+    String hive = "struct<id:bigint," + "status:uniontype<string,int>,"
+        + "items:array<uniontype<struct<value:string>>>," + "metadata:map<string,uniontype<struct<priority:int>>>>";
 
-    Schema seu_arrayItemSchema =
-        struct("Item", "doc-item", "com.example.data", required("value", Schema.Type.STRING));
+    Schema seu_arrayItemSchema = struct("Item", "doc-item", "com.example.data", required("value", Schema.Type.STRING));
 
     Schema seu_mapValueMetadataSchema =
         struct("MetadataInfo", "doc-metadata", "com.example.data", required("priority", Schema.Type.INT));


### PR DESCRIPTION
### What changes are proposed in this pull request, and why are they necessary?
When Avro schemas define single-element unions (e.g., `["string"]` for primitives, `[{"type":"record",...}]` for array items/map values), the schema merge logic in `MergeHiveSchemaWithAvro` was incorrectly unwrapping them, changing non-nullable types to nullable types or losing the union structure entirely.

This issue occurs because some table systems (like OpenHouse) don't represent single-element unions as `uniontype<...>` in the Hive schema. When the Hive schema simply shows `string` or `struct<...>` instead of `uniontype<string>` or `uniontype<struct<...>>`, the merge logic treats them as regular types and unwraps the Avro union.

**Changes made:**

1. **`HiveSchemaWithPartnerVisitor.java`**: Added logic at the top level of the `visit()` method to:
   - Detect when the Avro partner schema has a single-element union but the Hive `TypeInfo` doesn't declare a union (via `shouldUnwrapPartner()`)
   - Temporarily unwrap the partner before the switch statement for proper type matching
   - Rewrap the result after processing to preserve the original Avro structure

2. **`SchemaUtilities.java`**: 
   - Added `wrapInSingleElementUnion()` utility method along with `extractSingleElementUnion()`
   - These methods provide a consistent API for single-element union handling

3. **Key behavior**: The fix only applies when there's a **mismatch** between Hive and Avro:
   - If Hive declares `uniontype<...>`, normal union processing occurs (no unwrap/rewrap)
   - If Hive doesn't declare `uniontype` but Avro has a single-element union, we unwrap for matching then rewrap to preserve structure

This ensures that Avro schemas with single-element unions (commonly found in `avro.schema.literal` properties) maintain their exact structure after merging, preventing unintended nullability changes.

### How was this patch tested?
Added two comprehensive unit tests in `MergeHiveSchemaWithAvroTests`:

1. **`shouldHandleSingleElementUnionsInAllTypes`**: 
   - Tests single-element unions in primitives (`["string"]`, `["boolean"]`), array items, and map values
   - Hive schema does NOT use `uniontype` (simulating OpenHouse-style schemas)
   - Verifies that all single-element unions are preserved in the output

2. **`shouldHandleSingleElementUnionsWithHiveUnionType`**:
   - Tests backward compatibility when Hive explicitly declares `uniontype<...>`
   - Includes both regular multi-type unions and single-element unions
   - Ensures the fix doesn't interfere with normal union processing

Both tests verify that:
- The input Avro schema structure is preserved (single-element unions remain wrapped)
- Field names, nullability, docs, and default values are maintained
- Complex nested structures (records within arrays/maps) work correctly

All existing tests continue to pass, confirming no regressions.

Also manually ran integration tests in spark, by generating a jar. Confirmed that the original symptoms are now fixed, ie. view on top of the table that had the single-element-union now show correct nullability for all fields