### PR TITLE
Fix Coral parse failure for non-reserved keywords used as table aliases

### DIFF
--- a/coral-hive/src/main/antlr/imports/FromClauseParser.g
+++ b/coral-hive/src/main/antlr/imports/FromClauseParser.g
@@ -186,10 +186,16 @@ tableSource
     : tabname=tableName
     ((tableProperties) => props=tableProperties)?
     ((tableSample) => ts=tableSample)?
-    ((KW_AS) => (KW_AS alias=Identifier)
+    ((KW_AS) => (KW_AS asAlias=identifier)
     |
-    (Identifier) => (alias=Identifier))?
-    -> ^(TOK_TABREF $tabname $props? $ts? $alias?)
+    (tableAliasCandidate) => (implicitAlias=tableAliasCandidate))?
+    -> ^(TOK_TABREF $tabname $props? $ts? $asAlias? $implicitAlias?)
+    ;
+
+tableAliasCandidate
+    :
+    Identifier
+    | nonReserved -> Identifier[$nonReserved.text]
     ;
 
 tableName

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/parsetree/ParseTreeBuilderTest.java
@@ -248,4 +248,61 @@ public class ParseTreeBuilderTest {
     // Validate if the translation is successful
     assertEquals(sqlNode.toString().replaceAll("\\r?\\n", " "), table.getViewExpandedText());
   }
+
+  /**
+   * Validates that non-reserved keywords (e.g., collection, comment, role — listed under the
+   * {@code nonReserved} rule in the Hive grammar) can be used as unquoted table aliases in FROM
+   * clauses. This is needed because Hive's CBO automatically adds the table name as an unquoted
+   * alias when persisting view definitions.
+   * See BDP-70589.
+   */
+  @DataProvider(name = "nonReservedKeywordImplicitAlias")
+  public Object[][] getNonReservedKeywordImplicitAliasSql() {
+    return new Object[][] { { "SELECT collection.a FROM test.tableOne collection WHERE collection.a > 0", "SELECT `collection`.`a`\nFROM `test`.`tableOne` AS `collection`\nWHERE `collection`.`a` > 0" }, { "SELECT comment.a FROM test.tableOne comment WHERE comment.a > 0", "SELECT `comment`.`a`\nFROM `test`.`tableOne` AS `comment`\nWHERE `comment`.`a` > 0" }, { "SELECT role.a FROM test.tableOne role WHERE role.a > 0", "SELECT `role`.`a`\nFROM `test`.`tableOne` AS `role`\nWHERE `role`.`a` > 0" }, { "SELECT data.a FROM test.tableOne data WHERE data.a > 0", "SELECT `data`.`a`\nFROM `test`.`tableOne` AS `data`\nWHERE `data`.`a` > 0" }, { "SELECT schema.a FROM test.tableOne schema WHERE schema.a > 0", "SELECT `schema`.`a`\nFROM `test`.`tableOne` AS `schema`\nWHERE `schema`.`a` > 0" }, { "SELECT view.a FROM test.tableOne view WHERE view.a > 0", "SELECT `view`.`a`\nFROM `test`.`tableOne` AS `view`\nWHERE `view`.`a` > 0" }, { "SELECT index.a FROM test.tableOne index WHERE index.a > 0", "SELECT `index`.`a`\nFROM `test`.`tableOne` AS `index`\nWHERE `index`.`a` > 0" }, { "SELECT enable.a FROM test.tableOne enable WHERE enable.a > 0", "SELECT `enable`.`a`\nFROM `test`.`tableOne` AS `enable`\nWHERE `enable`.`a` > 0" }, };
+  }
+
+  @Test(dataProvider = "nonReservedKeywordImplicitAlias")
+  public void testNonReservedKeywordAsImplicitAlias(String input, String expected) {
+    SqlNode sqlNode = convert(input);
+    assertNotNull(sqlNode, "Failed to parse SQL with nonReserved keyword as implicit alias: " + input);
+    assertEquals(sqlNode.toString(), expected);
+  }
+
+  @DataProvider(name = "nonReservedKeywordExplicitAlias")
+  public Object[][] getNonReservedKeywordExplicitAliasSql() {
+    return new Object[][] { { "SELECT collection.a FROM test.tableOne AS collection WHERE collection.a > 0", "SELECT `collection`.`a`\nFROM `test`.`tableOne` AS `collection`\nWHERE `collection`.`a` > 0" }, { "SELECT role.a FROM test.tableOne AS role WHERE role.a > 0", "SELECT `role`.`a`\nFROM `test`.`tableOne` AS `role`\nWHERE `role`.`a` > 0" }, };
+  }
+
+  @Test(dataProvider = "nonReservedKeywordExplicitAlias")
+  public void testNonReservedKeywordAsExplicitAlias(String input, String expected) {
+    SqlNode sqlNode = convert(input);
+    assertNotNull(sqlNode, "Failed to parse SQL with nonReserved keyword as explicit AS alias: " + input);
+    assertEquals(sqlNode.toString(), expected);
+  }
+
+  @DataProvider(name = "sql11KeywordExplicitAlias")
+  public Object[][] getSql11KeywordExplicitAliasSql() {
+    return new Object[][] { { "SELECT a FROM test.tableOne AS group WHERE a > 0", "SELECT `a`\nFROM `test`.`tableOne` AS `group`\nWHERE `a` > 0" }, { "SELECT a FROM test.tableOne AS union WHERE a > 0", "SELECT `a`\nFROM `test`.`tableOne` AS `union`\nWHERE `a` > 0" }, { "SELECT a FROM test.tableOne AS inner WHERE a > 0", "SELECT `a`\nFROM `test`.`tableOne` AS `inner`\nWHERE `a` > 0" }, { "SELECT a FROM test.tableOne AS left WHERE a > 0", "SELECT `a`\nFROM `test`.`tableOne` AS `left`\nWHERE `a` > 0" }, { "SELECT a FROM test.tableOne AS order WHERE a > 0", "SELECT `a`\nFROM `test`.`tableOne` AS `order`\nWHERE `a` > 0" }, { "SELECT a FROM test.tableOne AS table WHERE a > 0", "SELECT `a`\nFROM `test`.`tableOne` AS `table`\nWHERE `a` > 0" }, };
+  }
+
+  @Test(dataProvider = "sql11KeywordExplicitAlias")
+  public void testSql11KeywordAsExplicitAlias(String input, String expected) {
+    SqlNode sqlNode = convert(input);
+    assertNotNull(sqlNode, "Failed to parse SQL with sql11 keyword as explicit AS alias: " + input);
+    assertEquals(sqlNode.toString(), expected);
+  }
+
+  @DataProvider(name = "sql11KeywordNotConsumedAsAlias")
+  public Object[][] getSql11KeywordNotConsumedAsAliasSql() {
+    return new Object[][] { { "SELECT a FROM test.tableOne group BY a", "GROUP BY" }, { "SELECT a FROM test.tableOne order BY a", "ORDER BY" }, { "SELECT test.tableOne.a FROM test.tableOne inner JOIN test.tableTwo ON test.tableOne.a = test.tableTwo.x", "INNER JOIN" }, { "SELECT test.tableOne.a FROM test.tableOne left JOIN test.tableTwo ON test.tableOne.a = test.tableTwo.x", "LEFT JOIN" }, { "SELECT test.tableOne.a FROM test.tableOne full OUTER JOIN test.tableTwo ON test.tableOne.a = test.tableTwo.x", "FULL" }, { "SELECT a FROM test.tableOne union SELECT x FROM test.tableTwo", "UNION" }, };
+  }
+
+  @Test(dataProvider = "sql11KeywordNotConsumedAsAlias")
+  public void testSql11KeywordNotConsumedAsAlias(String input, String expectedClause) {
+    SqlNode sqlNode = convert(input);
+    assertNotNull(sqlNode, "Failed to parse SQL where sql11 keyword should not be alias: " + input);
+    String result = sqlNode.toString();
+    assertTrue(result.contains(expectedClause),
+        expectedClause + " should be parsed as SQL clause, not alias: " + result);
+  }
 }

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/CoralSparkTest.java
@@ -1037,6 +1037,14 @@ public class CoralSparkTest {
     return coralSpark.getSparkSql();
   }
 
+  @Test
+  public void testReservedKeywordAsTableAlias() {
+    RelNode relNode = TestUtils.toRelNode("default", "view_reserved_keyword_alias");
+    CoralSpark coralSpark = createCoralSpark(relNode);
+    String sparkSql = coralSpark.getSparkSql();
+    assertEquals(sparkSql, "SELECT *\nFROM default.collection collection\nWHERE collection.a > 0");
+  }
+
   private CoralSpark createCoralSpark(RelNode relNode) {
     return CoralSpark.create(relNode, getHiveMetastoreClient());
   }

--- a/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
+++ b/coral-spark/src/test/java/com/linkedin/coral/spark/TestUtils.java
@@ -243,6 +243,10 @@ public class TestUtils {
         "tblproperties('functions' = 'LessThanHundred_versioning_prefix_0_1_x:coral_udf_version_0_1_x.com.linkedin.coral.hive.hive2rel.CoralTestVersionedUDF',",
         "              'dependencies' = 'ivy://com.linkedin:udf-shaded:1.0')", "AS",
         "SELECT LessThanHundred_versioning_prefix_0_1_x(a)", "FROM foo"));
+
+    run(driver, "CREATE TABLE IF NOT EXISTS `collection`(a int, b string)");
+    run(driver,
+        "CREATE VIEW IF NOT EXISTS view_reserved_keyword_alias AS SELECT `collection`.a, `collection`.b FROM default.`collection` `collection` WHERE `collection`.a > 0");
   }
 
   private static void executeCreateTableQuery(Driver driver, String dbName, String tableName, String schema) {


### PR DESCRIPTION
### What changes are proposed in this pull request, and why are they necessary?
When Hive stores a view, its Cost-Based Optimizer (CBO) automatically
    appends the table name as an unquoted alias to every table reference:

      -- You write:
      CREATE VIEW v AS SELECT * FROM db.collection WHERE x > 0
      -- Hive stores:
      SELECT * FROM db.collection collection WHERE x > 0

When the table name is a Hive non-reserved keyword (e.g., collection, comment, role — listed under the nonReserved rule in the Hive grammar), Coral's parser fails because the tableSource grammar rule only accepted Identifier lexer tokens as aliases. ANTLR tokenizes keywords like "collection" as KW_COLLECTION, not Identifier, so they could not match.

The fix introduces a tableAliasCandidate parser rule that accepts Identifier | nonReserved keywords, and uses it for implicit (non-AS) table aliases. The nonReserved set includes keywords like collection, comment, and role that are safe to use as identifiers.

Using the full identifier rule was not safe because Coral sets useSQL11ReservedKeywordsForIdentifier() to true, which makes identifier also match structural SQL keywords (UNION, INNER, GROUP, LEFT, etc.).
This caused the parser to consume these keywords as table aliases instead of recognizing them as SQL operators. For example:

      SELECT * FROM test.bar1 UNION SELECT * FROM test.bar2
                              ^^^^^ consumed as alias -> parse failure

      SELECT * FROM test.bar1 INNER JOIN test.bar2 ON ...
                              ^^^^^ consumed as alias -> parse failure

The explicit KW_AS alias branch still uses the full identifier rule since AS provides unambiguous disambiguation:
      SELECT * FROM db.group AS group WHERE ...  -- works

### How was this patch tested?
- New unit tests added
- Tested the change with LinkedIn's regression DAGs against the branch v2.3.9 with zero regressions. 