### PR TITLE
Add isIcebergBacked() capability hook to CoralTable

### DIFF
--- a/coral-common/src/main/java/com/linkedin/coral/common/catalog/CoralTable.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/catalog/CoralTable.java
@@ -48,4 +48,15 @@ public interface CoralTable {
    * @return CoralDataType representing the table schema (typically a StructType)
    */
   CoralDataType getSchema();
+
+  /**
+   * Returns whether this table is backed by Iceberg.
+   * Used by schema converters to choose the Iceberg-aware merge path
+   * instead of the Hive merge path.
+   *
+   * @return true if the table is Iceberg-backed, false otherwise
+   */
+  default boolean isIcebergBacked() {
+    return false;
+  }
 }

--- a/coral-common/src/main/java/com/linkedin/coral/common/catalog/IcebergTable.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/catalog/IcebergTable.java
@@ -81,6 +81,11 @@ public class IcebergTable implements CoralTable {
     return table;
   }
 
+  @Override
+  public boolean isIcebergBacked() {
+    return true;
+  }
+
   /**
    * Returns the table schema in Coral type system.
    * Converts Iceberg schema to Coral types using IcebergToCoralTypeConverter.

--- a/coral-common/src/test/java/com/linkedin/coral/common/catalog/CoralTableIsIcebergBackedTest.java
+++ b/coral-common/src/test/java/com/linkedin/coral/common/catalog/CoralTableIsIcebergBackedTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2024-2026 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.common.catalog;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+import com.linkedin.coral.common.types.CoralDataType;
+
+import static org.testng.Assert.*;
+
+
+public class CoralTableIsIcebergBackedTest {
+
+  @Test
+  public void testDefaultIsIcebergBackedReturnsFalse() {
+    CoralTable table = new CoralTable() {
+      @Override
+      public String name() {
+        return "test.table";
+      }
+
+      @Override
+      public Map<String, String> properties() {
+        return Collections.emptyMap();
+      }
+
+      @Override
+      public TableType tableType() {
+        return TableType.TABLE;
+      }
+
+      @Override
+      public CoralDataType getSchema() {
+        return null;
+      }
+    };
+
+    assertFalse(table.isIcebergBacked());
+  }
+
+  @Test
+  public void testHiveTableIsNotIcebergBacked() {
+    org.apache.hadoop.hive.metastore.api.Table hiveTable = new org.apache.hadoop.hive.metastore.api.Table();
+    hiveTable.setDbName("db");
+    hiveTable.setTableName("tbl");
+    hiveTable.setTableType("MANAGED_TABLE");
+    hiveTable.setSd(new org.apache.hadoop.hive.metastore.api.StorageDescriptor());
+    hiveTable.getSd().setCols(Collections.emptyList());
+    hiveTable.setPartitionKeys(Collections.emptyList());
+
+    HiveTable table = new HiveTable(hiveTable);
+    assertFalse(table.isIcebergBacked());
+  }
+}


### PR DESCRIPTION
## Motivation
Schema converters need to distinguish Iceberg-backed tables from Hive tables to choose the correct merge path (Iceberg-aware `MergeCoralSchemaWithAvro` vs Hive-based `MergeHiveSchemaWithAvro`). Without a capability hook, callers would need `instanceof` checks, which break when Spark-side wrappers like `LiOpenHouseCoralTable` are introduced — those implement `CoralTable` directly and are not instances of `IcebergTable`.

## Summary
- Add `default boolean isIcebergBacked()` on `CoralTable` returning `false`
- Override in `IcebergTable` to return `true`
- `HiveTable` inherits the default (`false`)

## How this will be used
In future PRs, `SchemaUtilities.getAvroSchemaForTable(CoralTable, strictMode)` and `RelToAvroSchemaConverter.getTableScanSchema()` will use `coralTable.isIcebergBacked()` to route to the Iceberg-aware merge path. Spark-side wrappers like `LiOpenHouseCoralTable` will also override this to return `true`.

## Test plan
- [x] New `CoralTableIsIcebergBackedTest` verifying: default interface method returns `false`, `HiveTable` returns `false`
- [x] `coral-common` test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)