### PR TITLE
Add coral-benchmark module for cross-dialect translation testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Coral can be used as a library in other projects, or as a service. See instructi
 - **Coral-Spark-Plan** [WIP]: Converts Spark plan strings into an equivalent logical plan.
 - **Coral-Visualization**: Renders Coral SqlNode and RelNode trees to an image.
 - **Coral-Service**: Exposes Coral via REST APIs (see [Coral-as-a-Service](#Coral-as-a-Service) for more details).
+- **Coral-Benchmark** [WIP]: Cross-dialect translation correctness framework. Verifies translations via IR round-trip, target-engine EXPLAIN, and result-set comparison against real engines.
 
 ## Version Upgrades
 

--- a/coral-benchmark/build.gradle
+++ b/coral-benchmark/build.gradle
@@ -1,0 +1,5 @@
+apply plugin: 'java-library'
+
+dependencies {
+  api project(path: ':coral-common')
+}

--- a/coral-benchmark/coral-benchmark-spec.md
+++ b/coral-benchmark/coral-benchmark-spec.md
@@ -1,0 +1,281 @@
+# Coral Benchmark: Cross-Dialect Integration Testing Framework
+
+## 1. Purpose
+
+A new module (`coral-benchmark`) that tests Coral translations end-to-end: from any supported source dialect to any supported target dialect. The framework verifies both **syntactic correctness** (the translated query is valid in the target dialect) and **semantic correctness** (the translated query produces equivalent results on real engine execution).
+
+## 2. Design Principles
+
+- **Grounded in existing APIs.** The framework builds on `CoralCatalog`, `CoralTable`, and the Coral type system (`CoralDataType`, `CoralTypeKind`). It does not invent parallel abstractions for catalog or types.
+- **In-memory by default.** Tests run against an in-memory `CoralCatalog` implementation with no external metastore dependency.
+- **Dialect-agnostic core, dialect-specific plugins.** The core framework knows nothing about Hive, Spark, or Trino. Each dialect contributes an implementation of a small SPI that the core orchestrates.
+- **Incremental verification levels.** Users choose the level of verification appropriate to their needs, from pure IR round-trip checks up to full result-set comparison on live engines.
+
+## 3. Core Concepts
+
+### 3.1 Catalog Setup
+
+Tests declare their table schemas using the Coral type system and register them in an in-memory catalog.
+
+**In-memory catalog.** A concrete `InMemoryCatalog implements CoralCatalog` that holds tables in a `Map<namespace, Map<tableName, CoralTable>>`. Provides a builder API for test ergonomics:
+
+```java
+InMemoryCatalog catalog = InMemoryCatalog.builder()
+    .createNamespace("db")
+    .addTable("db", "users", StructType.of(Arrays.asList(
+        StructField.of("id", PrimitiveType.of(CoralTypeKind.INT, true)),
+        StructField.of("name", PrimitiveType.of(CoralTypeKind.STRING, true)),
+        StructField.of("created", TimestampType.of(3, true)),
+        StructField.of("tags", ArrayType.of(PrimitiveType.of(CoralTypeKind.STRING, true), true))
+    ), true))
+    .addTable("db", "events", StructType.of(Arrays.asList(
+        StructField.of("user_id", PrimitiveType.of(CoralTypeKind.INT, true)),
+        StructField.of("event_type", PrimitiveType.of(CoralTypeKind.STRING, true)),
+        StructField.of("payload", MapType.of(
+            PrimitiveType.of(CoralTypeKind.STRING, true),
+            PrimitiveType.of(CoralTypeKind.STRING, true), true)),
+        StructField.of("ts", TimestampType.of(3, true))
+    ), true))
+    .build();
+```
+
+All column types are expressed through the existing Coral type hierarchy (`PrimitiveType`, `StructType`, `ArrayType`, `MapType`, `DecimalType`, `TimestampType`, etc.). No raw strings for types.
+
+### 3.2 Query Corpus
+
+Queries are plain SQL SELECT statements stored as individual `.sql` files organized by source dialect:
+
+```
+coral-benchmark/src/test/resources/
+  queries/
+    hive/
+      group_by_count.sql
+      join_with_filter.sql
+      nested_struct_access.sql
+    trino/
+      group_by_count.sql
+      ...
+    spark/
+      ...
+```
+
+Each file contains a single SELECT statement written in the source dialect's syntax. File names are descriptive of the query pattern being tested. The same logical query may appear under multiple dialect directories, written in each dialect's native syntax.
+
+### 3.3 Dialect SPI
+
+Each dialect plugs into the framework by implementing a single interface:
+
+```java
+public interface DialectPlugin {
+
+    /** Identifier for this dialect (e.g., HIVE, SPARK, TRINO). */
+    Dialect dialect();
+
+    /** Parse a SQL string in this dialect and produce a Coral IR RelNode. */
+    RelNode toRelNode(String sql, CoralCatalog catalog);
+
+    /** Convert a Coral IR RelNode to a SQL string in this dialect. */
+    String toDialectSql(RelNode relNode, CoralCatalog catalog);
+}
+```
+
+Implementations wrap the existing converters:
+- **Hive**: `HiveToRelConverter` / `CoralRelToSqlNodeConverter` (Hive dialect)
+- **Trino**: `TrinoToRelConverter` / `RelToTrinoConverter`
+- **Spark**: `HiveToRelConverter` (Spark SQL parses as Hive) / `CoralSpark`
+
+Plugins are discovered by `ServiceLoader` or registered explicitly at suite construction time.
+
+### 3.4 Engine SPI (for execution-level verification)
+
+For tests that go beyond syntactic validation and actually execute queries, each engine provides:
+
+```java
+public interface EnginePlugin {
+
+    /** Which dialect this engine natively executes. */
+    Dialect dialect();
+
+    /** Start the engine (may be a no-op for remote engines). */
+    void start();
+
+    /** Create the given table schema in the engine's catalog, ready for data loading. */
+    void createTable(String namespace, String tableName, CoralDataType schema);
+
+    /** Load row data into a previously created table. */
+    void loadData(String namespace, String tableName, RowSet data);
+
+    /** Run EXPLAIN on a query and return success/failure. Validates syntax + planning. */
+    ExplainResult explain(String sql);
+
+    /** Execute a query and return its result set. */
+    ResultSet execute(String sql);
+
+    /** Tear down the engine. */
+    void stop();
+}
+```
+
+Engine implementations are expected for embedded/local versions of:
+- **Spark**: embedded SparkSession
+- **Trino**: Trino test harness / in-memory connector
+- **Hive**: embedded HiveServer2 or Tez local mode
+
+The `EnginePlugin` is optional. Tests that only verify translation correctness at the IR level do not need engine plugins.
+
+### 3.5 Test Data
+
+A `RowSet` abstraction carries typed tabular data for loading into engines:
+
+```java
+RowSet userData = RowSet.builder(usersSchema)   // usersSchema is the StructType from catalog setup
+    .addRow(1, "alice", Timestamp.valueOf("2024-01-15 10:00:00"), Arrays.asList("admin", "user"))
+    .addRow(2, "bob",   Timestamp.valueOf("2024-03-20 14:30:00"), Arrays.asList("user"))
+    .build();
+```
+
+Values are Java objects matching the Coral type mapping (INT -> Integer, STRING -> String, ARRAY -> List, MAP -> Map, STRUCT -> Object[], etc.).
+
+## 4. Verification Levels
+
+The framework supports three escalating levels of verification. Each level subsumes the ones before it.
+
+### Level 1: Translation (IR round-trip)
+
+Translates a query from a source dialect to the target dialect through Coral IR. Verifies that the translation pipeline completes without error and produces non-empty SQL.
+
+```
+Source SQL --[toRelNode]--> RelNode --[toDialectSql]--> Target SQL
+```
+
+**What it catches:** Parser failures, unsupported SQL constructs, operator mapping gaps, type conversion errors.
+
+### Level 2: Syntactic Validation (EXPLAIN)
+
+Takes the translated SQL and runs it through the target engine's EXPLAIN. This validates that the target engine can parse and plan the query against the declared schema.
+
+```
+Target SQL --[engine.explain]--> ExplainResult (success/failure + plan)
+```
+
+**What it catches:** Dialect-specific syntax errors the Coral converter missed, schema mismatches, unresolved functions.
+
+### Level 3: Semantic Validation (result-set comparison)
+
+Loads test data into both source and target engines, executes the original query on the source engine and the translated query on the target engine, then compares result sets.
+
+```
+Source Engine: execute(sourceSQL, sourceData) --> ResultSet A
+Target Engine: execute(targetSQL, targetData) --> ResultSet B
+compare(A, B) --> equivalent?
+```
+
+**What it catches:** Subtle semantic differences in function behavior, NULL handling, type coercion, ordering, and precision across engines.
+
+## 5. Test Suite Construction
+
+A `TranslationTestSuite` is parameterized by source dialect, target dialect, and verification level:
+
+```java
+TranslationTestSuite suite = TranslationTestSuite.builder()
+    .source(Dialect.HIVE)
+    .target(Dialect.TRINO)
+    .catalog(catalog)                          // InMemoryCatalog from Section 3.1
+    .queryDir("queries/hive")                  // directory of .sql files
+    .verificationLevel(VerificationLevel.EXPLAIN)
+    .build();
+
+suite.run();  // returns TestReport with per-query pass/fail + details
+```
+
+For result-set comparison:
+
+```java
+TranslationTestSuite suite = TranslationTestSuite.builder()
+    .source(Dialect.HIVE)
+    .target(Dialect.TRINO)
+    .catalog(catalog)
+    .queryDir("queries/hive")
+    .verificationLevel(VerificationLevel.RESULT_SET)
+    .testData(Map.of(
+        "db.users", userData,
+        "db.events", eventData
+    ))
+    .sourceEngine(new SparkEnginePlugin())     // Spark executes Hive SQL natively
+    .targetEngine(new TrinoEnginePlugin())
+    .build();
+```
+
+The suite iterates over all `.sql` files in the query directory and runs each through the configured pipeline.
+
+## 6. Comparison Semantics
+
+Result-set comparison must handle real-world engine differences:
+
+- **Row ordering:** Unordered by default (compare as sets). Ordered comparison only when the query has an explicit ORDER BY.
+- **Floating-point tolerance:** Configurable epsilon for FLOAT/DOUBLE comparisons.
+- **NULL equivalence:** Two NULLs in the same position are treated as equal for comparison purposes.
+- **Timestamp precision:** Normalize to the lower precision of the two engines before comparison.
+- **Type widening:** Allow safe promotions (e.g., INT vs BIGINT) in the comparison, flag unsafe mismatches.
+
+## 7. Reporting
+
+`TestReport` provides structured output:
+
+- Per-query: status (PASS/FAIL/SKIP/ERROR), source SQL, translated SQL, and failure details (diff of result sets, exception stack traces, EXPLAIN output).
+- Aggregate: pass rate by dialect pair, failure categories (translation error, explain failure, result mismatch), regression tracking across runs.
+
+## 8. Module Structure
+
+```
+coral-benchmark/
+  src/main/java/com/linkedin/coral/benchmark/
+    catalog/
+      InMemoryCatalog.java          # CoralCatalog impl for tests
+      InMemoryTable.java            # CoralTable impl for tests
+    spi/
+      Dialect.java                  # Enum: HIVE, SPARK, TRINO, ...
+      DialectPlugin.java            # Translation SPI
+      EnginePlugin.java             # Execution SPI
+      VerificationLevel.java        # Enum: TRANSLATION, EXPLAIN, RESULT_SET
+    data/
+      ExplainResult.java            # Result of running EXPLAIN
+      ResultSet.java                # Query result container
+      RowSet.java                   # Typed tabular test data
+    comparison/
+      ComparisonConfig.java         # Tolerances, ordering, type widening
+      ComparisonResult.java         # Outcome of comparing two result sets
+      ResultSetComparator.java      # Configurable comparison logic
+    suite/
+      QueryTestResult.java          # Per-query test outcome
+      TestReport.java               # Aggregate results
+      TranslationTestSuite.java     # Main orchestrator
+    plugins/
+      HiveDialectPlugin.java
+      TrinoDialectPlugin.java
+      SparkDialectPlugin.java
+  src/main/java/com/linkedin/coral/benchmark/engines/
+      SparkEnginePlugin.java
+      TrinoEnginePlugin.java
+  src/test/resources/
+    queries/
+      hive/
+      trino/
+      spark/
+```
+
+## 9. Dependencies
+
+- `coral-common` (CoralCatalog, CoralTable, CoralDataType, type hierarchy)
+- `coral-hive` (HiveToRelConverter, HiveDialectPlugin)
+- `coral-trino` (TrinoToRelConverter, RelToTrinoConverter)
+- `coral-spark` (CoralSpark)
+- Embedded Spark (test scope, for SparkEnginePlugin)
+- Trino test framework (test scope, for TrinoEnginePlugin)
+
+## 10. Non-Goals (for initial version)
+
+- **DDL/DML translation testing.** Only SELECT queries are in scope.
+- **Performance benchmarking.** This is a correctness framework, not a latency benchmark.
+- **Production metastore integration.** Tests use in-memory catalogs only.
+- **View resolution.** Queries reference base tables, not views-on-views. View expansion is tested separately in existing module tests.

--- a/coral-benchmark/coral-benchmark-spec.md
+++ b/coral-benchmark/coral-benchmark-spec.md
@@ -13,6 +13,36 @@ A new module (`coral-benchmark`) that tests Coral translations end-to-end: from 
 
 ## 3. Core Concepts
 
+The framework is organized around a single orchestrator (`TranslationTestSuite`) that
+drives a corpus of SQL queries through pluggable translation and execution stages,
+comparing results via a configurable comparator. The major components and their
+relationships:
+
+```
+                       +-----------------------------+
+                       |   TranslationTestSuite      |
+                       |       (orchestrator)        |
+                       +--+--------+--------+--------+
+                          |        |        |
+                    uses  |        |        |  uses
+                          v        v        v
+                +-----------+ +-------+ +---------------------+
+                |  Catalog  | |  SPI  | | ResultSetComparator |
+                | (schemas) | | impls | |   (Level 3 only)    |
+                +-----------+ +---+---+ +---------------------+
+                                  |
+                          +-------+--------+
+                          v                v
+                  +---------------+ +--------------+
+                  | DialectPlugin | | EnginePlugin |
+                  |  (translate)  | |  (execute)   |
+                  +---------------+ +--------------+
+```
+
+The orchestrator iterates over `.sql` files from the configured query directory,
+runs each through the appropriate plugins for the requested verification level, and
+emits a `QueryTestResult` per query plus an aggregate `TestReport`.
+
 ### 3.1 Catalog Setup
 
 Tests declare their table schemas using the Coral type system and register them in an in-memory catalog.
@@ -63,28 +93,45 @@ Each file contains a single SELECT statement written in the source dialect's syn
 
 ### 3.3 Dialect SPI
 
-Each dialect plugs into the framework by implementing a single interface:
+Each dialect plugs into the framework via a *provider/plugin* pair. The provider is the
+ServiceLoader-discoverable entry point (no-arg constructor); the plugin is the
+fully-constructed translator bound to a catalog. This split keeps the plugin immutable
+(catalog as a `final` field, no two-phase `init`) while still supporting standard SPI
+discovery.
 
 ```java
+public interface DialectPluginProvider {
+
+    /** Identifier for the dialect this provider produces plugins for. */
+    Dialect dialect();
+
+    /** Construct a plugin bound to the given catalog. */
+    DialectPlugin create(CoralCatalog catalog);
+}
+
 public interface DialectPlugin {
 
     /** Identifier for this dialect (e.g., HIVE, SPARK, TRINO). */
     Dialect dialect();
 
     /** Parse a SQL string in this dialect and produce a Coral IR RelNode. */
-    RelNode toRelNode(String sql, CoralCatalog catalog);
+    RelNode toRelNode(String sql);
 
     /** Convert a Coral IR RelNode to a SQL string in this dialect. */
-    String toDialectSql(RelNode relNode, CoralCatalog catalog);
+    String toDialectSql(RelNode relNode);
 }
 ```
 
-Implementations wrap the existing converters:
+Provider implementations are typically three lines, e.g.
+`new HiveDialectPlugin(catalog)`. Plugins themselves wrap the existing converters:
 - **Hive**: `HiveToRelConverter` / `CoralRelToSqlNodeConverter` (Hive dialect)
 - **Trino**: `TrinoToRelConverter` / `RelToTrinoConverter`
 - **Spark**: `HiveToRelConverter` (Spark SQL parses as Hive) / `CoralSpark`
 
-Plugins are discovered by `ServiceLoader` or registered explicitly at suite construction time.
+Providers are discovered by `ServiceLoader` (via
+`META-INF/services/com.linkedin.coral.benchmark.spi.DialectPluginProvider`) or registered
+explicitly on the suite builder. The framework calls `provider.create(catalog)` once per
+suite to materialize the plugin.
 
 ### 3.4 Engine SPI (for execution-level verification)
 
@@ -138,7 +185,36 @@ Values are Java objects matching the Coral type mapping (INT -> Integer, STRING 
 
 ## 4. Verification Levels
 
-The framework supports three escalating levels of verification. Each level subsumes the ones before it.
+The framework supports three escalating levels of verification. Each level subsumes the
+ones before it: passing Level 3 implies Level 2 also passed, which implies Level 1.
+
+```
+  Level 1 (TRANSLATION):
+
+      Source SQL --[toRelNode]--> IR --[toDialectSql]--> Target SQL
+
+
+  Level 2 (EXPLAIN):  Level 1, plus:
+
+      Target SQL --[targetEngine.explain]--> ExplainResult
+
+
+  Level 3 (RESULT_SET):  Level 2, plus:
+
+      sourceEngine.execute(Source SQL) ---> ResultSet A
+                                                         \
+                                                          ResultSetComparator
+                                                         /
+      targetEngine.execute(Target SQL) ---> ResultSet B
+```
+
+Each step up the ladder requires more setup:
+
+| Level       | Engines required | Test data required |
+| ----------- | ---------------- | ------------------ |
+| TRANSLATION | none             | no                 |
+| EXPLAIN     | target only      | no                 |
+| RESULT_SET  | source + target  | yes                |
 
 ### Level 1: Translation (IR round-trip)
 
@@ -227,6 +303,11 @@ Result-set comparison must handle real-world engine differences:
 
 ## 8. Module Structure
 
+This section describes only the framework code that ships in this module. Concrete
+`DialectPlugin` and `EnginePlugin` implementations are deferred to follow-up changes;
+their hosting module is intentionally left undecided here so it can be chosen against
+real implementations rather than against speculation.
+
 ```
 coral-benchmark/
   src/main/java/com/linkedin/coral/benchmark/
@@ -235,7 +316,8 @@ coral-benchmark/
       InMemoryTable.java            # CoralTable impl for tests
     spi/
       Dialect.java                  # Enum: HIVE, SPARK, TRINO, ...
-      DialectPlugin.java            # Translation SPI
+      DialectPluginProvider.java    # Translation SPI - ServiceLoader entry point
+      DialectPlugin.java            # Translation SPI - catalog-bound plugin
       EnginePlugin.java             # Execution SPI
       VerificationLevel.java        # Enum: TRANSLATION, EXPLAIN, RESULT_SET
     data/
@@ -250,13 +332,6 @@ coral-benchmark/
       QueryTestResult.java          # Per-query test outcome
       TestReport.java               # Aggregate results
       TranslationTestSuite.java     # Main orchestrator
-    plugins/
-      HiveDialectPlugin.java
-      TrinoDialectPlugin.java
-      SparkDialectPlugin.java
-  src/main/java/com/linkedin/coral/benchmark/engines/
-      SparkEnginePlugin.java
-      TrinoEnginePlugin.java
   src/test/resources/
     queries/
       hive/
@@ -267,11 +342,6 @@ coral-benchmark/
 ## 9. Dependencies
 
 - `coral-common` (CoralCatalog, CoralTable, CoralDataType, type hierarchy)
-- `coral-hive` (HiveToRelConverter, HiveDialectPlugin)
-- `coral-trino` (TrinoToRelConverter, RelToTrinoConverter)
-- `coral-spark` (CoralSpark)
-- Embedded Spark (test scope, for SparkEnginePlugin)
-- Trino test framework (test scope, for TrinoEnginePlugin)
 
 ## 10. Non-Goals (for initial version)
 

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/catalog/InMemoryCatalog.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/catalog/InMemoryCatalog.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2017-2026 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.benchmark.catalog;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import com.linkedin.coral.common.catalog.CoralCatalog;
+import com.linkedin.coral.common.catalog.CoralTable;
+import com.linkedin.coral.common.types.CoralDataType;
+import com.linkedin.coral.common.types.StructType;
+
+
+/**
+ * An in-memory implementation of {@link CoralCatalog} for benchmark tests.
+ *
+ * <p>Holds namespaces and tables in memory with no external metastore dependency.
+ * Tables are registered using the Coral type system ({@link StructType},
+ * {@link com.linkedin.coral.common.types.PrimitiveType}, etc.).
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * InMemoryCatalog catalog = InMemoryCatalog.builder()
+ *     .createNamespace("db")
+ *     .addTable("db", "users", StructType.of(
+ *         Arrays.asList(
+ *             StructField.of("id", PrimitiveType.of(CoralTypeKind.INT, true)),
+ *             StructField.of("name", PrimitiveType.of(CoralTypeKind.STRING, true))
+ *         ), true))
+ *     .build();
+ * }</pre>
+ */
+public final class InMemoryCatalog implements CoralCatalog {
+
+  private final Map<String, Map<String, CoralTable>> namespaces;
+
+  private InMemoryCatalog(Map<String, Map<String, CoralTable>> namespaces) {
+    // Deep-copy to make the catalog immutable after construction
+    Map<String, Map<String, CoralTable>> copy = new LinkedHashMap<>();
+    for (Map.Entry<String, Map<String, CoralTable>> entry : namespaces.entrySet()) {
+      copy.put(entry.getKey(), Collections.unmodifiableMap(new LinkedHashMap<>(entry.getValue())));
+    }
+    this.namespaces = Collections.unmodifiableMap(copy);
+  }
+
+  @Override
+  public CoralTable getTable(String namespace, String tableName) {
+    Map<String, CoralTable> tables = namespaces.get(namespace);
+    return tables != null ? tables.get(tableName) : null;
+  }
+
+  @Override
+  public boolean namespaceExists(String namespace) {
+    return namespaces.containsKey(namespace);
+  }
+
+  @Override
+  public List<String> getAllTables(String namespace) {
+    Map<String, CoralTable> tables = namespaces.get(namespace);
+    return tables != null
+        ? Collections.unmodifiableList(new ArrayList<>(tables.keySet()))
+        : Collections.emptyList();
+  }
+
+  @Override
+  public List<String> getAllNamespaces() {
+    return Collections.unmodifiableList(new ArrayList<>(namespaces.keySet()));
+  }
+
+  /**
+   * Creates a new builder for constructing an InMemoryCatalog.
+   *
+   * @return a new builder
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder for constructing an {@link InMemoryCatalog}.
+   *
+   * <p>Namespaces are created explicitly via {@link #createNamespace(String)}.
+   * Tables are added to existing namespaces via {@link #addTable(String, String, StructType)}
+   * or {@link #addTable(String, String, StructType, Map)}.
+   */
+  public static final class Builder {
+
+    private final Map<String, Map<String, CoralTable>> namespaces = new LinkedHashMap<>();
+
+    private Builder() {
+    }
+
+    /**
+     * Creates a namespace (database) in the catalog.
+     *
+     * @param namespace the namespace name
+     * @return this builder
+     * @throws IllegalArgumentException if the namespace already exists
+     */
+    public Builder createNamespace(String namespace) {
+      Objects.requireNonNull(namespace, "Namespace cannot be null");
+      if (namespaces.containsKey(namespace)) {
+        throw new IllegalArgumentException("Namespace already exists: " + namespace);
+      }
+      namespaces.put(namespace, new LinkedHashMap<>());
+      return this;
+    }
+
+    /**
+     * Adds a table with the given schema and no extra properties.
+     *
+     * @param namespace the namespace (must already exist via {@link #createNamespace})
+     * @param tableName the table name
+     * @param schema    the table schema
+     * @return this builder
+     * @throws IllegalArgumentException if the namespace does not exist or the table already exists
+     */
+    public Builder addTable(String namespace, String tableName, StructType schema) {
+      return addTable(namespace, tableName, schema, Collections.emptyMap());
+    }
+
+    /**
+     * Adds a table with the given schema and properties.
+     *
+     * @param namespace  the namespace (must already exist via {@link #createNamespace})
+     * @param tableName  the table name
+     * @param schema     the table schema
+     * @param properties table properties
+     * @return this builder
+     * @throws IllegalArgumentException if the namespace does not exist or the table already exists
+     */
+    public Builder addTable(String namespace, String tableName, StructType schema, Map<String, String> properties) {
+      Objects.requireNonNull(namespace, "Namespace cannot be null");
+      Objects.requireNonNull(tableName, "Table name cannot be null");
+      Objects.requireNonNull(schema, "Schema cannot be null");
+      Objects.requireNonNull(properties, "Properties cannot be null");
+
+      Map<String, CoralTable> tables = namespaces.get(namespace);
+      if (tables == null) {
+        throw new IllegalArgumentException("Namespace does not exist: " + namespace
+            + ". Call createNamespace() first.");
+      }
+      if (tables.containsKey(tableName)) {
+        throw new IllegalArgumentException("Table already exists: " + namespace + "." + tableName);
+      }
+
+      tables.put(tableName, new InMemoryTable(namespace, tableName, schema, properties));
+      return this;
+    }
+
+    /**
+     * Builds the catalog. The resulting catalog is immutable.
+     *
+     * @return a new InMemoryCatalog
+     */
+    public InMemoryCatalog build() {
+      return new InMemoryCatalog(namespaces);
+    }
+  }
+}

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/catalog/InMemoryCatalog.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/catalog/InMemoryCatalog.java
@@ -7,7 +7,6 @@ package com.linkedin.coral.benchmark.catalog;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,7 +14,6 @@ import java.util.Objects;
 
 import com.linkedin.coral.common.catalog.CoralCatalog;
 import com.linkedin.coral.common.catalog.CoralTable;
-import com.linkedin.coral.common.types.CoralDataType;
 import com.linkedin.coral.common.types.StructType;
 
 
@@ -65,9 +63,7 @@ public final class InMemoryCatalog implements CoralCatalog {
   @Override
   public List<String> getAllTables(String namespace) {
     Map<String, CoralTable> tables = namespaces.get(namespace);
-    return tables != null
-        ? Collections.unmodifiableList(new ArrayList<>(tables.keySet()))
-        : Collections.emptyList();
+    return tables != null ? Collections.unmodifiableList(new ArrayList<>(tables.keySet())) : Collections.emptyList();
   }
 
   @Override
@@ -145,8 +141,8 @@ public final class InMemoryCatalog implements CoralCatalog {
 
       Map<String, CoralTable> tables = namespaces.get(namespace);
       if (tables == null) {
-        throw new IllegalArgumentException("Namespace does not exist: " + namespace
-            + ". Call createNamespace() first.");
+        throw new IllegalArgumentException(
+            "Namespace does not exist: " + namespace + ". Call createNamespace() first.");
       }
       if (tables.containsKey(tableName)) {
         throw new IllegalArgumentException("Table already exists: " + namespace + "." + tableName);

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/catalog/InMemoryTable.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/catalog/InMemoryTable.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2017-2026 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.benchmark.catalog;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+import com.linkedin.coral.common.catalog.CoralTable;
+import com.linkedin.coral.common.catalog.TableType;
+import com.linkedin.coral.common.types.CoralDataType;
+
+
+/**
+ * An in-memory implementation of {@link CoralTable} for benchmark tests.
+ *
+ * <p>Always represents a base table ({@link TableType#TABLE}), not a view.
+ * The schema is provided at construction time via the Coral type system.
+ */
+public final class InMemoryTable implements CoralTable {
+
+  private final String name;
+  private final CoralDataType schema;
+  private final Map<String, String> properties;
+
+  /**
+   * Creates an in-memory table with the given name, schema, and properties.
+   *
+   * @param namespace  the namespace (database) name
+   * @param tableName  the table name
+   * @param schema     the table schema (typically a {@link com.linkedin.coral.common.types.StructType})
+   * @param properties table properties (may be empty)
+   */
+  InMemoryTable(String namespace, String tableName, CoralDataType schema, Map<String, String> properties) {
+    this.name = Objects.requireNonNull(namespace) + "." + Objects.requireNonNull(tableName);
+    this.schema = Objects.requireNonNull(schema, "Schema cannot be null");
+    this.properties = Collections.unmodifiableMap(Objects.requireNonNull(properties));
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    return properties;
+  }
+
+  @Override
+  public TableType tableType() {
+    return TableType.TABLE;
+  }
+
+  @Override
+  public CoralDataType getSchema() {
+    return schema;
+  }
+}

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/comparison/ComparisonConfig.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/comparison/ComparisonConfig.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2017-2026 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.benchmark.comparison;
+
+/**
+ * Configuration for how two {@link com.linkedin.coral.benchmark.data.ResultSet}s are compared.
+ *
+ * <p>Controls tolerances for the real-world differences between engine outputs:
+ * floating-point precision, row ordering, NULL handling, timestamp precision,
+ * and type widening.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * ComparisonConfig config = ComparisonConfig.builder()
+ *     .floatingPointEpsilon(1e-6)
+ *     .orderedComparison(false)
+ *     .allowTypeWidening(true)
+ *     .build();
+ * }</pre>
+ */
+public final class ComparisonConfig {
+
+  /** Default epsilon for FLOAT/DOUBLE comparisons. */
+  public static final double DEFAULT_EPSILON = 1e-9;
+
+  private final double floatingPointEpsilon;
+  private final boolean orderedComparison;
+  private final boolean allowTypeWidening;
+
+  private ComparisonConfig(double floatingPointEpsilon, boolean orderedComparison, boolean allowTypeWidening) {
+    this.floatingPointEpsilon = floatingPointEpsilon;
+    this.orderedComparison = orderedComparison;
+    this.allowTypeWidening = allowTypeWidening;
+  }
+
+  /**
+   * Returns the epsilon used for FLOAT/DOUBLE equality comparisons.
+   * Two floating-point values are considered equal if their absolute difference
+   * is less than this epsilon.
+   *
+   * @return the epsilon
+   */
+  public double getFloatingPointEpsilon() {
+    return floatingPointEpsilon;
+  }
+
+  /**
+   * Returns whether rows should be compared in order.
+   *
+   * <p>When false (the default), result sets are compared as multisets (bags):
+   * the same rows must appear the same number of times, regardless of order.
+   * When true, row order must also match — use this only for queries with
+   * an explicit ORDER BY.
+   *
+   * @return true if row order matters
+   */
+  public boolean isOrderedComparison() {
+    return orderedComparison;
+  }
+
+  /**
+   * Returns whether safe type widening is allowed during comparison.
+   *
+   * <p>When true, values are promoted to the wider type before comparison
+   * (e.g., INT vs BIGINT, FLOAT vs DOUBLE). When false, any type mismatch
+   * between corresponding columns is treated as a comparison failure.
+   *
+   * @return true if type widening is allowed
+   */
+  public boolean isAllowTypeWidening() {
+    return allowTypeWidening;
+  }
+
+  /**
+   * Returns a builder with default settings: unordered comparison, default epsilon,
+   * type widening allowed.
+   *
+   * @return a new builder
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Returns a config with all default settings.
+   *
+   * @return the default comparison config
+   */
+  public static ComparisonConfig defaults() {
+    return new Builder().build();
+  }
+
+  /**
+   * Builder for {@link ComparisonConfig}.
+   */
+  public static final class Builder {
+    private double floatingPointEpsilon = DEFAULT_EPSILON;
+    private boolean orderedComparison = false;
+    private boolean allowTypeWidening = true;
+
+    private Builder() {
+    }
+
+    /**
+     * Sets the epsilon for floating-point comparisons.
+     *
+     * @param epsilon a non-negative tolerance value
+     * @return this builder
+     */
+    public Builder floatingPointEpsilon(double epsilon) {
+      if (epsilon < 0) {
+        throw new IllegalArgumentException("Epsilon must be non-negative, got: " + epsilon);
+      }
+      this.floatingPointEpsilon = epsilon;
+      return this;
+    }
+
+    /**
+     * Sets whether row order matters.
+     *
+     * @param ordered true for ordered comparison, false for set comparison
+     * @return this builder
+     */
+    public Builder orderedComparison(boolean ordered) {
+      this.orderedComparison = ordered;
+      return this;
+    }
+
+    /**
+     * Sets whether safe type widening is allowed.
+     *
+     * @param allow true to allow widening (INT vs BIGINT, etc.)
+     * @return this builder
+     */
+    public Builder allowTypeWidening(boolean allow) {
+      this.allowTypeWidening = allow;
+      return this;
+    }
+
+    /**
+     * Builds the comparison config.
+     *
+     * @return an immutable ComparisonConfig
+     */
+    public ComparisonConfig build() {
+      return new ComparisonConfig(floatingPointEpsilon, orderedComparison, allowTypeWidening);
+    }
+  }
+}

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/comparison/ComparisonResult.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/comparison/ComparisonResult.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2017-2026 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.benchmark.comparison;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+
+/**
+ * The outcome of comparing two result sets.
+ *
+ * <p>On equivalence, the result is simply {@link #isEquivalent()} == true.
+ * On mismatch, it provides structured details about the differences found:
+ * row count mismatch, schema mismatch, or per-row diffs.
+ */
+public final class ComparisonResult {
+
+  private final boolean equivalent;
+  private final String summary;
+  private final List<String> diffs;
+
+  private ComparisonResult(boolean equivalent, String summary, List<String> diffs) {
+    this.equivalent = equivalent;
+    this.summary = summary;
+    this.diffs = Collections.unmodifiableList(diffs);
+  }
+
+  /**
+   * Creates a result indicating the two result sets are equivalent.
+   *
+   * @return an equivalent result
+   */
+  public static ComparisonResult equivalent() {
+    return new ComparisonResult(true, "Result sets are equivalent", Collections.emptyList());
+  }
+
+  /**
+   * Creates a result indicating the two result sets differ.
+   *
+   * @param summary a human-readable summary of the mismatch
+   * @param diffs   individual difference descriptions (e.g., per-row or per-column diffs)
+   * @return a mismatch result
+   */
+  public static ComparisonResult mismatch(String summary, List<String> diffs) {
+    Objects.requireNonNull(summary, "Summary cannot be null");
+    Objects.requireNonNull(diffs, "Diffs list cannot be null");
+    return new ComparisonResult(false, summary, diffs);
+  }
+
+  /**
+   * Returns whether the two result sets are equivalent under the comparison config.
+   *
+   * @return true if equivalent
+   */
+  public boolean isEquivalent() {
+    return equivalent;
+  }
+
+  /**
+   * Returns a human-readable summary of the comparison outcome.
+   *
+   * @return the summary
+   */
+  public String getSummary() {
+    return summary;
+  }
+
+  /**
+   * Returns individual difference descriptions. Empty if the result sets are equivalent.
+   *
+   * @return an unmodifiable list of diff descriptions
+   */
+  public List<String> getDiffs() {
+    return diffs;
+  }
+}

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/comparison/ComparisonResult.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/comparison/ComparisonResult.java
@@ -8,7 +8,6 @@ package com.linkedin.coral.benchmark.comparison;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 
 /**

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/comparison/ResultSetComparator.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/comparison/ResultSetComparator.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2017-2026 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.benchmark.comparison;
+
+import java.util.Objects;
+
+import com.linkedin.coral.benchmark.data.ResultSet;
+
+
+/**
+ * Compares two {@link ResultSet}s for equivalence according to a {@link ComparisonConfig}.
+ *
+ * <p>Handles the real-world differences between engine outputs:
+ * <ul>
+ *   <li><b>Row ordering:</b> unordered (multiset) comparison by default; ordered only when
+ *       {@link ComparisonConfig#isOrderedComparison()} is true.</li>
+ *   <li><b>Floating-point tolerance:</b> FLOAT/DOUBLE values are compared using the
+ *       configured epsilon.</li>
+ *   <li><b>NULL equivalence:</b> two NULLs in the same column position are considered equal.</li>
+ *   <li><b>Timestamp precision:</b> timestamps are normalized to the lower precision of
+ *       the two result sets before comparison.</li>
+ *   <li><b>Type widening:</b> when allowed, values are promoted to the wider type
+ *       (e.g., INT vs BIGINT) before comparison.</li>
+ * </ul>
+ */
+public final class ResultSetComparator {
+
+  private final ComparisonConfig config;
+
+  /**
+   * Creates a comparator with the given configuration.
+   *
+   * @param config the comparison configuration
+   */
+  public ResultSetComparator(ComparisonConfig config) {
+    this.config = Objects.requireNonNull(config, "ComparisonConfig cannot be null");
+  }
+
+  /**
+   * Creates a comparator with default configuration.
+   */
+  public ResultSetComparator() {
+    this(ComparisonConfig.defaults());
+  }
+
+  /**
+   * Compares two result sets for equivalence.
+   *
+   * @param source the result set from the source engine
+   * @param target the result set from the target engine
+   * @return the comparison result indicating equivalence or detailing differences
+   */
+  public ComparisonResult compare(ResultSet source, ResultSet target) {
+    Objects.requireNonNull(source, "Source result set cannot be null");
+    Objects.requireNonNull(target, "Target result set cannot be null");
+
+    // Implementation will:
+    // 1. Compare schemas (column count, types with optional widening)
+    // 2. Compare row counts
+    // 3. Compare row contents (ordered or as multisets, per config)
+    //    - Apply floating-point epsilon
+    //    - Apply NULL equivalence
+    //    - Normalize timestamp precision
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  /**
+   * Returns the comparison configuration used by this comparator.
+   *
+   * @return the config
+   */
+  public ComparisonConfig getConfig() {
+    return config;
+  }
+}

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/data/ExplainResult.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/data/ExplainResult.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2017-2026 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.benchmark.data;
+
+import java.util.Objects;
+import java.util.Optional;
+
+
+/**
+ * The result of running EXPLAIN on a SQL query through an engine.
+ *
+ * <p>Captures whether the engine could successfully parse and plan the query.
+ * On success, optionally includes the query plan text. On failure, includes
+ * the error message.
+ */
+public final class ExplainResult {
+
+  private final boolean success;
+  private final String plan;
+  private final String errorMessage;
+  private final Exception exception;
+
+  private ExplainResult(boolean success, String plan, String errorMessage, Exception exception) {
+    this.success = success;
+    this.plan = plan;
+    this.errorMessage = errorMessage;
+    this.exception = exception;
+  }
+
+  /**
+   * Creates a successful explain result.
+   *
+   * @param plan the query plan text produced by the engine (may be null if the engine
+   *             does not expose plan text)
+   * @return a successful result
+   */
+  public static ExplainResult success(String plan) {
+    return new ExplainResult(true, plan, null, null);
+  }
+
+  /**
+   * Creates a failed explain result.
+   *
+   * @param errorMessage a human-readable description of the failure
+   * @param exception    the exception thrown by the engine, or null
+   * @return a failed result
+   */
+  public static ExplainResult failure(String errorMessage, Exception exception) {
+    Objects.requireNonNull(errorMessage, "Error message cannot be null for a failure");
+    return new ExplainResult(false, null, errorMessage, exception);
+  }
+
+  /**
+   * Returns whether the EXPLAIN succeeded.
+   *
+   * @return true if the engine could parse and plan the query
+   */
+  public boolean isSuccess() {
+    return success;
+  }
+
+  /**
+   * Returns the query plan text, if available.
+   *
+   * @return the plan text, or empty if not available or explain failed
+   */
+  public Optional<String> getPlan() {
+    return Optional.ofNullable(plan);
+  }
+
+  /**
+   * Returns the error message, if the explain failed.
+   *
+   * @return the error message, or empty if explain succeeded
+   */
+  public Optional<String> getErrorMessage() {
+    return Optional.ofNullable(errorMessage);
+  }
+
+  /**
+   * Returns the exception that caused the failure, if any.
+   *
+   * @return the exception, or empty if explain succeeded or no exception was captured
+   */
+  public Optional<Exception> getException() {
+    return Optional.ofNullable(exception);
+  }
+}

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/data/ResultSet.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/data/ResultSet.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2017-2026 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.benchmark.data;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import com.linkedin.coral.common.types.StructType;
+
+
+/**
+ * The result of executing a SQL query on an engine.
+ *
+ * <p>Contains the output schema (column names and types) and the rows produced
+ * by the query. Used as input to {@link com.linkedin.coral.benchmark.comparison.ResultSetComparator}
+ * for cross-engine result comparison.
+ */
+public final class ResultSet {
+
+  private final StructType schema;
+  private final List<Object[]> rows;
+
+  private ResultSet(StructType schema, List<Object[]> rows) {
+    this.schema = Objects.requireNonNull(schema, "Schema cannot be null");
+    this.rows = Collections.unmodifiableList(rows);
+  }
+
+  /**
+   * Returns the schema of the result set columns.
+   *
+   * @return the struct type describing the output columns
+   */
+  public StructType getSchema() {
+    return schema;
+  }
+
+  /**
+   * Returns the result rows. Each row is an Object array with one element per column,
+   * following the same type mapping as {@link RowSet}.
+   *
+   * @return an unmodifiable list of rows
+   */
+  public List<Object[]> getRows() {
+    return rows;
+  }
+
+  /**
+   * Returns the number of rows in this result set.
+   *
+   * @return the row count
+   */
+  public int size() {
+    return rows.size();
+  }
+
+  /**
+   * Creates a new ResultSet.
+   *
+   * @param schema the output schema
+   * @param rows   the result rows
+   * @return a new ResultSet
+   */
+  public static ResultSet of(StructType schema, List<Object[]> rows) {
+    return new ResultSet(schema, new ArrayList<>(rows));
+  }
+}

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/data/RowSet.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/data/RowSet.java
@@ -20,21 +20,21 @@ import com.linkedin.coral.common.types.StructType;
  * <p>A RowSet is bound to a schema (a {@link StructType}) and contains zero or more rows.
  * Each row is an array of Java objects whose types correspond to the Coral type mapping:
  * <ul>
- *   <li>BOOLEAN -> {@link Boolean}</li>
- *   <li>TINYINT -> {@link Byte}</li>
- *   <li>SMALLINT -> {@link Short}</li>
- *   <li>INT -> {@link Integer}</li>
- *   <li>BIGINT -> {@link Long}</li>
- *   <li>FLOAT -> {@link Float}</li>
- *   <li>DOUBLE -> {@link Double}</li>
- *   <li>DECIMAL -> {@link java.math.BigDecimal}</li>
- *   <li>STRING/VARCHAR/CHAR -> {@link String}</li>
- *   <li>DATE -> {@link java.sql.Date}</li>
- *   <li>TIMESTAMP -> {@link java.sql.Timestamp}</li>
- *   <li>BINARY -> {@code byte[]}</li>
- *   <li>ARRAY -> {@link List}</li>
- *   <li>MAP -> {@link java.util.Map}</li>
- *   <li>STRUCT -> {@code Object[]}</li>
+ *   <li>BOOLEAN: {@link Boolean}</li>
+ *   <li>TINYINT: {@link Byte}</li>
+ *   <li>SMALLINT: {@link Short}</li>
+ *   <li>INT: {@link Integer}</li>
+ *   <li>BIGINT: {@link Long}</li>
+ *   <li>FLOAT: {@link Float}</li>
+ *   <li>DOUBLE: {@link Double}</li>
+ *   <li>DECIMAL: {@link java.math.BigDecimal}</li>
+ *   <li>STRING/VARCHAR/CHAR: {@link String}</li>
+ *   <li>DATE: {@link java.sql.Date}</li>
+ *   <li>TIMESTAMP: {@link java.sql.Timestamp}</li>
+ *   <li>BINARY: {@code byte[]}</li>
+ *   <li>ARRAY: {@link List}</li>
+ *   <li>MAP: {@link java.util.Map}</li>
+ *   <li>STRUCT: {@code Object[]}</li>
  * </ul>
  *
  * <p>Null values are represented by Java {@code null} and are only permitted for nullable columns.

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/data/RowSet.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/data/RowSet.java
@@ -6,6 +6,7 @@
 package com.linkedin.coral.benchmark.data;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/data/RowSet.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/data/RowSet.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2017-2026 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.benchmark.data;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import com.linkedin.coral.common.types.CoralDataType;
+import com.linkedin.coral.common.types.CoralTypeKind;
+import com.linkedin.coral.common.types.StructType;
+
+
+/**
+ * Typed tabular data for loading into engine tables during benchmark tests.
+ *
+ * <p>A RowSet is bound to a schema (a {@link StructType}) and contains zero or more rows.
+ * Each row is an array of Java objects whose types correspond to the Coral type mapping:
+ * <ul>
+ *   <li>BOOLEAN -> {@link Boolean}</li>
+ *   <li>TINYINT -> {@link Byte}</li>
+ *   <li>SMALLINT -> {@link Short}</li>
+ *   <li>INT -> {@link Integer}</li>
+ *   <li>BIGINT -> {@link Long}</li>
+ *   <li>FLOAT -> {@link Float}</li>
+ *   <li>DOUBLE -> {@link Double}</li>
+ *   <li>DECIMAL -> {@link java.math.BigDecimal}</li>
+ *   <li>STRING/VARCHAR/CHAR -> {@link String}</li>
+ *   <li>DATE -> {@link java.sql.Date}</li>
+ *   <li>TIMESTAMP -> {@link java.sql.Timestamp}</li>
+ *   <li>BINARY -> {@code byte[]}</li>
+ *   <li>ARRAY -> {@link List}</li>
+ *   <li>MAP -> {@link java.util.Map}</li>
+ *   <li>STRUCT -> {@code Object[]}</li>
+ * </ul>
+ *
+ * <p>Null values are represented by Java {@code null} and are only permitted for nullable columns.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * RowSet data = RowSet.builder(tableSchema)
+ *     .addRow(1, "alice", Timestamp.valueOf("2024-01-15 10:00:00"), Arrays.asList("admin"))
+ *     .addRow(2, "bob",   Timestamp.valueOf("2024-03-20 14:30:00"), Arrays.asList("user"))
+ *     .build();
+ * }</pre>
+ */
+public final class RowSet {
+
+  private final StructType schema;
+  private final List<Object[]> rows;
+
+  private RowSet(StructType schema, List<Object[]> rows) {
+    this.schema = Objects.requireNonNull(schema, "Schema cannot be null");
+    this.rows = Collections.unmodifiableList(rows);
+  }
+
+  /**
+   * Returns the schema that defines the column types for this row set.
+   *
+   * @return the struct type describing the columns
+   */
+  public StructType getSchema() {
+    return schema;
+  }
+
+  /**
+   * Returns the rows in this row set. Each row is an Object array with one element per column.
+   *
+   * @return an unmodifiable list of rows
+   */
+  public List<Object[]> getRows() {
+    return rows;
+  }
+
+  /**
+   * Returns the number of rows in this row set.
+   *
+   * @return the row count
+   */
+  public int size() {
+    return rows.size();
+  }
+
+  /**
+   * Creates a new builder for constructing a RowSet with the given schema.
+   *
+   * @param schema the table schema (must be a {@link StructType})
+   * @return a new builder
+   */
+  public static Builder builder(StructType schema) {
+    return new Builder(schema);
+  }
+
+  /**
+   * Builder for constructing a {@link RowSet}.
+   */
+  public static final class Builder {
+
+    private final StructType schema;
+    private final int columnCount;
+    private final List<Object[]> rows = new ArrayList<>();
+
+    private Builder(StructType schema) {
+      this.schema = Objects.requireNonNull(schema, "Schema cannot be null");
+      this.columnCount = schema.getFields().size();
+    }
+
+    /**
+     * Adds a row of values. The number of values must match the number of columns
+     * in the schema. Values must be Java objects matching the Coral type mapping.
+     *
+     * @param values one value per column, in schema order
+     * @return this builder
+     * @throws IllegalArgumentException if the number of values does not match the schema
+     */
+    public Builder addRow(Object... values) {
+      if (values.length != columnCount) {
+        throw new IllegalArgumentException(
+            "Expected " + columnCount + " values, got " + values.length);
+      }
+      rows.add(Arrays.copyOf(values, values.length));
+      return this;
+    }
+
+    /**
+     * Builds the RowSet.
+     *
+     * @return an immutable RowSet
+     */
+    public RowSet build() {
+      return new RowSet(schema, new ArrayList<>(rows));
+    }
+  }
+}

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/data/RowSet.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/data/RowSet.java
@@ -6,13 +6,10 @@
 package com.linkedin.coral.benchmark.data;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import com.linkedin.coral.common.types.CoralDataType;
-import com.linkedin.coral.common.types.CoralTypeKind;
 import com.linkedin.coral.common.types.StructType;
 
 
@@ -120,8 +117,7 @@ public final class RowSet {
      */
     public Builder addRow(Object... values) {
       if (values.length != columnCount) {
-        throw new IllegalArgumentException(
-            "Expected " + columnCount + " values, got " + values.length);
+        throw new IllegalArgumentException("Expected " + columnCount + " values, got " + values.length);
       }
       rows.add(Arrays.copyOf(values, values.length));
       return this;

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/spi/Dialect.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/spi/Dialect.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2017-2026 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.benchmark.spi;
+
+/**
+ * Supported SQL dialects in the Coral translation framework.
+ *
+ * <p>Each value corresponds to a SQL dialect that Coral can parse from or generate to.
+ * A {@link DialectPlugin} provides the translation logic for a specific dialect,
+ * while an {@link EnginePlugin} provides execution capabilities.
+ */
+public enum Dialect {
+  HIVE,
+  SPARK,
+  TRINO
+}

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/spi/DialectPlugin.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/spi/DialectPlugin.java
@@ -7,11 +7,15 @@ package com.linkedin.coral.benchmark.spi;
 
 import org.apache.calcite.rel.RelNode;
 
-import com.linkedin.coral.common.catalog.CoralCatalog;
-
 
 /**
  * SPI for plugging a SQL dialect into the benchmark framework.
+ *
+ * <p>A {@code DialectPlugin} is a fully-constructed translator bound to a catalog. Instances
+ * are produced by a {@link DialectPluginProvider}, which is the registration entry point
+ * discovered via {@link java.util.ServiceLoader}. The factory split keeps plugins immutable
+ * (catalog-bound at construction time, no two-phase {@code init}) while still supporting
+ * standard SPI discovery, where the provider needs a no-arg constructor.
  *
  * <p>Each implementation wraps the existing Coral converters for a specific dialect:
  * <ul>
@@ -19,10 +23,6 @@ import com.linkedin.coral.common.catalog.CoralCatalog;
  *   <li>Trino: {@code TrinoToRelConverter} / {@code RelToTrinoConverter}</li>
  *   <li>Spark: {@code HiveToRelConverter} (Spark SQL parses as Hive) / {@code CoralSpark}</li>
  * </ul>
- *
- * <p>Implementations can be registered explicitly via
- * {@link com.linkedin.coral.benchmark.suite.TranslationTestSuite.Builder} or discovered
- * via {@link java.util.ServiceLoader}.
  */
 public interface DialectPlugin {
 
@@ -36,22 +36,19 @@ public interface DialectPlugin {
   /**
    * Parses a SQL string written in this dialect and converts it to Coral IR.
    *
-   * @param sql    a SELECT statement in this dialect's syntax
-   * @param catalog the catalog providing table metadata for query resolution
+   * @param sql a SELECT statement in this dialect's syntax
    * @return the Calcite {@link RelNode} representing the Coral intermediate representation
    * @throws IllegalArgumentException if the SQL cannot be parsed in this dialect
    */
-  RelNode toRelNode(String sql, CoralCatalog catalog);
+  RelNode toRelNode(String sql);
 
   /**
    * Converts a Coral IR {@link RelNode} into a SQL string in this dialect.
    *
    * @param relNode the Coral intermediate representation
-   * @param catalog the catalog providing table metadata (needed by some converters
-   *                for UDF resolution or type mapping)
    * @return a SQL string in this dialect's syntax
    * @throws UnsupportedOperationException if the IR contains constructs that cannot
    *         be expressed in this dialect
    */
-  String toDialectSql(RelNode relNode, CoralCatalog catalog);
+  String toDialectSql(RelNode relNode);
 }

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/spi/DialectPlugin.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/spi/DialectPlugin.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2017-2026 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.benchmark.spi;
+
+import org.apache.calcite.rel.RelNode;
+
+import com.linkedin.coral.common.catalog.CoralCatalog;
+
+
+/**
+ * SPI for plugging a SQL dialect into the benchmark framework.
+ *
+ * <p>Each implementation wraps the existing Coral converters for a specific dialect:
+ * <ul>
+ *   <li>Hive: {@code HiveToRelConverter} / {@code CoralRelToSqlNodeConverter}</li>
+ *   <li>Trino: {@code TrinoToRelConverter} / {@code RelToTrinoConverter}</li>
+ *   <li>Spark: {@code HiveToRelConverter} (Spark SQL parses as Hive) / {@code CoralSpark}</li>
+ * </ul>
+ *
+ * <p>Implementations can be registered explicitly via
+ * {@link com.linkedin.coral.benchmark.suite.TranslationTestSuite.Builder} or discovered
+ * via {@link java.util.ServiceLoader}.
+ */
+public interface DialectPlugin {
+
+  /**
+   * Returns the dialect this plugin handles.
+   *
+   * @return the dialect identifier
+   */
+  Dialect dialect();
+
+  /**
+   * Parses a SQL string written in this dialect and converts it to Coral IR.
+   *
+   * @param sql    a SELECT statement in this dialect's syntax
+   * @param catalog the catalog providing table metadata for query resolution
+   * @return the Calcite {@link RelNode} representing the Coral intermediate representation
+   * @throws IllegalArgumentException if the SQL cannot be parsed in this dialect
+   */
+  RelNode toRelNode(String sql, CoralCatalog catalog);
+
+  /**
+   * Converts a Coral IR {@link RelNode} into a SQL string in this dialect.
+   *
+   * @param relNode the Coral intermediate representation
+   * @param catalog the catalog providing table metadata (needed by some converters
+   *                for UDF resolution or type mapping)
+   * @return a SQL string in this dialect's syntax
+   * @throws UnsupportedOperationException if the IR contains constructs that cannot
+   *         be expressed in this dialect
+   */
+  String toDialectSql(RelNode relNode, CoralCatalog catalog);
+}

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/spi/DialectPluginProvider.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/spi/DialectPluginProvider.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2017-2026 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.benchmark.spi;
+
+import com.linkedin.coral.common.catalog.CoralCatalog;
+
+
+/**
+ * SPI for discovering and constructing {@link DialectPlugin} instances.
+ *
+ * <p>Provider implementations are the registration entry point picked up by
+ * {@link java.util.ServiceLoader}, so they must declare a public no-arg constructor and a
+ * {@code META-INF/services/com.linkedin.coral.benchmark.spi.DialectPluginProvider}
+ * file listing the implementing class. The provider is a thin factory: its only job is
+ * to produce a fully-constructed {@link DialectPlugin} bound to the supplied catalog,
+ * which lets the plugin keep its catalog reference {@code final} and avoids the
+ * two-phase-{@code init} pattern.
+ *
+ * <p>Typical implementation:
+ * <pre>{@code
+ * public final class HiveDialectPluginProvider implements DialectPluginProvider {
+ *     public Dialect dialect() { return Dialect.HIVE; }
+ *     public DialectPlugin create(CoralCatalog catalog) {
+ *         return new HiveDialectPlugin(catalog);
+ *     }
+ * }
+ * }</pre>
+ */
+public interface DialectPluginProvider {
+
+  /**
+   * Returns the dialect that this provider produces plugins for.
+   *
+   * @return the dialect identifier
+   */
+  Dialect dialect();
+
+  /**
+   * Constructs a {@link DialectPlugin} bound to the given catalog.
+   *
+   * @param catalog the catalog providing table metadata for query resolution and emission
+   * @return a new, fully-constructed plugin instance
+   */
+  DialectPlugin create(CoralCatalog catalog);
+}

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/spi/EnginePlugin.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/spi/EnginePlugin.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2017-2026 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.benchmark.spi;
+
+import com.linkedin.coral.benchmark.data.ExplainResult;
+import com.linkedin.coral.benchmark.data.ResultSet;
+import com.linkedin.coral.benchmark.data.RowSet;
+import com.linkedin.coral.common.types.CoralDataType;
+
+
+/**
+ * SPI for plugging a query execution engine into the benchmark framework.
+ *
+ * <p>Engine plugins are only required for {@link VerificationLevel#EXPLAIN} and
+ * {@link VerificationLevel#RESULT_SET}. Tests at {@link VerificationLevel#TRANSLATION}
+ * do not use engines at all.
+ *
+ * <p>Expected implementations:
+ * <ul>
+ *   <li>Spark: embedded {@code SparkSession}</li>
+ *   <li>Trino: Trino test harness with in-memory connector</li>
+ *   <li>Hive: embedded HiveServer2 or Tez local mode</li>
+ * </ul>
+ *
+ * <p>Lifecycle: {@link #start()} is called once before any queries are executed,
+ * and {@link #stop()} is called once after all queries complete. Between those calls,
+ * {@link #createTable}, {@link #loadData}, {@link #explain}, and {@link #execute}
+ * may be called in any order and any number of times.
+ */
+public interface EnginePlugin {
+
+  /**
+   * Returns the dialect this engine natively executes.
+   *
+   * @return the dialect identifier
+   */
+  Dialect dialect();
+
+  /**
+   * Starts the engine. Called once before any queries are executed.
+   * May be a no-op for engines that are always available (e.g., remote services).
+   */
+  void start();
+
+  /**
+   * Creates a table in the engine's catalog with the given schema.
+   * The table must be queryable after this call returns (though it may be empty
+   * until {@link #loadData} is called).
+   *
+   * @param namespace the namespace (database) name
+   * @param tableName the table name
+   * @param schema    the table schema as a Coral {@link CoralDataType} (typically a
+   *                  {@link com.linkedin.coral.common.types.StructType})
+   */
+  void createTable(String namespace, String tableName, CoralDataType schema);
+
+  /**
+   * Loads row data into a previously created table.
+   *
+   * @param namespace the namespace (database) name
+   * @param tableName the table name
+   * @param data      the rows to load
+   * @throws IllegalStateException if the table has not been created via {@link #createTable}
+   */
+  void loadData(String namespace, String tableName, RowSet data);
+
+  /**
+   * Runs EXPLAIN on the given SQL and returns the result.
+   * This validates that the engine can parse and plan the query without executing it.
+   *
+   * @param sql a SQL string in this engine's native dialect
+   * @return the explain result indicating success or failure with details
+   */
+  ExplainResult explain(String sql);
+
+  /**
+   * Executes the given SQL query and returns the result set.
+   *
+   * @param sql a SQL string in this engine's native dialect
+   * @return the query result set
+   */
+  ResultSet execute(String sql);
+
+  /**
+   * Stops and tears down the engine. Called once after all queries complete.
+   * Releases any resources acquired in {@link #start()}.
+   */
+  void stop();
+}

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/spi/VerificationLevel.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/spi/VerificationLevel.java
@@ -10,8 +10,8 @@ package com.linkedin.coral.benchmark.spi;
  * Each level subsumes the ones before it.
  *
  * <ul>
- *   <li>{@link #TRANSLATION} — Verifies that the translation pipeline (source SQL -> IR -> target SQL)
- *       completes without error and produces non-empty output.</li>
+ *   <li>{@link #TRANSLATION} — Verifies that the translation pipeline
+ *       (source SQL to IR to target SQL) completes without error and produces non-empty output.</li>
  *   <li>{@link #EXPLAIN} — Additionally runs the translated SQL through the target engine's EXPLAIN
  *       to validate syntax and query planning against the declared schema.</li>
  *   <li>{@link #RESULT_SET} — Additionally loads test data into both engines, executes the queries,

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/spi/VerificationLevel.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/spi/VerificationLevel.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2017-2026 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.benchmark.spi;
+
+/**
+ * Escalating levels of verification for cross-dialect translation tests.
+ * Each level subsumes the ones before it.
+ *
+ * <ul>
+ *   <li>{@link #TRANSLATION} — Verifies that the translation pipeline (source SQL -> IR -> target SQL)
+ *       completes without error and produces non-empty output.</li>
+ *   <li>{@link #EXPLAIN} — Additionally runs the translated SQL through the target engine's EXPLAIN
+ *       to validate syntax and query planning against the declared schema.</li>
+ *   <li>{@link #RESULT_SET} — Additionally loads test data into both engines, executes the queries,
+ *       and compares result sets for semantic equivalence.</li>
+ * </ul>
+ */
+public enum VerificationLevel {
+  /** Verify that translation from source to target dialect completes without error. */
+  TRANSLATION,
+
+  /** Verify translation + target engine can EXPLAIN the translated query. */
+  EXPLAIN,
+
+  /** Verify translation + EXPLAIN + result sets from both engines are equivalent. */
+  RESULT_SET
+}

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/suite/QueryTestResult.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/suite/QueryTestResult.java
@@ -28,17 +28,14 @@ public final class QueryTestResult {
   public enum Status {
     /** All requested verification levels passed. */
     PASS,
-    /** A verification level failed. */
-    FAIL,
-    /** The query was skipped (e.g., known unsupported construct). */
-    SKIP,
-    /** An unexpected error occurred during testing. */
-    ERROR
+    /** A verification level failed (translation error, explain failure, result mismatch,
+     *  or unexpected exception). */
+    FAIL
   }
 
   /**
    * Category of failure, indicating which stage of the pipeline failed.
-   * Only meaningful when {@link #getStatus()} is {@link Status#FAIL} or {@link Status#ERROR}.
+   * Only meaningful when {@link #getStatus()} is {@link Status#FAIL}.
    */
   public enum FailureCategory {
     /** The translation from source dialect through IR to target dialect failed. */
@@ -108,12 +105,12 @@ public final class QueryTestResult {
     return Optional.ofNullable(comparisonResult);
   }
 
-  /** Returns the failure category, if the test failed or errored. */
+  /** Returns the failure category, if the test failed. */
   public Optional<FailureCategory> getFailureCategory() {
     return Optional.ofNullable(failureCategory);
   }
 
-  /** Returns the error message, if the test failed or errored. */
+  /** Returns the error message, if the test failed. */
   public Optional<String> getErrorMessage() {
     return Optional.ofNullable(errorMessage);
   }

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/suite/QueryTestResult.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/suite/QueryTestResult.java
@@ -1,0 +1,198 @@
+/**
+ * Copyright 2017-2026 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.benchmark.suite;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import com.linkedin.coral.benchmark.comparison.ComparisonResult;
+import com.linkedin.coral.benchmark.data.ExplainResult;
+import com.linkedin.coral.benchmark.spi.VerificationLevel;
+
+
+/**
+ * The result of running a single query through the benchmark pipeline.
+ *
+ * <p>Contains the source SQL, translated SQL (if translation succeeded), and verification
+ * outcomes at each level that was executed. Tracks which verification level was requested
+ * and where the pipeline succeeded or failed.
+ */
+public final class QueryTestResult {
+
+  /**
+   * Outcome status for a single query test.
+   */
+  public enum Status {
+    /** All requested verification levels passed. */
+    PASS,
+    /** A verification level failed. */
+    FAIL,
+    /** The query was skipped (e.g., known unsupported construct). */
+    SKIP,
+    /** An unexpected error occurred during testing. */
+    ERROR
+  }
+
+  /**
+   * Category of failure, indicating which stage of the pipeline failed.
+   * Only meaningful when {@link #getStatus()} is {@link Status#FAIL} or {@link Status#ERROR}.
+   */
+  public enum FailureCategory {
+    /** The translation from source dialect through IR to target dialect failed. */
+    TRANSLATION_ERROR,
+    /** Translation succeeded but the target engine could not EXPLAIN the query. */
+    EXPLAIN_FAILURE,
+    /** Translation and EXPLAIN succeeded but result sets from the two engines differ. */
+    RESULT_MISMATCH
+  }
+
+  private final String queryName;
+  private final String sourceSql;
+  private final VerificationLevel requestedLevel;
+  private final Status status;
+  private final String translatedSql;
+  private final ExplainResult explainResult;
+  private final ComparisonResult comparisonResult;
+  private final FailureCategory failureCategory;
+  private final String errorMessage;
+  private final Exception exception;
+
+  private QueryTestResult(Builder builder) {
+    this.queryName = Objects.requireNonNull(builder.queryName);
+    this.sourceSql = Objects.requireNonNull(builder.sourceSql);
+    this.requestedLevel = Objects.requireNonNull(builder.requestedLevel);
+    this.status = Objects.requireNonNull(builder.status);
+    this.translatedSql = builder.translatedSql;
+    this.explainResult = builder.explainResult;
+    this.comparisonResult = builder.comparisonResult;
+    this.failureCategory = builder.failureCategory;
+    this.errorMessage = builder.errorMessage;
+    this.exception = builder.exception;
+  }
+
+  /** Returns the query file name (without path or extension). */
+  public String getQueryName() {
+    return queryName;
+  }
+
+  /** Returns the original SQL in the source dialect. */
+  public String getSourceSql() {
+    return sourceSql;
+  }
+
+  /** Returns the verification level that was requested for this query. */
+  public VerificationLevel getRequestedLevel() {
+    return requestedLevel;
+  }
+
+  /** Returns the overall status of this query test. */
+  public Status getStatus() {
+    return status;
+  }
+
+  /** Returns the SQL translated to the target dialect, if translation succeeded. */
+  public Optional<String> getTranslatedSql() {
+    return Optional.ofNullable(translatedSql);
+  }
+
+  /** Returns the EXPLAIN result, if EXPLAIN verification was performed. */
+  public Optional<ExplainResult> getExplainResult() {
+    return Optional.ofNullable(explainResult);
+  }
+
+  /** Returns the result-set comparison result, if result-set verification was performed. */
+  public Optional<ComparisonResult> getComparisonResult() {
+    return Optional.ofNullable(comparisonResult);
+  }
+
+  /** Returns the failure category, if the test failed or errored. */
+  public Optional<FailureCategory> getFailureCategory() {
+    return Optional.ofNullable(failureCategory);
+  }
+
+  /** Returns the error message, if the test failed or errored. */
+  public Optional<String> getErrorMessage() {
+    return Optional.ofNullable(errorMessage);
+  }
+
+  /** Returns the exception, if one was thrown during testing. */
+  public Optional<Exception> getException() {
+    return Optional.ofNullable(exception);
+  }
+
+  /**
+   * Creates a new builder.
+   *
+   * @param queryName      the query file name
+   * @param sourceSql      the original SQL
+   * @param requestedLevel the verification level requested
+   * @return a new builder
+   */
+  public static Builder builder(String queryName, String sourceSql, VerificationLevel requestedLevel) {
+    return new Builder(queryName, sourceSql, requestedLevel);
+  }
+
+  /**
+   * Builder for {@link QueryTestResult}.
+   */
+  public static final class Builder {
+    private final String queryName;
+    private final String sourceSql;
+    private final VerificationLevel requestedLevel;
+    private Status status;
+    private String translatedSql;
+    private ExplainResult explainResult;
+    private ComparisonResult comparisonResult;
+    private FailureCategory failureCategory;
+    private String errorMessage;
+    private Exception exception;
+
+    private Builder(String queryName, String sourceSql, VerificationLevel requestedLevel) {
+      this.queryName = queryName;
+      this.sourceSql = sourceSql;
+      this.requestedLevel = requestedLevel;
+    }
+
+    public Builder status(Status status) {
+      this.status = status;
+      return this;
+    }
+
+    public Builder translatedSql(String translatedSql) {
+      this.translatedSql = translatedSql;
+      return this;
+    }
+
+    public Builder explainResult(ExplainResult explainResult) {
+      this.explainResult = explainResult;
+      return this;
+    }
+
+    public Builder comparisonResult(ComparisonResult comparisonResult) {
+      this.comparisonResult = comparisonResult;
+      return this;
+    }
+
+    public Builder failureCategory(FailureCategory category) {
+      this.failureCategory = category;
+      return this;
+    }
+
+    public Builder errorMessage(String errorMessage) {
+      this.errorMessage = errorMessage;
+      return this;
+    }
+
+    public Builder exception(Exception exception) {
+      this.exception = exception;
+      return this;
+    }
+
+    public QueryTestResult build() {
+      return new QueryTestResult(this);
+    }
+  }
+}

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/suite/TestReport.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/suite/TestReport.java
@@ -81,25 +81,13 @@ public final class TestReport {
     return countByStatus(QueryTestResult.Status.FAIL);
   }
 
-  /** Returns the number of queries that were skipped. */
-  public int skipCount() {
-    return countByStatus(QueryTestResult.Status.SKIP);
-  }
-
-  /** Returns the number of queries that errored. */
-  public int errorCount() {
-    return countByStatus(QueryTestResult.Status.ERROR);
-  }
-
   /**
    * Returns the pass rate as a value between 0.0 and 1.0.
-   * Skipped queries are excluded from the denominator.
    *
-   * @return the pass rate, or 0.0 if no queries were executed
+   * @return the pass rate, or 0.0 if no queries were tested
    */
   public double passRate() {
-    int executed = totalCount() - skipCount();
-    return executed > 0 ? (double) passCount() / executed : 0.0;
+    return totalCount() > 0 ? (double) passCount() / totalCount() : 0.0;
   }
 
   /** Returns only the results that failed. */
@@ -109,16 +97,9 @@ public final class TestReport {
         .collect(Collectors.toList());
   }
 
-  /** Returns only the results that errored. */
-  public List<QueryTestResult> getErrors() {
-    return queryResults.stream()
-        .filter(r -> r.getStatus() == QueryTestResult.Status.ERROR)
-        .collect(Collectors.toList());
-  }
-
   /**
    * Returns failure counts broken down by category: translation error, explain failure,
-   * and result mismatch. Only includes results with status FAIL or ERROR that have a
+   * and result mismatch. Only includes results with status FAIL that have a
    * failure category set.
    *
    * @return a map from failure category to the count of queries in that category

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/suite/TestReport.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/suite/TestReport.java
@@ -92,9 +92,7 @@ public final class TestReport {
 
   /** Returns only the results that failed. */
   public List<QueryTestResult> getFailures() {
-    return queryResults.stream()
-        .filter(r -> r.getStatus() == QueryTestResult.Status.FAIL)
-        .collect(Collectors.toList());
+    return queryResults.stream().filter(r -> r.getStatus() == QueryTestResult.Status.FAIL).collect(Collectors.toList());
   }
 
   /**
@@ -110,8 +108,7 @@ public final class TestReport {
       counts.put(category, 0);
     }
     for (QueryTestResult result : queryResults) {
-      result.getFailureCategory().ifPresent(
-          category -> counts.merge(category, 1, Integer::sum));
+      result.getFailureCategory().ifPresent(category -> counts.merge(category, 1, Integer::sum));
     }
     return Collections.unmodifiableMap(counts);
   }
@@ -124,8 +121,7 @@ public final class TestReport {
    */
   public List<QueryTestResult> getFailuresByCategory(QueryTestResult.FailureCategory category) {
     Objects.requireNonNull(category);
-    return queryResults.stream()
-        .filter(r -> r.getFailureCategory().orElse(null) == category)
+    return queryResults.stream().filter(r -> r.getFailureCategory().orElse(null) == category)
         .collect(Collectors.toList());
   }
 

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/suite/TestReport.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/suite/TestReport.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright 2017-2026 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.benchmark.suite;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import com.linkedin.coral.benchmark.spi.Dialect;
+import com.linkedin.coral.benchmark.spi.VerificationLevel;
+
+
+/**
+ * Aggregate results of running a {@link TranslationTestSuite}.
+ *
+ * <p>Provides per-query results and aggregate statistics: pass rate, failure counts
+ * by category (translation error, explain failure, result mismatch), and the
+ * dialect pair and verification level that were tested.
+ */
+public final class TestReport {
+
+  private final Dialect sourceDialect;
+  private final Dialect targetDialect;
+  private final VerificationLevel verificationLevel;
+  private final List<QueryTestResult> queryResults;
+
+  /**
+   * Creates a new test report.
+   *
+   * @param sourceDialect     the source dialect
+   * @param targetDialect     the target dialect
+   * @param verificationLevel the verification level that was used
+   * @param queryResults      the per-query results
+   */
+  public TestReport(Dialect sourceDialect, Dialect targetDialect, VerificationLevel verificationLevel,
+      List<QueryTestResult> queryResults) {
+    this.sourceDialect = Objects.requireNonNull(sourceDialect);
+    this.targetDialect = Objects.requireNonNull(targetDialect);
+    this.verificationLevel = Objects.requireNonNull(verificationLevel);
+    this.queryResults = Collections.unmodifiableList(Objects.requireNonNull(queryResults));
+  }
+
+  /** Returns the source dialect that was tested. */
+  public Dialect getSourceDialect() {
+    return sourceDialect;
+  }
+
+  /** Returns the target dialect that was tested. */
+  public Dialect getTargetDialect() {
+    return targetDialect;
+  }
+
+  /** Returns the verification level that was used. */
+  public VerificationLevel getVerificationLevel() {
+    return verificationLevel;
+  }
+
+  /** Returns the per-query results. */
+  public List<QueryTestResult> getQueryResults() {
+    return queryResults;
+  }
+
+  /** Returns the total number of queries tested. */
+  public int totalCount() {
+    return queryResults.size();
+  }
+
+  /** Returns the number of queries that passed. */
+  public int passCount() {
+    return countByStatus(QueryTestResult.Status.PASS);
+  }
+
+  /** Returns the number of queries that failed. */
+  public int failCount() {
+    return countByStatus(QueryTestResult.Status.FAIL);
+  }
+
+  /** Returns the number of queries that were skipped. */
+  public int skipCount() {
+    return countByStatus(QueryTestResult.Status.SKIP);
+  }
+
+  /** Returns the number of queries that errored. */
+  public int errorCount() {
+    return countByStatus(QueryTestResult.Status.ERROR);
+  }
+
+  /**
+   * Returns the pass rate as a value between 0.0 and 1.0.
+   * Skipped queries are excluded from the denominator.
+   *
+   * @return the pass rate, or 0.0 if no queries were executed
+   */
+  public double passRate() {
+    int executed = totalCount() - skipCount();
+    return executed > 0 ? (double) passCount() / executed : 0.0;
+  }
+
+  /** Returns only the results that failed. */
+  public List<QueryTestResult> getFailures() {
+    return queryResults.stream()
+        .filter(r -> r.getStatus() == QueryTestResult.Status.FAIL)
+        .collect(Collectors.toList());
+  }
+
+  /** Returns only the results that errored. */
+  public List<QueryTestResult> getErrors() {
+    return queryResults.stream()
+        .filter(r -> r.getStatus() == QueryTestResult.Status.ERROR)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Returns failure counts broken down by category: translation error, explain failure,
+   * and result mismatch. Only includes results with status FAIL or ERROR that have a
+   * failure category set.
+   *
+   * @return a map from failure category to the count of queries in that category
+   */
+  public Map<QueryTestResult.FailureCategory, Integer> failureCountsByCategory() {
+    Map<QueryTestResult.FailureCategory, Integer> counts = new LinkedHashMap<>();
+    for (QueryTestResult.FailureCategory category : QueryTestResult.FailureCategory.values()) {
+      counts.put(category, 0);
+    }
+    for (QueryTestResult result : queryResults) {
+      result.getFailureCategory().ifPresent(
+          category -> counts.merge(category, 1, Integer::sum));
+    }
+    return Collections.unmodifiableMap(counts);
+  }
+
+  /**
+   * Returns the results that failed with a specific failure category.
+   *
+   * @param category the failure category to filter by
+   * @return the matching results
+   */
+  public List<QueryTestResult> getFailuresByCategory(QueryTestResult.FailureCategory category) {
+    Objects.requireNonNull(category);
+    return queryResults.stream()
+        .filter(r -> r.getFailureCategory().orElse(null) == category)
+        .collect(Collectors.toList());
+  }
+
+  private int countByStatus(QueryTestResult.Status status) {
+    return (int) queryResults.stream().filter(r -> r.getStatus() == status).count();
+  }
+}

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/suite/TranslationTestSuite.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/suite/TranslationTestSuite.java
@@ -320,18 +320,15 @@ public final class TranslationTestSuite {
       Objects.requireNonNull(verificationLevel, "Verification level is required");
 
       if (verificationLevel.ordinal() >= VerificationLevel.EXPLAIN.ordinal() && targetEngine == null) {
-        throw new IllegalStateException(
-            "Target engine is required for verification level " + verificationLevel);
+        throw new IllegalStateException("Target engine is required for verification level " + verificationLevel);
       }
 
       if (verificationLevel == VerificationLevel.RESULT_SET) {
         if (sourceEngine == null) {
-          throw new IllegalStateException(
-              "Source engine is required for RESULT_SET verification");
+          throw new IllegalStateException("Source engine is required for RESULT_SET verification");
         }
         if (testData.isEmpty()) {
-          throw new IllegalStateException(
-              "Test data is required for RESULT_SET verification");
+          throw new IllegalStateException("Test data is required for RESULT_SET verification");
         }
       }
 

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/suite/TranslationTestSuite.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/suite/TranslationTestSuite.java
@@ -108,7 +108,7 @@ public final class TranslationTestSuite {
    *
    * <p>For each query file, the pipeline is:
    * <ol>
-   *   <li><b>TRANSLATION:</b> sourcePlugin.toRelNode(sql) -> targetPlugin.toDialectSql(relNode)</li>
+   *   <li><b>TRANSLATION:</b> sourcePlugin.toRelNode(sql) then targetPlugin.toDialectSql(relNode)</li>
    *   <li><b>EXPLAIN:</b> (1) + targetEngine.explain(translatedSql)</li>
    *   <li><b>RESULT_SET:</b> (1) + (2) + sourceEngine.execute(sourceSql) vs
    *       targetEngine.execute(translatedSql), compared via ResultSetComparator</li>

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/suite/TranslationTestSuite.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/suite/TranslationTestSuite.java
@@ -1,0 +1,341 @@
+/**
+ * Copyright 2017-2026 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.benchmark.suite;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import com.linkedin.coral.benchmark.comparison.ComparisonConfig;
+import com.linkedin.coral.benchmark.data.RowSet;
+import com.linkedin.coral.benchmark.spi.Dialect;
+import com.linkedin.coral.benchmark.spi.DialectPlugin;
+import com.linkedin.coral.benchmark.spi.EnginePlugin;
+import com.linkedin.coral.benchmark.spi.VerificationLevel;
+import com.linkedin.coral.common.catalog.CoralCatalog;
+
+
+/**
+ * Main orchestrator for cross-dialect translation benchmark tests.
+ *
+ * <p>A test suite is parameterized by source dialect, target dialect, verification level,
+ * and the catalog/data/engines needed for that level. It reads all {@code .sql} files from
+ * a query directory, translates each through the Coral IR pipeline, and verifies the result
+ * at the configured level.
+ *
+ * <p>Usage (Level 1 - translation only):
+ * <pre>{@code
+ * TranslationTestSuite suite = TranslationTestSuite.builder()
+ *     .source(Dialect.HIVE)
+ *     .target(Dialect.TRINO)
+ *     .catalog(catalog)
+ *     .queryDir("queries/hive")
+ *     .verificationLevel(VerificationLevel.TRANSLATION)
+ *     .build();
+ *
+ * TestReport report = suite.run();
+ * }</pre>
+ *
+ * <p>Usage (Level 2 - EXPLAIN):
+ * <pre>{@code
+ * TranslationTestSuite suite = TranslationTestSuite.builder()
+ *     .source(Dialect.HIVE)
+ *     .target(Dialect.TRINO)
+ *     .catalog(catalog)
+ *     .queryDir("queries/hive")
+ *     .verificationLevel(VerificationLevel.EXPLAIN)
+ *     .targetEngine(new TrinoEnginePlugin())
+ *     .build();
+ *
+ * TestReport report = suite.run();
+ * }</pre>
+ *
+ * <p>Usage (Level 3 - result set comparison):
+ * <pre>{@code
+ * TranslationTestSuite suite = TranslationTestSuite.builder()
+ *     .source(Dialect.HIVE)
+ *     .target(Dialect.TRINO)
+ *     .catalog(catalog)
+ *     .queryDir("queries/hive")
+ *     .verificationLevel(VerificationLevel.RESULT_SET)
+ *     .testData("db.users", userData)
+ *     .testData("db.events", eventData)
+ *     .sourceEngine(new SparkEnginePlugin())
+ *     .targetEngine(new TrinoEnginePlugin())
+ *     .comparisonConfig(ComparisonConfig.builder()
+ *         .floatingPointEpsilon(1e-6)
+ *         .build())
+ *     .build();
+ *
+ * TestReport report = suite.run();
+ * }</pre>
+ */
+public final class TranslationTestSuite {
+
+  private final Dialect source;
+  private final Dialect target;
+  private final CoralCatalog catalog;
+  private final String queryDir;
+  private final VerificationLevel verificationLevel;
+  private final DialectPlugin sourcePlugin;
+  private final DialectPlugin targetPlugin;
+  private final EnginePlugin sourceEngine;
+  private final EnginePlugin targetEngine;
+  private final Map<String, RowSet> testData;
+  private final ComparisonConfig comparisonConfig;
+
+  private TranslationTestSuite(Builder builder) {
+    this.source = builder.source;
+    this.target = builder.target;
+    this.catalog = builder.catalog;
+    this.queryDir = builder.queryDir;
+    this.verificationLevel = builder.verificationLevel;
+    this.sourcePlugin = builder.sourcePlugin;
+    this.targetPlugin = builder.targetPlugin;
+    this.sourceEngine = builder.sourceEngine;
+    this.targetEngine = builder.targetEngine;
+    this.testData = Collections.unmodifiableMap(new HashMap<>(builder.testData));
+    this.comparisonConfig = builder.comparisonConfig;
+  }
+
+  /**
+   * Runs the test suite: reads all .sql files from the query directory, translates each,
+   * and verifies at the configured level.
+   *
+   * <p>For each query file, the pipeline is:
+   * <ol>
+   *   <li><b>TRANSLATION:</b> sourcePlugin.toRelNode(sql) -> targetPlugin.toDialectSql(relNode)</li>
+   *   <li><b>EXPLAIN:</b> (1) + targetEngine.explain(translatedSql)</li>
+   *   <li><b>RESULT_SET:</b> (1) + (2) + sourceEngine.execute(sourceSql) vs
+   *       targetEngine.execute(translatedSql), compared via ResultSetComparator</li>
+   * </ol>
+   *
+   * <p>Engine lifecycle is managed automatically: start() is called before the first query,
+   * and stop() is called after the last query, even if exceptions occur.
+   *
+   * @return the test report with per-query results and aggregate statistics
+   */
+  public TestReport run() {
+    // Implementation will:
+    // 1. Discover/load .sql files from queryDir
+    // 2. Start engines if needed (EXPLAIN or RESULT_SET level)
+    // 3. For RESULT_SET: create tables and load test data into both engines
+    // 4. For each query: translate, verify at each level up to requested, collect result
+    // 5. Stop engines
+    // 6. Build and return TestReport
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  /**
+   * Creates a new builder.
+   *
+   * @return a new builder
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder for {@link TranslationTestSuite}.
+   *
+   * <p>Required for all levels: source, target, catalog, queryDir, verificationLevel.
+   * <p>Required for EXPLAIN: targetEngine (or both sourcePlugin and targetPlugin if not using ServiceLoader).
+   * <p>Required for RESULT_SET: sourceEngine, targetEngine, testData.
+   */
+  public static final class Builder {
+    private Dialect source;
+    private Dialect target;
+    private CoralCatalog catalog;
+    private String queryDir;
+    private VerificationLevel verificationLevel;
+    private DialectPlugin sourcePlugin;
+    private DialectPlugin targetPlugin;
+    private EnginePlugin sourceEngine;
+    private EnginePlugin targetEngine;
+    private final Map<String, RowSet> testData = new HashMap<>();
+    private ComparisonConfig comparisonConfig = ComparisonConfig.defaults();
+
+    private Builder() {
+    }
+
+    /**
+     * Sets the source dialect.
+     *
+     * @param source the dialect of the input queries
+     * @return this builder
+     */
+    public Builder source(Dialect source) {
+      this.source = Objects.requireNonNull(source);
+      return this;
+    }
+
+    /**
+     * Sets the target dialect.
+     *
+     * @param target the dialect to translate queries into
+     * @return this builder
+     */
+    public Builder target(Dialect target) {
+      this.target = Objects.requireNonNull(target);
+      return this;
+    }
+
+    /**
+     * Sets the catalog providing table metadata for query resolution.
+     *
+     * @param catalog the catalog (typically an {@link com.linkedin.coral.benchmark.catalog.InMemoryCatalog})
+     * @return this builder
+     */
+    public Builder catalog(CoralCatalog catalog) {
+      this.catalog = Objects.requireNonNull(catalog);
+      return this;
+    }
+
+    /**
+     * Sets the directory containing .sql query files.
+     * Path is relative to the classpath (test resources).
+     *
+     * @param queryDir the directory path (e.g., "queries/hive")
+     * @return this builder
+     */
+    public Builder queryDir(String queryDir) {
+      this.queryDir = Objects.requireNonNull(queryDir);
+      return this;
+    }
+
+    /**
+     * Sets the verification level.
+     *
+     * @param level the level of verification to perform
+     * @return this builder
+     */
+    public Builder verificationLevel(VerificationLevel level) {
+      this.verificationLevel = Objects.requireNonNull(level);
+      return this;
+    }
+
+    /**
+     * Explicitly sets the source dialect plugin. If not set, the plugin is resolved
+     * via {@link java.util.ServiceLoader} based on the source dialect.
+     *
+     * @param plugin the source dialect plugin
+     * @return this builder
+     */
+    public Builder sourcePlugin(DialectPlugin plugin) {
+      this.sourcePlugin = Objects.requireNonNull(plugin);
+      return this;
+    }
+
+    /**
+     * Explicitly sets the target dialect plugin. If not set, the plugin is resolved
+     * via {@link java.util.ServiceLoader} based on the target dialect.
+     *
+     * @param plugin the target dialect plugin
+     * @return this builder
+     */
+    public Builder targetPlugin(DialectPlugin plugin) {
+      this.targetPlugin = Objects.requireNonNull(plugin);
+      return this;
+    }
+
+    /**
+     * Sets the engine for executing queries in the source dialect.
+     * Required for {@link VerificationLevel#RESULT_SET}.
+     *
+     * @param engine the source engine
+     * @return this builder
+     */
+    public Builder sourceEngine(EnginePlugin engine) {
+      this.sourceEngine = Objects.requireNonNull(engine);
+      return this;
+    }
+
+    /**
+     * Sets the engine for executing queries in the target dialect.
+     * Required for {@link VerificationLevel#EXPLAIN} and {@link VerificationLevel#RESULT_SET}.
+     *
+     * @param engine the target engine
+     * @return this builder
+     */
+    public Builder targetEngine(EnginePlugin engine) {
+      this.targetEngine = Objects.requireNonNull(engine);
+      return this;
+    }
+
+    /**
+     * Adds test data for a table. The key is the fully qualified table name
+     * (e.g., "db.users"). Required for {@link VerificationLevel#RESULT_SET}.
+     *
+     * @param qualifiedTableName the fully qualified table name ("namespace.table")
+     * @param data               the row data
+     * @return this builder
+     */
+    public Builder testData(String qualifiedTableName, RowSet data) {
+      Objects.requireNonNull(qualifiedTableName);
+      Objects.requireNonNull(data);
+      this.testData.put(qualifiedTableName, data);
+      return this;
+    }
+
+    /**
+     * Adds test data for multiple tables at once.
+     *
+     * @param testData a map from fully qualified table names to row data
+     * @return this builder
+     */
+    public Builder testData(Map<String, RowSet> testData) {
+      Objects.requireNonNull(testData);
+      this.testData.putAll(testData);
+      return this;
+    }
+
+    /**
+     * Sets the comparison config for result-set comparison. Defaults to
+     * {@link ComparisonConfig#defaults()} if not set.
+     *
+     * @param config the comparison config
+     * @return this builder
+     */
+    public Builder comparisonConfig(ComparisonConfig config) {
+      this.comparisonConfig = Objects.requireNonNull(config);
+      return this;
+    }
+
+    /**
+     * Builds the test suite, validating that all required configuration is present
+     * for the requested verification level.
+     *
+     * @return a new TranslationTestSuite
+     * @throws IllegalStateException if required configuration is missing
+     */
+    public TranslationTestSuite build() {
+      Objects.requireNonNull(source, "Source dialect is required");
+      Objects.requireNonNull(target, "Target dialect is required");
+      Objects.requireNonNull(catalog, "Catalog is required");
+      Objects.requireNonNull(queryDir, "Query directory is required");
+      Objects.requireNonNull(verificationLevel, "Verification level is required");
+
+      if (verificationLevel.ordinal() >= VerificationLevel.EXPLAIN.ordinal() && targetEngine == null) {
+        throw new IllegalStateException(
+            "Target engine is required for verification level " + verificationLevel);
+      }
+
+      if (verificationLevel == VerificationLevel.RESULT_SET) {
+        if (sourceEngine == null) {
+          throw new IllegalStateException(
+              "Source engine is required for RESULT_SET verification");
+        }
+        if (testData.isEmpty()) {
+          throw new IllegalStateException(
+              "Test data is required for RESULT_SET verification");
+        }
+      }
+
+      return new TranslationTestSuite(this);
+    }
+  }
+}

--- a/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/suite/TranslationTestSuite.java
+++ b/coral-benchmark/src/main/java/com/linkedin/coral/benchmark/suite/TranslationTestSuite.java
@@ -9,11 +9,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.ServiceLoader;
 
 import com.linkedin.coral.benchmark.comparison.ComparisonConfig;
 import com.linkedin.coral.benchmark.data.RowSet;
 import com.linkedin.coral.benchmark.spi.Dialect;
 import com.linkedin.coral.benchmark.spi.DialectPlugin;
+import com.linkedin.coral.benchmark.spi.DialectPluginProvider;
 import com.linkedin.coral.benchmark.spi.EnginePlugin;
 import com.linkedin.coral.benchmark.spi.VerificationLevel;
 import com.linkedin.coral.common.catalog.CoralCatalog;
@@ -88,14 +90,14 @@ public final class TranslationTestSuite {
   private final Map<String, RowSet> testData;
   private final ComparisonConfig comparisonConfig;
 
-  private TranslationTestSuite(Builder builder) {
+  private TranslationTestSuite(Builder builder, DialectPlugin sourcePlugin, DialectPlugin targetPlugin) {
     this.source = builder.source;
     this.target = builder.target;
     this.catalog = builder.catalog;
     this.queryDir = builder.queryDir;
     this.verificationLevel = builder.verificationLevel;
-    this.sourcePlugin = builder.sourcePlugin;
-    this.targetPlugin = builder.targetPlugin;
+    this.sourcePlugin = sourcePlugin;
+    this.targetPlugin = targetPlugin;
     this.sourceEngine = builder.sourceEngine;
     this.targetEngine = builder.targetEngine;
     this.testData = Collections.unmodifiableMap(new HashMap<>(builder.testData));
@@ -108,10 +110,12 @@ public final class TranslationTestSuite {
    *
    * <p>For each query file, the pipeline is:
    * <ol>
-   *   <li><b>TRANSLATION:</b> sourcePlugin.toRelNode(sql) then targetPlugin.toDialectSql(relNode)</li>
-   *   <li><b>EXPLAIN:</b> (1) + targetEngine.explain(translatedSql)</li>
-   *   <li><b>RESULT_SET:</b> (1) + (2) + sourceEngine.execute(sourceSql) vs
-   *       targetEngine.execute(translatedSql), compared via ResultSetComparator</li>
+   *   <li><b>TRANSLATION:</b> {@code sourcePlugin.toRelNode(sql)} then
+   *       {@code targetPlugin.toDialectSql(relNode)}</li>
+   *   <li><b>EXPLAIN:</b> (1) + {@code targetEngine.explain(translatedSql)}</li>
+   *   <li><b>RESULT_SET:</b> (1) + (2) + {@code sourceEngine.execute(sourceSql)} vs
+   *       {@code targetEngine.execute(translatedSql)}, compared via
+   *       {@code ResultSetComparator}</li>
    * </ol>
    *
    * <p>Engine lifecycle is managed automatically: start() is called before the first query,
@@ -143,8 +147,15 @@ public final class TranslationTestSuite {
    * Builder for {@link TranslationTestSuite}.
    *
    * <p>Required for all levels: source, target, catalog, queryDir, verificationLevel.
-   * <p>Required for EXPLAIN: targetEngine (or both sourcePlugin and targetPlugin if not using ServiceLoader).
+   * <p>Required for EXPLAIN: targetEngine.
    * <p>Required for RESULT_SET: sourceEngine, targetEngine, testData.
+   *
+   * <p>Dialect plugins are resolved by matching {@link DialectPluginProvider#dialect()}
+   * against the configured source and target dialects, using
+   * {@link java.util.ServiceLoader} discovery by default. Callers may override either
+   * provider explicitly via {@link #sourcePluginProvider} or {@link #targetPluginProvider}
+   * (e.g. for tests, or to inject a non-discovered implementation). The framework calls
+   * {@code provider.create(catalog)} during {@link #build()} to materialize the plugin.
    */
   public static final class Builder {
     private Dialect source;
@@ -152,8 +163,8 @@ public final class TranslationTestSuite {
     private CoralCatalog catalog;
     private String queryDir;
     private VerificationLevel verificationLevel;
-    private DialectPlugin sourcePlugin;
-    private DialectPlugin targetPlugin;
+    private DialectPluginProvider sourcePluginProvider;
+    private DialectPluginProvider targetPluginProvider;
     private EnginePlugin sourceEngine;
     private EnginePlugin targetEngine;
     private final Map<String, RowSet> testData = new HashMap<>();
@@ -219,26 +230,28 @@ public final class TranslationTestSuite {
     }
 
     /**
-     * Explicitly sets the source dialect plugin. If not set, the plugin is resolved
-     * via {@link java.util.ServiceLoader} based on the source dialect.
+     * Explicitly sets the provider used to construct the source dialect plugin. If not
+     * set, the provider is resolved via {@link java.util.ServiceLoader} based on the
+     * source dialect.
      *
-     * @param plugin the source dialect plugin
+     * @param provider the source dialect plugin provider
      * @return this builder
      */
-    public Builder sourcePlugin(DialectPlugin plugin) {
-      this.sourcePlugin = Objects.requireNonNull(plugin);
+    public Builder sourcePluginProvider(DialectPluginProvider provider) {
+      this.sourcePluginProvider = Objects.requireNonNull(provider);
       return this;
     }
 
     /**
-     * Explicitly sets the target dialect plugin. If not set, the plugin is resolved
-     * via {@link java.util.ServiceLoader} based on the target dialect.
+     * Explicitly sets the provider used to construct the target dialect plugin. If not
+     * set, the provider is resolved via {@link java.util.ServiceLoader} based on the
+     * target dialect.
      *
-     * @param plugin the target dialect plugin
+     * @param provider the target dialect plugin provider
      * @return this builder
      */
-    public Builder targetPlugin(DialectPlugin plugin) {
-      this.targetPlugin = Objects.requireNonNull(plugin);
+    public Builder targetPluginProvider(DialectPluginProvider provider) {
+      this.targetPluginProvider = Objects.requireNonNull(provider);
       return this;
     }
 
@@ -332,7 +345,26 @@ public final class TranslationTestSuite {
         }
       }
 
-      return new TranslationTestSuite(this);
+      DialectPluginProvider resolvedSourceProvider =
+          sourcePluginProvider != null ? sourcePluginProvider : resolveProvider(source);
+      DialectPluginProvider resolvedTargetProvider =
+          targetPluginProvider != null ? targetPluginProvider : resolveProvider(target);
+
+      DialectPlugin sourcePlugin = resolvedSourceProvider.create(catalog);
+      DialectPlugin targetPlugin = resolvedTargetProvider.create(catalog);
+
+      return new TranslationTestSuite(this, sourcePlugin, targetPlugin);
+    }
+
+    private static DialectPluginProvider resolveProvider(Dialect dialect) {
+      for (DialectPluginProvider provider : ServiceLoader.load(DialectPluginProvider.class)) {
+        if (provider.dialect() == dialect) {
+          return provider;
+        }
+      }
+      throw new IllegalStateException("No DialectPluginProvider registered for dialect " + dialect
+          + ". Set one explicitly via sourcePluginProvider/targetPluginProvider, or add a " + "META-INF/services/"
+          + DialectPluginProvider.class.getName() + " entry.");
     }
   }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,7 @@ pluginManagement {
   }
 }
 
+include 'coral-benchmark'
 include 'coral-common'
 include 'coral-dbt'
 include 'coral-hive'


### PR DESCRIPTION
# Add coral-benchmark module for cross-dialect translation testing

## Summary

Adds a new `coral-benchmark` module that provides a framework for testing Coral translations end-to-end between any pair of supported dialects (Hive, Spark, Trino). This is the API design — interfaces, data types, and the orchestration layer — ready for implementation to be filled in.

## Motivation

Coral's existing tests verify individual dialect converters in isolation (e.g., Hive-to-Trino, Hive-to-Spark). There is no unified way to test arbitrary dialect-to-dialect translations, validate that translated queries are syntactically valid on the target engine, or compare query results across engines for semantic equivalence. This module closes that gap.

## Design

The framework is built around two SPIs and three verification levels:

**SPIs:**
- `DialectPlugin` — wraps existing Coral converters (`HiveToRelConverter`, `TrinoToRelConverter`, `RelToTrinoConverter`, `CoralSpark`) behind a uniform `toRelNode()` / `toDialectSql()` interface.
- `EnginePlugin` — provides execution capabilities (`createTable`, `loadData`, `explain`, `execute`) for embedded engines (Spark, Trino, Hive).

**Verification levels (escalating):**
1. **TRANSLATION** — source SQL -> Coral IR -> target SQL completes without error.
2. **EXPLAIN** — the translated SQL passes the target engine's EXPLAIN (syntax + planning validation).
3. **RESULT_SET** — query results from source and target engines are compared for semantic equivalence, with configurable tolerances for floating-point precision, row ordering, NULL handling, and type widening.

**Supporting components:**
- `InMemoryCatalog` — an in-memory `CoralCatalog` implementation using the Coral type system (`StructType`, `PrimitiveType`, etc.) so tests have no external metastore dependency.
- `RowSet` / `ResultSet` — typed tabular data containers for loading test data and capturing query results.
- `ResultSetComparator` with `ComparisonConfig` — configurable comparison logic for cross-engine result equivalence.
- `TranslationTestSuite` — builder-configured orchestrator that reads `.sql` files from a query directory and runs each through the configured pipeline.
- `TestReport` / `QueryTestResult` — structured reporting with per-query outcomes and aggregate failure categorization (translation error, explain failure, result mismatch).

## What's included

- 15 Java source files across 5 packages (`spi`, `catalog`, `data`, `comparison`, `suite`)
- `build.gradle` with `api` dependency on `:coral-common`
- The testing spec document (`coral-benchmark-spec.md`)
- Module registered in `settings.gradle`
- Compiles cleanly via `./gradlew :coral-benchmark:compileJava`

## What's not included (yet)

- Concrete `DialectPlugin` implementations (Hive, Spark, Trino)
- Concrete `EnginePlugin` implementations (embedded Spark, Trino)
- `ResultSetComparator.compare()` implementation
- `TranslationTestSuite.run()` implementation
- Query corpus (`.sql` test files)
