### PR TITLE
[Coral-Schema] Fix NoSuchMethodError for DECIMAL columns: replace Jackson1Utils with String.valueOf

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvro.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvro.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
-import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 
 import org.apache.avro.Schema;
 import org.apache.hadoop.hive.serde2.avro.AvroSerDe;
@@ -21,8 +20,6 @@ import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.UnionTypeInfo;
-import org.codehaus.jackson.node.JsonNodeFactory;
-
 import com.linkedin.coral.com.google.common.base.Preconditions;
 
 import static com.linkedin.coral.schema.avro.AvroSerdeUtils.*;
@@ -257,13 +254,12 @@ class MergeHiveSchemaWithAvro extends HiveSchemaWithPartnerVisitor<Schema, Schem
 
       case DECIMAL:
         DecimalTypeInfo dti = (DecimalTypeInfo) primitive;
-        JsonNodeFactory factory = JsonNodeFactory.instance;
         Schema decimalSchema = Schema.create(Schema.Type.BYTES);
         decimalSchema.addProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE, AvroSerDe.DECIMAL_TYPE_NAME);
         AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_PRECISION,
-            Jackson1Utils.toJsonString(factory.numberNode(dti.getPrecision())), false);
+            String.valueOf(dti.getPrecision()), false);
         AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_SCALE,
-            Jackson1Utils.toJsonString(factory.numberNode(dti.getScale())), false);
+            String.valueOf(dti.getScale()), false);
 
         return decimalSchema;
 

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvro.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvro.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2021-2026 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -20,6 +20,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.UnionTypeInfo;
+
 import com.linkedin.coral.com.google.common.base.Preconditions;
 
 import static com.linkedin.coral.schema.avro.AvroSerdeUtils.*;

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
@@ -12,7 +12,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
-import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 
 import org.apache.avro.Schema;
 import org.apache.calcite.rel.type.DynamicRecordType;
@@ -25,8 +24,6 @@ import org.apache.calcite.sql.type.MapSqlType;
 import org.apache.calcite.sql.type.MultisetSqlType;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.hadoop.hive.serde2.avro.AvroSerDe;
-import org.codehaus.jackson.node.JsonNodeFactory;
-
 import com.linkedin.coral.com.google.common.base.Preconditions;
 
 
@@ -120,13 +117,12 @@ class RelDataTypeToAvroType {
         schema.addProp("logicalType", "date");
         return schema;
       case DECIMAL:
-        JsonNodeFactory factory = JsonNodeFactory.instance;
         Schema decimalSchema = Schema.create(Schema.Type.BYTES);
         decimalSchema.addProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE, AvroSerDe.DECIMAL_TYPE_NAME);
         AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_PRECISION,
-            Jackson1Utils.toJsonString(factory.numberNode(relDataType.getPrecision())), false);
+            String.valueOf(relDataType.getPrecision()), false);
         AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_SCALE,
-            Jackson1Utils.toJsonString(factory.numberNode(relDataType.getScale())), false);
+            String.valueOf(relDataType.getScale()), false);
         return decimalSchema;
       default:
         throw new UnsupportedOperationException(relDataType.getSqlTypeName() + " is not supported.");

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2024 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2026 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -24,6 +24,7 @@ import org.apache.calcite.sql.type.MapSqlType;
 import org.apache.calcite.sql.type.MultisetSqlType;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.hadoop.hive.serde2.avro.AvroSerDe;
+
 import com.linkedin.coral.com.google.common.base.Preconditions;
 
 

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/TypeInfoToAvroSchemaConverter.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/TypeInfoToAvroSchemaConverter.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
-import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 
 import org.apache.avro.Schema;
 import org.apache.commons.lang3.StringUtils;
@@ -24,8 +23,6 @@ import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.UnionTypeInfo;
-import org.codehaus.jackson.node.JsonNodeFactory;
-
 import com.linkedin.coral.com.google.common.collect.Lists;
 
 
@@ -198,13 +195,12 @@ public class TypeInfoToAvroSchemaConverter {
 
       case DECIMAL:
         DecimalTypeInfo dti = (DecimalTypeInfo) primitiveTypeInfo;
-        JsonNodeFactory factory = JsonNodeFactory.instance;
         schema = Schema.create(Schema.Type.BYTES);
         schema.addProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE, AvroSerDe.DECIMAL_TYPE_NAME);
         AvroCompatibilityHelper.setSchemaPropFromJsonString(schema, AvroSerDe.AVRO_PROP_PRECISION,
-            Jackson1Utils.toJsonString(factory.numberNode(dti.getPrecision())), false);
+            String.valueOf(dti.getPrecision()), false);
         AvroCompatibilityHelper.setSchemaPropFromJsonString(schema, AvroSerDe.AVRO_PROP_SCALE,
-            Jackson1Utils.toJsonString(factory.numberNode(dti.getScale())), false);
+            String.valueOf(dti.getScale()), false);
         break;
 
       case FLOAT:

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/TypeInfoToAvroSchemaConverter.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/TypeInfoToAvroSchemaConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2019-2026 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -23,6 +23,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.UnionTypeInfo;
+
 import com.linkedin.coral.com.google.common.collect.Lists;
 
 

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2020-2026 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -206,21 +206,22 @@ public class MergeHiveSchemaWithAvroTests {
 
     Schema dateSchema = Schema.create(Schema.Type.INT);
     dateSchema.addProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE, AvroSerDe.DATE_TYPE_NAME);
-
     Schema timestampSchema = Schema.create(Schema.Type.LONG);
     timestampSchema.addProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE, AvroSerDe.TIMESTAMP_TYPE_NAME);
-
     Schema decimalSchema = Schema.create(Schema.Type.BYTES);
     decimalSchema.addProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE, AvroSerDe.DECIMAL_TYPE_NAME);
     AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_PRECISION,
         String.valueOf(4), false);
     AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_SCALE,
         String.valueOf(2), false);
+    assertSchema(struct("r1", optional("fa", dateSchema), optional("fb", timestampSchema), optional("fc", decimalSchema)),
+        merged);
 
-    Schema expected =
-        struct("r1", optional("fa", dateSchema), optional("fb", timestampSchema), optional("fc", decimalSchema));
-
-    assertSchema(expected, merged);
+    // Additionally assert precision/scale are JSON integers, not quoted strings.
+    // "precision" : 4  is what Jackson IntNode serialization produces; "precision" : "4" (quoted) would not match.
+    String json = merged.toString(true);
+    assertTrue(json.contains("\"precision\" : 4"), json);
+    assertTrue(json.contains("\"scale\" : 2"), json);
   }
 
   @Test

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
-import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 
 import org.apache.avro.Schema;
 import org.apache.commons.collections.map.HashedMap;
@@ -18,7 +17,6 @@ import org.apache.hadoop.hive.serde2.avro.AvroSerDe;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
-import org.codehaus.jackson.node.IntNode;
 import org.testng.annotations.Test;
 
 import com.linkedin.coral.com.google.common.base.Preconditions;
@@ -215,14 +213,34 @@ public class MergeHiveSchemaWithAvroTests {
     Schema decimalSchema = Schema.create(Schema.Type.BYTES);
     decimalSchema.addProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE, AvroSerDe.DECIMAL_TYPE_NAME);
     AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_PRECISION,
-        Jackson1Utils.toJsonString(new IntNode(4)), false);
+        String.valueOf(4), false);
     AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_SCALE,
-        Jackson1Utils.toJsonString(new IntNode(2)), false);
+        String.valueOf(2), false);
 
     Schema expected =
         struct("r1", optional("fa", dateSchema), optional("fb", timestampSchema), optional("fc", decimalSchema));
 
     assertSchema(expected, merged);
+  }
+
+  @Test
+  public void shouldRecoverLogicalTypeDecimalZeroScale() {
+    String hive = "struct<fa:decimal(10,0)>";
+    Schema avro = struct("r1", optional("fa", Schema.Type.BYTES));
+    // Assert precision/scale are JSON integers, not quoted strings.
+    // "precision" : 10 matches what Jackson IntNode serialization produces; "precision" : "10" would not.
+    String json = merge(hive, avro).toString(true);
+    assertTrue(json.contains("\"precision\" : 10"), json);
+    assertTrue(json.contains("\"scale\" : 0"), json);
+  }
+
+  @Test
+  public void shouldRecoverLogicalTypeDecimalMaxHivePrecision() {
+    String hive = "struct<fa:decimal(38,10)>";
+    Schema avro = struct("r1", optional("fa", Schema.Type.BYTES));
+    String json = merge(hive, avro).toString(true);
+    assertTrue(json.contains("\"precision\" : 38"), json);
+    assertTrue(json.contains("\"scale\" : 10"), json);
   }
 
   @Test

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
@@ -238,11 +238,11 @@ public class MergeHiveSchemaWithAvroTests {
         String.valueOf(0), false);
     assertSchema(struct("r1", optional("fa", decimalSchema)), merged);
 
-    // Additionally verify precision/scale are JSON integers, not quoted strings.
-    // "precision" : 10  is what Jackson IntNode serialization produces; "precision" : "10" would not match.
-    String json = merged.toString(true);
-    assertTrue(json.contains("\"precision\" : 10"), json);
-    assertTrue(json.contains("\"scale\" : 0"), json);
+    // Verify precision/scale are JSON integers, not quoted strings, by comparing against a hard-coded expected.
+    // "precision" : 10  is what Jackson IntNode serialization produces; "precision" : "10" (quoted) would not match.
+    String expected = "{\n  \"type\" : \"bytes\",\n  \"logicalType\" : \"decimal\",\n"
+        + "  \"precision\" : 10,\n  \"scale\" : 0\n}";
+    assertEquals(merged.getField("fa").schema().getTypes().get(1).toString(true), expected);
   }
 
   @Test
@@ -259,9 +259,9 @@ public class MergeHiveSchemaWithAvroTests {
         String.valueOf(10), false);
     assertSchema(struct("r1", optional("fa", decimalSchema)), merged);
 
-    String json = merged.toString(true);
-    assertTrue(json.contains("\"precision\" : 38"), json);
-    assertTrue(json.contains("\"scale\" : 10"), json);
+    String expected = "{\n  \"type\" : \"bytes\",\n  \"logicalType\" : \"decimal\",\n"
+        + "  \"precision\" : 38,\n  \"scale\" : 10\n}";
+    assertEquals(merged.getField("fa").schema().getTypes().get(1).toString(true), expected);
   }
 
   @Test

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
@@ -214,15 +214,9 @@ public class MergeHiveSchemaWithAvroTests {
         false);
     AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_SCALE, String.valueOf(2),
         false);
-    assertSchema(
-        struct("r1", optional("fa", dateSchema), optional("fb", timestampSchema), optional("fc", decimalSchema)),
-        merged);
-
-    // Additionally assert precision/scale are JSON integers, not quoted strings.
-    // "precision" : 4  is what Jackson IntNode serialization produces; "precision" : "4" (quoted) would not match.
-    String json = merged.toString(true);
-    assertTrue(json.contains("\"precision\" : 4"), json);
-    assertTrue(json.contains("\"scale\" : 2"), json);
+    Schema expected =
+        struct("r1", optional("fa", dateSchema), optional("fb", timestampSchema), optional("fc", decimalSchema));
+    assertSchema(expected, merged);
   }
 
   @Test

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
@@ -236,13 +236,8 @@ public class MergeHiveSchemaWithAvroTests {
         String.valueOf(10), false);
     AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_SCALE,
         String.valueOf(0), false);
-    assertSchema(struct("r1", optional("fa", decimalSchema)), merged);
-
-    // Verify precision/scale are JSON integers, not quoted strings, by comparing against a hard-coded expected.
-    // "precision" : 10  is what Jackson IntNode serialization produces; "precision" : "10" (quoted) would not match.
-    String expected = "{\n  \"type\" : \"bytes\",\n  \"logicalType\" : \"decimal\",\n"
-        + "  \"precision\" : 10,\n  \"scale\" : 0\n}";
-    assertEquals(merged.getField("fa").schema().getTypes().get(1).toString(true), expected);
+    Schema expected = struct("r1", optional("fa", decimalSchema));
+    assertSchema(expected, merged);
   }
 
   @Test
@@ -257,11 +252,8 @@ public class MergeHiveSchemaWithAvroTests {
         String.valueOf(38), false);
     AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_SCALE,
         String.valueOf(10), false);
-    assertSchema(struct("r1", optional("fa", decimalSchema)), merged);
-
-    String expected = "{\n  \"type\" : \"bytes\",\n  \"logicalType\" : \"decimal\",\n"
-        + "  \"precision\" : 38,\n  \"scale\" : 10\n}";
-    assertEquals(merged.getField("fa").schema().getTypes().get(1).toString(true), expected);
+    Schema expected = struct("r1", optional("fa", decimalSchema));
+    assertSchema(expected, merged);
   }
 
   @Test

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
@@ -210,10 +210,8 @@ public class MergeHiveSchemaWithAvroTests {
     timestampSchema.addProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE, AvroSerDe.TIMESTAMP_TYPE_NAME);
     Schema decimalSchema = Schema.create(Schema.Type.BYTES);
     decimalSchema.addProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE, AvroSerDe.DECIMAL_TYPE_NAME);
-    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_PRECISION, String.valueOf(4),
-        false);
-    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_SCALE, String.valueOf(2),
-        false);
+    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_PRECISION, "4", false);
+    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_SCALE, "2", false);
     Schema expected =
         struct("r1", optional("fa", dateSchema), optional("fb", timestampSchema), optional("fc", decimalSchema));
     assertSchema(expected, merged);
@@ -227,10 +225,8 @@ public class MergeHiveSchemaWithAvroTests {
 
     Schema decimalSchema = Schema.create(Schema.Type.BYTES);
     decimalSchema.addProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE, AvroSerDe.DECIMAL_TYPE_NAME);
-    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_PRECISION,
-        String.valueOf(10), false);
-    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_SCALE, String.valueOf(0),
-        false);
+    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_PRECISION, "10", false);
+    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_SCALE, "0", false);
     Schema expected = struct("r1", optional("fa", decimalSchema));
     assertSchema(expected, merged);
   }
@@ -243,10 +239,8 @@ public class MergeHiveSchemaWithAvroTests {
 
     Schema decimalSchema = Schema.create(Schema.Type.BYTES);
     decimalSchema.addProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE, AvroSerDe.DECIMAL_TYPE_NAME);
-    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_PRECISION,
-        String.valueOf(38), false);
-    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_SCALE, String.valueOf(10),
-        false);
+    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_PRECISION, "38", false);
+    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_SCALE, "10", false);
     Schema expected = struct("r1", optional("fa", decimalSchema));
     assertSchema(expected, merged);
   }

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
@@ -228,9 +228,19 @@ public class MergeHiveSchemaWithAvroTests {
   public void shouldRecoverLogicalTypeDecimalZeroScale() {
     String hive = "struct<fa:decimal(10,0)>";
     Schema avro = struct("r1", optional("fa", Schema.Type.BYTES));
-    // Assert precision/scale are JSON integers, not quoted strings.
-    // "precision" : 10 matches what Jackson IntNode serialization produces; "precision" : "10" would not.
-    String json = merge(hive, avro).toString(true);
+    Schema merged = merge(hive, avro);
+
+    Schema decimalSchema = Schema.create(Schema.Type.BYTES);
+    decimalSchema.addProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE, AvroSerDe.DECIMAL_TYPE_NAME);
+    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_PRECISION,
+        String.valueOf(10), false);
+    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_SCALE,
+        String.valueOf(0), false);
+    assertSchema(struct("r1", optional("fa", decimalSchema)), merged);
+
+    // Additionally verify precision/scale are JSON integers, not quoted strings.
+    // "precision" : 10  is what Jackson IntNode serialization produces; "precision" : "10" would not match.
+    String json = merged.toString(true);
     assertTrue(json.contains("\"precision\" : 10"), json);
     assertTrue(json.contains("\"scale\" : 0"), json);
   }
@@ -239,7 +249,17 @@ public class MergeHiveSchemaWithAvroTests {
   public void shouldRecoverLogicalTypeDecimalMaxHivePrecision() {
     String hive = "struct<fa:decimal(38,10)>";
     Schema avro = struct("r1", optional("fa", Schema.Type.BYTES));
-    String json = merge(hive, avro).toString(true);
+    Schema merged = merge(hive, avro);
+
+    Schema decimalSchema = Schema.create(Schema.Type.BYTES);
+    decimalSchema.addProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE, AvroSerDe.DECIMAL_TYPE_NAME);
+    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_PRECISION,
+        String.valueOf(38), false);
+    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_SCALE,
+        String.valueOf(10), false);
+    assertSchema(struct("r1", optional("fa", decimalSchema)), merged);
+
+    String json = merged.toString(true);
     assertTrue(json.contains("\"precision\" : 38"), json);
     assertTrue(json.contains("\"scale\" : 10"), json);
   }

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeHiveSchemaWithAvroTests.java
@@ -210,11 +210,12 @@ public class MergeHiveSchemaWithAvroTests {
     timestampSchema.addProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE, AvroSerDe.TIMESTAMP_TYPE_NAME);
     Schema decimalSchema = Schema.create(Schema.Type.BYTES);
     decimalSchema.addProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE, AvroSerDe.DECIMAL_TYPE_NAME);
-    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_PRECISION,
-        String.valueOf(4), false);
-    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_SCALE,
-        String.valueOf(2), false);
-    assertSchema(struct("r1", optional("fa", dateSchema), optional("fb", timestampSchema), optional("fc", decimalSchema)),
+    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_PRECISION, String.valueOf(4),
+        false);
+    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_SCALE, String.valueOf(2),
+        false);
+    assertSchema(
+        struct("r1", optional("fa", dateSchema), optional("fb", timestampSchema), optional("fc", decimalSchema)),
         merged);
 
     // Additionally assert precision/scale are JSON integers, not quoted strings.
@@ -234,8 +235,8 @@ public class MergeHiveSchemaWithAvroTests {
     decimalSchema.addProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE, AvroSerDe.DECIMAL_TYPE_NAME);
     AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_PRECISION,
         String.valueOf(10), false);
-    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_SCALE,
-        String.valueOf(0), false);
+    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_SCALE, String.valueOf(0),
+        false);
     Schema expected = struct("r1", optional("fa", decimalSchema));
     assertSchema(expected, merged);
   }
@@ -250,8 +251,8 @@ public class MergeHiveSchemaWithAvroTests {
     decimalSchema.addProp(AvroSerDe.AVRO_PROP_LOGICAL_TYPE, AvroSerDe.DECIMAL_TYPE_NAME);
     AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_PRECISION,
         String.valueOf(38), false);
-    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_SCALE,
-        String.valueOf(10), false);
+    AvroCompatibilityHelper.setSchemaPropFromJsonString(decimalSchema, AvroSerDe.AVRO_PROP_SCALE, String.valueOf(10),
+        false);
     Schema expected = struct("r1", optional("fa", decimalSchema));
     assertSchema(expected, merged);
   }

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroTypeTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroTypeTests.java
@@ -91,4 +91,17 @@ public class RelDataTypeToAvroTypeTests {
     Assert.assertEquals(actualAvroType.toString(true),
         TestUtils.loadSchema("rel2avro-testDateTypeField-expected.avsc"));
   }
+
+  @Test
+  public void testDecimalTypeField() {
+    String viewSql = "CREATE VIEW v AS SELECT * FROM basedecimal";
+
+    TestUtils.executeCreateViewQuery("default", "v", viewSql);
+    RelNode relNode = hiveToRelConverter.convertView("default", "v");
+    Schema actualAvroType =
+        RelDataTypeToAvroType.relDataTypeToAvroTypeNonNullable(relNode.getRowType(), "decimalTypeField");
+
+    Assert.assertEquals(actualAvroType.toString(true),
+        TestUtils.loadSchema("rel2avro-testDecimalTypeField-expected.avsc"));
+  }
 }

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroTypeTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroTypeTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2024 LinkedIn Corporation. All rights reserved.
+ * Copyright 2020-2026 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TypeInfoToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TypeInfoToAvroSchemaConverterTests.java
@@ -20,8 +20,8 @@ public class TypeInfoToAvroSchemaConverterTests {
     // Hard-coded expected matches what Jackson IntNode serialization produces:
     // Jackson1Utils.toJsonString(factory.numberNode(N)) == String.valueOf(N),
     // and Avro's toString(true) renders integer props as  "key" : N  (no quotes around N).
-    String expected = "{\n  \"type\" : \"bytes\",\n  \"logicalType\" : \"decimal\",\n"
-        + "  \"precision\" : 10,\n  \"scale\" : 5\n}";
+    String expected =
+        "{\n  \"type\" : \"bytes\",\n  \"logicalType\" : \"decimal\",\n" + "  \"precision\" : 10,\n  \"scale\" : 5\n}";
     Assert.assertEquals(actual.toString(true), expected);
   }
 
@@ -29,8 +29,8 @@ public class TypeInfoToAvroSchemaConverterTests {
   public void shouldConvertDecimalWithZeroScale() {
     TypeInfoToAvroSchemaConverter converter = new TypeInfoToAvroSchemaConverter("ns", false);
     Schema actual = converter.convertTypeInfoToAvroSchema(TypeInfoFactory.getDecimalTypeInfo(10, 0), "ns", "Test");
-    String expected = "{\n  \"type\" : \"bytes\",\n  \"logicalType\" : \"decimal\",\n"
-        + "  \"precision\" : 10,\n  \"scale\" : 0\n}";
+    String expected =
+        "{\n  \"type\" : \"bytes\",\n  \"logicalType\" : \"decimal\",\n" + "  \"precision\" : 10,\n  \"scale\" : 0\n}";
     Assert.assertEquals(actual.toString(true), expected);
   }
 
@@ -38,8 +38,8 @@ public class TypeInfoToAvroSchemaConverterTests {
   public void shouldConvertDecimalWithMaxHivePrecision() {
     TypeInfoToAvroSchemaConverter converter = new TypeInfoToAvroSchemaConverter("ns", false);
     Schema actual = converter.convertTypeInfoToAvroSchema(TypeInfoFactory.getDecimalTypeInfo(38, 10), "ns", "Test");
-    String expected = "{\n  \"type\" : \"bytes\",\n  \"logicalType\" : \"decimal\",\n"
-        + "  \"precision\" : 38,\n  \"scale\" : 10\n}";
+    String expected =
+        "{\n  \"type\" : \"bytes\",\n  \"logicalType\" : \"decimal\",\n" + "  \"precision\" : 38,\n  \"scale\" : 10\n}";
     Assert.assertEquals(actual.toString(true), expected);
   }
 }

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TypeInfoToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TypeInfoToAvroSchemaConverterTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 LinkedIn Corporation. All rights reserved.
+ * Copyright 2024-2026 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -19,8 +19,7 @@ public class TypeInfoToAvroSchemaConverterTests {
   // and Avro's toString(true) renders integer props as  "key" : N  (no quotes around N).
   private static void assertDecimalProps(Schema schema, int expectedPrecision, int expectedScale) {
     String json = schema.toString(true);
-    Assert.assertTrue(json.contains("\"logicalType\" : \"decimal\""),
-        "Expected logicalType decimal in: " + json);
+    Assert.assertTrue(json.contains("\"logicalType\" : \"decimal\""), "Expected logicalType decimal in: " + json);
     Assert.assertTrue(json.contains("\"precision\" : " + expectedPrecision),
         "Expected integer precision " + expectedPrecision + " in: " + json);
     Assert.assertTrue(json.contains("\"scale\" : " + expectedScale),
@@ -30,8 +29,7 @@ public class TypeInfoToAvroSchemaConverterTests {
   @Test
   public void shouldConvertDecimalWithTypicalValues() {
     TypeInfoToAvroSchemaConverter converter = new TypeInfoToAvroSchemaConverter("ns", false);
-    Schema actual = converter.convertTypeInfoToAvroSchema(
-        TypeInfoFactory.getDecimalTypeInfo(10, 5), "ns", "Test");
+    Schema actual = converter.convertTypeInfoToAvroSchema(TypeInfoFactory.getDecimalTypeInfo(10, 5), "ns", "Test");
     Assert.assertEquals(actual.getType(), Schema.Type.BYTES);
     assertDecimalProps(actual, 10, 5);
   }
@@ -39,8 +37,7 @@ public class TypeInfoToAvroSchemaConverterTests {
   @Test
   public void shouldConvertDecimalWithZeroScale() {
     TypeInfoToAvroSchemaConverter converter = new TypeInfoToAvroSchemaConverter("ns", false);
-    Schema actual = converter.convertTypeInfoToAvroSchema(
-        TypeInfoFactory.getDecimalTypeInfo(10, 0), "ns", "Test");
+    Schema actual = converter.convertTypeInfoToAvroSchema(TypeInfoFactory.getDecimalTypeInfo(10, 0), "ns", "Test");
     Assert.assertEquals(actual.getType(), Schema.Type.BYTES);
     assertDecimalProps(actual, 10, 0);
   }
@@ -48,8 +45,7 @@ public class TypeInfoToAvroSchemaConverterTests {
   @Test
   public void shouldConvertDecimalWithMaxHivePrecision() {
     TypeInfoToAvroSchemaConverter converter = new TypeInfoToAvroSchemaConverter("ns", false);
-    Schema actual = converter.convertTypeInfoToAvroSchema(
-        TypeInfoFactory.getDecimalTypeInfo(38, 10), "ns", "Test");
+    Schema actual = converter.convertTypeInfoToAvroSchema(TypeInfoFactory.getDecimalTypeInfo(38, 10), "ns", "Test");
     Assert.assertEquals(actual.getType(), Schema.Type.BYTES);
     assertDecimalProps(actual, 38, 10);
   }

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TypeInfoToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TypeInfoToAvroSchemaConverterTests.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2024 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.schema.avro;
+
+import org.apache.avro.Schema;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TypeInfoToAvroSchemaConverterTests {
+
+  // Asserts that precision and scale appear as JSON integers (not quoted strings) in the schema.
+  // The expected strings match what Jackson IntNode serialization produces:
+  //   Jackson1Utils.toJsonString(factory.numberNode(N)) == String.valueOf(N),
+  // and Avro's toString(true) renders integer props as  "key" : N  (no quotes around N).
+  private static void assertDecimalProps(Schema schema, int expectedPrecision, int expectedScale) {
+    String json = schema.toString(true);
+    Assert.assertTrue(json.contains("\"logicalType\" : \"decimal\""),
+        "Expected logicalType decimal in: " + json);
+    Assert.assertTrue(json.contains("\"precision\" : " + expectedPrecision),
+        "Expected integer precision " + expectedPrecision + " in: " + json);
+    Assert.assertTrue(json.contains("\"scale\" : " + expectedScale),
+        "Expected integer scale " + expectedScale + " in: " + json);
+  }
+
+  @Test
+  public void shouldConvertDecimalWithTypicalValues() {
+    TypeInfoToAvroSchemaConverter converter = new TypeInfoToAvroSchemaConverter("ns", false);
+    Schema actual = converter.convertTypeInfoToAvroSchema(
+        TypeInfoFactory.getDecimalTypeInfo(10, 5), "ns", "Test");
+    Assert.assertEquals(actual.getType(), Schema.Type.BYTES);
+    assertDecimalProps(actual, 10, 5);
+  }
+
+  @Test
+  public void shouldConvertDecimalWithZeroScale() {
+    TypeInfoToAvroSchemaConverter converter = new TypeInfoToAvroSchemaConverter("ns", false);
+    Schema actual = converter.convertTypeInfoToAvroSchema(
+        TypeInfoFactory.getDecimalTypeInfo(10, 0), "ns", "Test");
+    Assert.assertEquals(actual.getType(), Schema.Type.BYTES);
+    assertDecimalProps(actual, 10, 0);
+  }
+
+  @Test
+  public void shouldConvertDecimalWithMaxHivePrecision() {
+    TypeInfoToAvroSchemaConverter converter = new TypeInfoToAvroSchemaConverter("ns", false);
+    Schema actual = converter.convertTypeInfoToAvroSchema(
+        TypeInfoFactory.getDecimalTypeInfo(38, 10), "ns", "Test");
+    Assert.assertEquals(actual.getType(), Schema.Type.BYTES);
+    assertDecimalProps(actual, 38, 10);
+  }
+}

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TypeInfoToAvroSchemaConverterTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/TypeInfoToAvroSchemaConverterTests.java
@@ -13,40 +13,33 @@ import org.testng.annotations.Test;
 
 public class TypeInfoToAvroSchemaConverterTests {
 
-  // Asserts that precision and scale appear as JSON integers (not quoted strings) in the schema.
-  // The expected strings match what Jackson IntNode serialization produces:
-  //   Jackson1Utils.toJsonString(factory.numberNode(N)) == String.valueOf(N),
-  // and Avro's toString(true) renders integer props as  "key" : N  (no quotes around N).
-  private static void assertDecimalProps(Schema schema, int expectedPrecision, int expectedScale) {
-    String json = schema.toString(true);
-    Assert.assertTrue(json.contains("\"logicalType\" : \"decimal\""), "Expected logicalType decimal in: " + json);
-    Assert.assertTrue(json.contains("\"precision\" : " + expectedPrecision),
-        "Expected integer precision " + expectedPrecision + " in: " + json);
-    Assert.assertTrue(json.contains("\"scale\" : " + expectedScale),
-        "Expected integer scale " + expectedScale + " in: " + json);
-  }
-
   @Test
   public void shouldConvertDecimalWithTypicalValues() {
     TypeInfoToAvroSchemaConverter converter = new TypeInfoToAvroSchemaConverter("ns", false);
     Schema actual = converter.convertTypeInfoToAvroSchema(TypeInfoFactory.getDecimalTypeInfo(10, 5), "ns", "Test");
-    Assert.assertEquals(actual.getType(), Schema.Type.BYTES);
-    assertDecimalProps(actual, 10, 5);
+    // Hard-coded expected matches what Jackson IntNode serialization produces:
+    // Jackson1Utils.toJsonString(factory.numberNode(N)) == String.valueOf(N),
+    // and Avro's toString(true) renders integer props as  "key" : N  (no quotes around N).
+    String expected = "{\n  \"type\" : \"bytes\",\n  \"logicalType\" : \"decimal\",\n"
+        + "  \"precision\" : 10,\n  \"scale\" : 5\n}";
+    Assert.assertEquals(actual.toString(true), expected);
   }
 
   @Test
   public void shouldConvertDecimalWithZeroScale() {
     TypeInfoToAvroSchemaConverter converter = new TypeInfoToAvroSchemaConverter("ns", false);
     Schema actual = converter.convertTypeInfoToAvroSchema(TypeInfoFactory.getDecimalTypeInfo(10, 0), "ns", "Test");
-    Assert.assertEquals(actual.getType(), Schema.Type.BYTES);
-    assertDecimalProps(actual, 10, 0);
+    String expected = "{\n  \"type\" : \"bytes\",\n  \"logicalType\" : \"decimal\",\n"
+        + "  \"precision\" : 10,\n  \"scale\" : 0\n}";
+    Assert.assertEquals(actual.toString(true), expected);
   }
 
   @Test
   public void shouldConvertDecimalWithMaxHivePrecision() {
     TypeInfoToAvroSchemaConverter converter = new TypeInfoToAvroSchemaConverter("ns", false);
     Schema actual = converter.convertTypeInfoToAvroSchema(TypeInfoFactory.getDecimalTypeInfo(38, 10), "ns", "Test");
-    Assert.assertEquals(actual.getType(), Schema.Type.BYTES);
-    assertDecimalProps(actual, 38, 10);
+    String expected = "{\n  \"type\" : \"bytes\",\n  \"logicalType\" : \"decimal\",\n"
+        + "  \"precision\" : 38,\n  \"scale\" : 10\n}";
+    Assert.assertEquals(actual.toString(true), expected);
   }
 }

--- a/coral-schema/src/test/resources/rel2avro-testDecimalTypeField-expected.avsc
+++ b/coral-schema/src/test/resources/rel2avro-testDecimalTypeField-expected.avsc
@@ -1,0 +1,15 @@
+{
+  "type" : "record",
+  "name" : "decimalTypeField",
+  "namespace" : "rel_avro",
+  "fields" : [ {
+    "name" : "decimal_col",
+    "type" : [ "null", {
+      "type" : "bytes",
+      "logicalType" : "decimal",
+      "precision" : 2,
+      "scale" : 1
+    } ],
+    "default" : null
+  } ]
+}


### PR DESCRIPTION
### What changes are proposed in this pull request, and why are they necessary?
In `coral-schema`, three classes handle the `DECIMAL` type by constructing a Jackson 1.x `JsonNode` via `JsonNodeFactory` and passing it to `avroutil1`'s `Jackson1Utils.toJsonString`:
  - `MergeHiveSchemaWithAvro`
  - `RelDataTypeToAvroType`
  - `TypeInfoToAvroSchemaConverter`

When a downstream consumer has its own `avroutil1` jar on the classpath, the classloader resolves `Jackson1Utils` from that jar — which only has `toJsonString(org.codehaus.jackson.JsonNode)`. If the `JsonNode` was created from a different (e.g. relocated) copy of Jackson 1, the signatures do not match and the JVM throws `NoSuchMethodError` at runtime.

The fix replaces `Jackson1Utils.toJsonString(factory.numberNode(int))` with `String.valueOf(int)`. Since precision and scale are primitive `int` values, `String.valueOf` produces the identical JSON integer string with no Jackson or `avroutil1` dependency. This removes all three affected `Jackson1Utils` and `JsonNodeFactory` imports.

### How was this patch tested?
- Extended `MergeHiveSchemaWithAvroTests` with two new DECIMAL cases: zero scale (`DECIMAL(10,0)`) and max Hive precision (`DECIMAL(38,10)`), in addition to the existing `DECIMAL(4,2)` case.
- Added `testDecimalTypeField` to `RelDataTypeToAvroTypeTests` using the existing `basedecimal` table (`DECIMAL(2,1)`), with a new expected schema resource file asserting that `precision` and `scale` are encoded as JSON integers.
- Added a new `TypeInfoToAvroSchemaConverterTests` class with three direct unit tests (no Hive metastore required): `DECIMAL(10,5)`, `DECIMAL(10,0)`, and `DECIMAL(38,10)`.
- All tests pass via `./gradlew :coral-schema:test`.
