### PR TITLE
[Coral-Schema] Disambiguate nested record namespaces with numeric suffixes

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2025 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2026 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2025 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2026 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:
  1. If you are new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you have added and executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
  7. Make sure that the command './gradlew clean build' passes. Resolve any formatting errors by running './gradlew spotlessApply'.
-->

### What changes are proposed in this pull request, and why are they necessary?
- Fix Avro namespace collisions when a parent schema contains multiple fields that reference nested records with the same name but different original namespaces, by doing the following
  - Detect collisions per parent record (same record name, different original namespaces).
  - Assign stable numeric suffixes to the reconstructed namespace of colliding records (e.g., “-0”, “-1”, …), keeping non-colliding cases unchanged.

This approach:
- Prevents fully-qualified name collisions.
- Avoids leaking source/original namespaces into generated schemas.
- Minimizes changes: only colliding records get suffixes; everything else remains the same.

Simple example:
Input (two fields with the same record name):
```
{
  "type": "record",
  "name": "Parent",
  "namespace": "com.app",
  "fields": [
    { "name": "ctxA", "type": ["null", {"type":"record","name":"Ctx","namespace":"com.foo"}] },
    { "name": "ctxB", "type": ["null", {"type":"record","name":"Ctx","namespace":"com.bar"}] }
  ]
}
```
- Before (with collision): both nested records reconstructed to the same namespace (e.g., "com.app.Parent"), and has the same name (eg. "Ctx"), which is invalid.
- After (no collision):
  - ctxA non-null type namespace: "com.app.Parent-0", with name "Ctx"
  - ctxB non-null type namespace: "com.app.Parent-1", with name "Ctx"

### How was this patch tested?
- Added unit tests in SchemaUtilitiesTests:
- Verifies collision handling for nullable union fields with same record name.
- Verifies collision handling for direct nested record fields (non-union) with same record name.
- Asserts distinct namespaces with numeric suffixes (e.g., endsWith("-0") / endsWith("-1")).
- Ran full module tests; all existing tests pass without updating expected .avsc files.
- Verified manually in Spark-shell that the namespace collision was fixed for the offending table