### PR TITLE
[Coral-Spark] Rewrite VARBINARY to BINARY in SparkSqlRewriter

### DIFF
--- a/coral-spark/src/main/java/com/linkedin/coral/spark/SparkSqlRewriter.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/SparkSqlRewriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2018-2026 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -89,6 +89,10 @@ public class SparkSqlRewriter extends SqlShuttle {
           final SqlBasicTypeNameSpec stringTypeName = new SqlBasicTypeNameSpec("STRING", SqlTypeName.VARCHAR, -1,
               basicTypeNameSpec.getScale(), basicTypeNameSpec.getCharSetName(), parserPos);
           return new SqlDataTypeSpec(stringTypeName, type.getTimeZone(), parserPos);
+        case "VARBINARY":
+          final SqlBasicTypeNameSpec binaryTypeName =
+              new SqlBasicTypeNameSpec(SqlTypeName.BINARY, -1, -1, basicTypeNameSpec.getCharSetName(), parserPos);
+          return new SqlDataTypeSpec(binaryTypeName, type.getTimeZone(), parserPos);
         default:
           return type;
       }

--- a/coral-spark/src/main/java/com/linkedin/coral/spark/SparkSqlRewriter.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/SparkSqlRewriter.java
@@ -89,6 +89,10 @@ public class SparkSqlRewriter extends SqlShuttle {
           final SqlBasicTypeNameSpec stringTypeName = new SqlBasicTypeNameSpec("STRING", SqlTypeName.VARCHAR, -1,
               basicTypeNameSpec.getScale(), basicTypeNameSpec.getCharSetName(), parserPos);
           return new SqlDataTypeSpec(stringTypeName, type.getTimeZone(), parserPos);
+        case "VARBINARY":
+          final SqlBasicTypeNameSpec binaryTypeName =
+              new SqlBasicTypeNameSpec(SqlTypeName.BINARY, -1, -1, basicTypeNameSpec.getCharSetName(), parserPos);
+          return new SqlDataTypeSpec(binaryTypeName, type.getTimeZone(), parserPos);
         default:
           return type;
       }

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -412,6 +412,16 @@ public class CoralSparkTest {
   }
 
   @Test
+  public void testBase64OnStringProducesBinaryCast() {
+    // base64() expects BINARY input, so Calcite inserts an implicit CAST(... AS VARBINARY)
+    // when the argument is a STRING. The SparkSqlRewriter must rewrite VARBINARY to BINARY
+    // since Spark's parser does not recognize VARBINARY.
+    RelNode relNode = TestUtils.toRelNode(String.join("\n", "", "SELECT base64(b)", "FROM complex"));
+    String targetSql = "SELECT base64(CAST(complex.b AS BINARY))\n" + "FROM default.complex complex";
+    assertEquals(createCoralSpark(relNode).getSparkSql(), targetSql);
+  }
+
+  @Test
   public void testInterval() {
     RelNode relNode = TestUtils.toRelNode("SELECT CAST('2021-08-31' AS DATE) + INTERVAL '7' DAY FROM default.complex");
     String targetSql = "SELECT (CAST('2021-08-31' AS DATE) + INTERVAL '7' DAY)\n" + "FROM default.complex complex";


### PR DESCRIPTION
### What changes are proposed in this pull request, and why are they necessary?
Calcite's type system uses VARBINARY for binary data, but Spark's SQL parser does not recognize VARBINARY as a valid cast target — it uses BINARY instead. When Hive views call base64() on string columns, Calcite inserts an implicit CAST(... AS VARBINARY) which produces unparseable Spark SQL, causing CoralSpark translation failures and downstream function registry poisoning via the DaliSpark Hive fallback path.

This follows the same pattern already used by TrinoSqlRewriter, which rewrites BINARY/VARBINARY to Trino's VARBINARY in its convertTypeSpec method. Here we do the equivalent for Spark: rewrite VARBINARY to BINARY in SparkSqlRewriter.visit(SqlDataTypeSpec).

### How was this patch tested?
- Verified existing test cases pass and added a new test case.
- Also, ran the regression DAGs and found zero regressions. The baseline version tested against was 2.3.9