### PR TITLE
Refactor partner-Avro parsing into reusable property-map helper

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -154,9 +154,8 @@ class SchemaUtilities {
   static Schema getCasePreservedSchemaFromTblProperties(@Nonnull final Table table) {
     Preconditions.checkNotNull(table);
 
-    Map<String, String> serdeProperties =
-        table.getSd() != null && table.getSd().getSerdeInfo() != null ? table.getSd().getSerdeInfo().getParameters()
-            : null;
+    Map<String, String> serdeProperties = table.getSd() != null && table.getSd().getSerdeInfo() != null
+        ? table.getSd().getSerdeInfo().getParameters() : null;
 
     return getCasePreservedSchemaFromPropertyMaps(table.getParameters(), serdeProperties, getCompleteName(table));
   }

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/SchemaUtilities.java
@@ -154,13 +154,45 @@ class SchemaUtilities {
   static Schema getCasePreservedSchemaFromTblProperties(@Nonnull final Table table) {
     Preconditions.checkNotNull(table);
 
-    // First try avro.schema.literal
-    String schemaStr = readSchemaFromSchemaLiteral(table);
+    Map<String, String> serdeProperties =
+        table.getSd() != null && table.getSd().getSerdeInfo() != null ? table.getSd().getSerdeInfo().getParameters()
+            : null;
+
+    return getCasePreservedSchemaFromPropertyMaps(table.getParameters(), serdeProperties, getCompleteName(table));
+  }
+
+  /**
+   * Returns case sensitive schema from property maps or null if not present.
+   * This is the shared implementation used by both the Hive Table path and the CoralTable path.
+   *
+   * @param tableProperties table-level properties (e.g. from Table.getParameters() or CoralTable.properties())
+   * @param serdeProperties serde-level properties, or null if not available (CoralTable path)
+   * @param tableName human-readable table name for logging
+   * @return Avro schema stored under 'avro.schema.literal', under 'dali.row.schema',
+   * or null if none of the above are present
+   */
+  static Schema getCasePreservedSchemaFromPropertyMaps(@Nonnull Map<String, String> tableProperties,
+      @Nullable Map<String, String> serdeProperties, String tableName) {
+    Preconditions.checkNotNull(tableProperties);
+
+    // First try avro.schema.literal from table properties
+    String schemaStr = tableProperties.get(AvroSerdeUtils.AVRO_SCHEMA_LITERAL);
+
+    // Then try avro.schema.literal from serde properties
+    if (Strings.isNullOrEmpty(schemaStr) && serdeProperties != null) {
+      schemaStr = serdeProperties.get(AvroSerdeUtils.AVRO_SCHEMA_LITERAL);
+    }
+
+    if (Strings.isNullOrEmpty(schemaStr)) {
+      LOG.debug("No avro schema defined under table or serde property {} for table {}",
+          AvroSerdeUtils.AVRO_SCHEMA_LITERAL, tableName);
+    }
+
     Schema schema = null;
 
     // Then, try dali.row.schema
     if (Strings.isNullOrEmpty(schemaStr)) {
-      schemaStr = table.getParameters().get(DALI_ROW_SCHEMA);
+      schemaStr = tableProperties.get(DALI_ROW_SCHEMA);
       if (!Strings.isNullOrEmpty(schemaStr)) {
         schemaStr = schemaStr.replaceAll("\n", "\\\\n");
         // Given schemas stored in `dali.row.schema` are all non-nullable, we need to convert them to be nullable to be compatible with Spark
@@ -171,11 +203,11 @@ class SchemaUtilities {
     }
 
     if (schema != null) {
-      LOG.info("Schema found for table {}", getCompleteName(table));
+      LOG.info("Schema found for table {}", tableName);
       LOG.debug("Schema is {}", schema.toString(true));
       return schema;
     } else {
-      LOG.warn("Cannot determine avro schema for table {}", getCompleteName(table));
+      LOG.warn("Cannot determine avro schema for table {}", tableName);
       return null;
     }
   }
@@ -992,28 +1024,6 @@ class SchemaUtilities {
     }
 
     return partKeys;
-  }
-
-  /**
-   * Note: This method is modified based on SchemaUtilities in Dali codebase
-   *
-   * @param table
-   * @return
-   */
-  private static String readSchemaFromSchemaLiteral(@Nonnull Table table) {
-    Preconditions.checkNotNull(table);
-
-    String schemaStr = table.getParameters().get(AvroSerdeUtils.AVRO_SCHEMA_LITERAL);
-    if (Strings.isNullOrEmpty(schemaStr)) {
-      schemaStr = table.getSd().getSerdeInfo().getParameters().get(AvroSerdeUtils.AVRO_SCHEMA_LITERAL);
-    }
-
-    if (Strings.isNullOrEmpty(schemaStr)) {
-      LOG.debug("No avro schema defined under table or serde property {} for table {}",
-          AvroSerdeUtils.AVRO_SCHEMA_LITERAL, getCompleteName(table));
-    }
-
-    return schemaStr;
   }
 
   private static String getCompleteName(@Nonnull Table table) {

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
@@ -42,7 +42,8 @@ public class SchemaUtilitiesTests {
     Map<String, String> serdeProperties = new HashMap<>();
     serdeProperties.put("avro.schema.literal", SIMPLE_AVRO_SCHEMA);
 
-    Schema result = SchemaUtilities.getCasePreservedSchemaFromPropertyMaps(tableProperties, serdeProperties, "test@table");
+    Schema result =
+        SchemaUtilities.getCasePreservedSchemaFromPropertyMaps(tableProperties, serdeProperties, "test@table");
 
     Assert.assertNotNull(result);
     Assert.assertEquals(result.getName(), "TestRecord");
@@ -60,7 +61,8 @@ public class SchemaUtilitiesTests {
     Map<String, String> serdeProperties = new HashMap<>();
     serdeProperties.put("avro.schema.literal", serdeSchema);
 
-    Schema result = SchemaUtilities.getCasePreservedSchemaFromPropertyMaps(tableProperties, serdeProperties, "test@table");
+    Schema result =
+        SchemaUtilities.getCasePreservedSchemaFromPropertyMaps(tableProperties, serdeProperties, "test@table");
 
     Assert.assertNotNull(result);
     Assert.assertEquals(result.getName(), "FromTable");
@@ -89,6 +91,7 @@ public class SchemaUtilitiesTests {
 
     Assert.assertNull(result);
   }
+
   @Test
   public void testCloneFieldList() {
     Schema dummySchema = SchemaBuilder.record("test").fields().name("a").type().intType().noDefault().endRecord();

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
@@ -6,7 +6,9 @@
 package com.linkedin.coral.schema.avro;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 
@@ -17,6 +19,76 @@ import org.testng.annotations.Test;
 
 
 public class SchemaUtilitiesTests {
+
+  private static final String SIMPLE_AVRO_SCHEMA =
+      "{\"type\":\"record\",\"name\":\"TestRecord\",\"namespace\":\"com.test\","
+          + "\"fields\":[{\"name\":\"id\",\"type\":\"int\"},{\"name\":\"name\",\"type\":\"string\"}]}";
+
+  @Test
+  public void testGetCasePreservedSchemaFromPropertyMapsWithSchemaLiteral() {
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put("avro.schema.literal", SIMPLE_AVRO_SCHEMA);
+
+    Schema result = SchemaUtilities.getCasePreservedSchemaFromPropertyMaps(tableProperties, null, "test@table");
+
+    Assert.assertNotNull(result);
+    Assert.assertEquals(result.getName(), "TestRecord");
+    Assert.assertEquals(result.getFields().size(), 2);
+  }
+
+  @Test
+  public void testGetCasePreservedSchemaFromPropertyMapsWithSerdeProperties() {
+    Map<String, String> tableProperties = new HashMap<>();
+    Map<String, String> serdeProperties = new HashMap<>();
+    serdeProperties.put("avro.schema.literal", SIMPLE_AVRO_SCHEMA);
+
+    Schema result = SchemaUtilities.getCasePreservedSchemaFromPropertyMaps(tableProperties, serdeProperties, "test@table");
+
+    Assert.assertNotNull(result);
+    Assert.assertEquals(result.getName(), "TestRecord");
+  }
+
+  @Test
+  public void testGetCasePreservedSchemaFromPropertyMapsTablePropsTakePrecedence() {
+    String tableSchema = "{\"type\":\"record\",\"name\":\"FromTable\",\"namespace\":\"com.test\","
+        + "\"fields\":[{\"name\":\"id\",\"type\":\"int\"}]}";
+    String serdeSchema = "{\"type\":\"record\",\"name\":\"FromSerde\",\"namespace\":\"com.test\","
+        + "\"fields\":[{\"name\":\"id\",\"type\":\"int\"}]}";
+
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put("avro.schema.literal", tableSchema);
+    Map<String, String> serdeProperties = new HashMap<>();
+    serdeProperties.put("avro.schema.literal", serdeSchema);
+
+    Schema result = SchemaUtilities.getCasePreservedSchemaFromPropertyMaps(tableProperties, serdeProperties, "test@table");
+
+    Assert.assertNotNull(result);
+    Assert.assertEquals(result.getName(), "FromTable");
+  }
+
+  @Test
+  public void testGetCasePreservedSchemaFromPropertyMapsWithDaliRowSchema() {
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put("dali.row.schema", SIMPLE_AVRO_SCHEMA);
+
+    Schema result = SchemaUtilities.getCasePreservedSchemaFromPropertyMaps(tableProperties, null, "test@table");
+
+    Assert.assertNotNull(result);
+    Assert.assertEquals(result.getName(), "TestRecord");
+    // dali.row.schema results are converted to nullable
+    for (Schema.Field field : result.getFields()) {
+      Assert.assertEquals(field.schema().getType(), Schema.Type.UNION);
+    }
+  }
+
+  @Test
+  public void testGetCasePreservedSchemaFromPropertyMapsReturnsNullWhenEmpty() {
+    Map<String, String> tableProperties = new HashMap<>();
+
+    Schema result = SchemaUtilities.getCasePreservedSchemaFromPropertyMaps(tableProperties, null, "test@table");
+
+    Assert.assertNull(result);
+  }
   @Test
   public void testCloneFieldList() {
     Schema dummySchema = SchemaBuilder.record("test").fields().name("a").type().intType().noDefault().endRecord();


### PR DESCRIPTION
## Motivation
Today, partner-Avro parsing in `SchemaUtilities` is tightly coupled to the Hive `Table` object — `getCasePreservedSchemaFromTblProperties(Table)` and `readSchemaFromSchemaLiteral(Table)` both require a Hive metastore `Table` to read `avro.schema.literal` and `dali.row.schema`.

This is a blocker for the Iceberg-first Avro rollout, where `CoralTable`-backed flows (e.g. Iceberg tables) need to read partner Avro from property maps (`CoralTable.properties()`) without having a Hive `Table` available. Without this refactor, every new schema path would need to duplicate the parsing logic.

## Summary
- Extract schema-reading logic from `getCasePreservedSchemaFromTblProperties` and `readSchemaFromSchemaLiteral` into a new `getCasePreservedSchemaFromPropertyMaps(Map<String, String>, Map<String, String>, String)` method
- Enables `CoralTable`-backed flows (e.g. Iceberg tables) to reuse partner-Avro parsing without requiring a Hive metastore `Table` object
- Refactor existing `getCasePreservedSchemaFromTblProperties(Table)` to delegate to the new method; remove now-unused `readSchemaFromSchemaLiteral`

## How the new method will be used

**Hive tables (unchanged):** `getCasePreservedSchemaFromTblProperties(Table)` is still called at all existing call sites. It now delegates internally to `getCasePreservedSchemaFromPropertyMaps`, extracting `table.getParameters()` and `table.getSd().getSerdeInfo().getParameters()` as the two maps.

**Iceberg/OpenHouse tables (future PRs):** When `SchemaUtilities.getAvroSchemaForTable(CoralTable, strictMode)` is added, it will call `getCasePreservedSchemaFromPropertyMaps` directly:

```java
Schema partnerAvro = getCasePreservedSchemaFromPropertyMaps(
    coralTable.properties(),  // table-level properties from CoralTable
    null,                     // no serde properties — Iceberg doesn't have a Hive SerDe layer
    coralTable.name()         // e.g. "db@tableName" for logging
);
```

The `serdeProperties` parameter is `null` because Iceberg/OpenHouse tables don't go through a Hive SerDe — they store `avro.schema.literal` (if at all) in their table properties directly. The method handles `null` serde properties gracefully by skipping that lookup.

## Test plan
- [x] 5 new unit tests in `SchemaUtilitiesTests` covering: schema literal from table properties, serde properties, table-over-serde precedence, `dali.row.schema` fallback with nullable conversion, and null return when empty
- [x] Full `coral-schema` test suite passes (pre-existing JDO failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)