### PR TITLE
Change Nexus URL to fix publish pipeline

### DIFF
--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -25,8 +25,8 @@ nexusPublishing {
       sonatype {
         username = System.getenv("SONATYPE_TOKEN_USERNAME")
         password = System.getenv("SONATYPE_TOKEN_PASSWORD")
-        nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-        snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+        nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+        snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
       }
     }
   }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:
  1. If you are new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you have added and executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
  7. Make sure that the command './gradlew clean build' passes. Resolve any formatting errors by running './gradlew spotlessApply'.
-->

### What changes are proposed in this pull request, and why are they necessary?
<!--
Kindly explain the proposed changes in this section. The goal is to outline the modifications and how this PR addresses the issue. Also, clarify the reasons for these changes. For example,
  1. If a new API is proposed, explain the intended use case.
  2. If a bug is being fixed, describe why it is a bug.
  3. If design documentation is available, please include the link.
-->
The current publishing of artifacts fails since the URL is no longer valid. error seen:
```
Caused by: java.lang.RuntimeException: Failed to load staging profiles, server at https://s01.oss.sonatype.org/service/local/ responded with status code 401, body: 
	at io.github.gradlenexus.publishplugin.internal.NexusClient.failure(NexusClient.kt:142)
	at io.github.gradlenexus.publishplugin.internal.NexusClient.findStagingProfileId(NexusClient.kt:73)
	at io.github.gradlenexus.publishplugin.InitializeNexusStagingRepository.determineStagingProfileId(InitializeNexusStagingRepository.kt:63)
	at io.github.gradlenexus.publishplugin.InitializeNexusStagingRepository.createStagingRepo(InitializeNexusStagingRepository.kt:50)
...
```

This PR updates the Nexus URL to fix publish pipeline for Coral. The URL is now same as what other LinkedIn projects, like iceberg & transport, use. 
 
### How was this patch tested?
<!--
Please describe all the tests conducted.
If new unit tests were included, mention that they were added in this section. Make sure to add test cases that thoroughly examine both negative and positive cases, if possible.
If the testing approach differed from regular unit tests (e.g., regression testing), please explain how it was conducted.
If no tests were added, please explain why they were not included and/or why it was difficult to add them.
-->
./gradlew build