### PR TITLE
[Coral-Schema] Preserve precision in RelDataTypeToAvroType for TIMESTAMP, TIME, and fixed BINARY

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvro.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvro.java
@@ -204,7 +204,9 @@ class MergeCoralSchemaWithAvro {
     if (timestampType.hasPrecision() && timestampType.getPrecision() <= 3) {
       return LogicalTypes.timestampMillis().addToSchema(schema);
     }
-    // Default to micros for precision 6, 9, or unspecified
+    // Default to micros for precision 6, 9, or unspecified.
+    // (RelDataTypeToAvroType, the derived-expression path, instead defaults unspecified precision to
+    // millis to preserve Hive-view output; reconcile deliberately if Hive ever moves onto this engine.)
     return LogicalTypes.timestampMicros().addToSchema(schema);
   }
 

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
@@ -105,12 +105,27 @@ class RelDataTypeToAvroType {
       case CHAR:
         return Schema.create(Schema.Type.STRING);
       case BINARY:
+        // Fixed-length BINARY(n) (e.g. an Iceberg FixedType) carries an explicit precision and maps
+        // to an Avro fixed; unbounded BINARY (precision unspecified, as for Hive binary) stays bytes.
+        if (relDataType.getPrecision() != RelDataType.PRECISION_NOT_SPECIFIED && relDataType.getPrecision() > 0) {
+          return Schema.createFixed("fixed" + relDataType.getPrecision(), null, null, relDataType.getPrecision());
+        }
         return Schema.create(Schema.Type.BYTES);
       case NULL:
         return Schema.create(Schema.Type.NULL);
       case TIMESTAMP:
+        // Precision > 3 (e.g. Iceberg's TIMESTAMP(6)) is microsecond-resolution and maps to
+        // timestamp-micros. Unspecified precision (Hive timestamps) and precision <= 3 stay
+        // timestamp-millis, preserving the existing Hive-path behavior.
         schema = Schema.create(Schema.Type.LONG);
-        schema.addProp("logicalType", "timestamp-millis");
+        schema.addProp("logicalType",
+            relDataType.getPrecision() != RelDataType.PRECISION_NOT_SPECIFIED && relDataType.getPrecision() > 3
+                ? "timestamp-micros" : "timestamp-millis");
+        return schema;
+      case TIME:
+        // Iceberg TIME is microsecond-resolution; Avro represents it as a long with time-micros.
+        schema = Schema.create(Schema.Type.LONG);
+        schema.addProp("logicalType", "time-micros");
         return schema;
       case DATE:
         // In Avro, "date" type is represented as {"type": "int", "logicalType": "date"}.

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroType.java
@@ -105,25 +105,30 @@ class RelDataTypeToAvroType {
       case CHAR:
         return Schema.create(Schema.Type.STRING);
       case BINARY:
-        // Fixed-length BINARY(n) (e.g. an Iceberg FixedType) carries an explicit precision and maps
-        // to an Avro fixed; unbounded BINARY (precision unspecified, as for Hive binary) stays bytes.
-        if (relDataType.getPrecision() != RelDataType.PRECISION_NOT_SPECIFIED && relDataType.getPrecision() > 0) {
+        // Fixed-length BINARY(n) (e.g. an Iceberg FixedType) carries an explicit positive length and
+        // maps to an Avro fixed. Unbounded BINARY (Hive binary, Iceberg variable-length binary)
+        // reports PRECISION_NOT_SPECIFIED (-1), so the same > 0 check leaves it as bytes.
+        if (relDataType.getPrecision() > 0) {
           return Schema.createFixed("fixed" + relDataType.getPrecision(), null, null, relDataType.getPrecision());
         }
         return Schema.create(Schema.Type.BYTES);
       case NULL:
         return Schema.create(Schema.Type.NULL);
       case TIMESTAMP:
-        // Precision > 3 (e.g. Iceberg's TIMESTAMP(6)) is microsecond-resolution and maps to
-        // timestamp-micros. Unspecified precision (Hive timestamps) and precision <= 3 stay
-        // timestamp-millis, preserving the existing Hive-path behavior.
+        // Precision > 3 (e.g. Iceberg's TIMESTAMP(6), microsecond resolution) maps to timestamp-micros.
+        // Unspecified precision (Hive timestamps, PRECISION_NOT_SPECIFIED == -1) and precision <= 3
+        // stay timestamp-millis, preserving the existing Hive-path behavior.
+        // Note: MergeCoralSchemaWithAvro.timestampToAvro defaults unspecified precision to
+        // timestamp-micros instead. The two cannot collide today (Iceberg is always TIMESTAMP(6), and
+        // Hive tables route through MergeHiveSchemaWithAvro); a future Hive-on-Coral consolidation
+        // should reconcile these defaults deliberately.
         schema = Schema.create(Schema.Type.LONG);
-        schema.addProp("logicalType",
-            relDataType.getPrecision() != RelDataType.PRECISION_NOT_SPECIFIED && relDataType.getPrecision() > 3
-                ? "timestamp-micros" : "timestamp-millis");
+        schema.addProp("logicalType", relDataType.getPrecision() > 3 ? "timestamp-micros" : "timestamp-millis");
         return schema;
       case TIME:
-        // Iceberg TIME is microsecond-resolution; Avro represents it as a long with time-micros.
+        // Iceberg TIME is microsecond resolution -- "time: Time of day, microsecond precision,
+        // without date, timezone" (https://iceberg.apache.org/spec/#primitive-types) -- so Avro
+        // represents it as a long with time-micros.
         schema = Schema.create(Schema.Type.LONG);
         schema.addProp("logicalType", "time-micros");
         return schema;

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroTypeTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/RelDataTypeToAvroTypeTests.java
@@ -10,6 +10,10 @@ import java.io.IOException;
 
 import org.apache.avro.Schema;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.MetaException;
@@ -20,6 +24,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.linkedin.coral.common.HiveMetastoreClient;
+import com.linkedin.coral.common.HiveTypeSystem;
 import com.linkedin.coral.hive.hive2rel.HiveToRelConverter;
 
 import static com.linkedin.coral.schema.avro.TestUtils.*;
@@ -103,5 +108,23 @@ public class RelDataTypeToAvroTypeTests {
 
     Assert.assertEquals(actualAvroType.toString(true),
         TestUtils.loadSchema("rel2avro-testDecimalTypeField-expected.avsc"));
+  }
+
+  @Test
+  public void testPrecisionSensitiveTypes() {
+    // Build a RelDataType directly so we can exercise the precision-prone leaf types the
+    // CoralCatalog/Iceberg path produces (TIMESTAMP(6), TIME, fixed BINARY) alongside the
+    // unspecified-precision forms the Hive path produces, without needing an Iceberg metastore.
+    RelDataTypeFactory typeFactory = new SqlTypeFactoryImpl(new HiveTypeSystem());
+    RelDataType recordType = typeFactory.builder().add("ts6", typeFactory.createSqlType(SqlTypeName.TIMESTAMP, 6))
+        .add("tsUnspecified", typeFactory.createSqlType(SqlTypeName.TIMESTAMP))
+        .add("timeField", typeFactory.createSqlType(SqlTypeName.TIME))
+        .add("binFixed16", typeFactory.createSqlType(SqlTypeName.BINARY, 16))
+        .add("binUnbounded", typeFactory.createSqlType(SqlTypeName.BINARY)).build();
+
+    Schema actualAvroType = RelDataTypeToAvroType.relDataTypeToAvroTypeNonNullable(recordType, "precisionTypes");
+
+    Assert.assertEquals(actualAvroType.toString(true),
+        TestUtils.loadSchema("rel2avro-testPrecisionTypes-expected.avsc"));
   }
 }

--- a/coral-schema/src/test/resources/rel2avro-testPrecisionTypes-expected.avsc
+++ b/coral-schema/src/test/resources/rel2avro-testPrecisionTypes-expected.avsc
@@ -1,0 +1,40 @@
+{
+  "type" : "record",
+  "name" : "precisionTypes",
+  "namespace" : "rel_avro",
+  "fields" : [ {
+    "name" : "ts6",
+    "type" : [ "null", {
+      "type" : "long",
+      "logicalType" : "timestamp-micros"
+    } ],
+    "default" : null
+  }, {
+    "name" : "tsUnspecified",
+    "type" : [ "null", {
+      "type" : "long",
+      "logicalType" : "timestamp-millis"
+    } ],
+    "default" : null
+  }, {
+    "name" : "timeField",
+    "type" : [ "null", {
+      "type" : "long",
+      "logicalType" : "time-micros"
+    } ],
+    "default" : null
+  }, {
+    "name" : "binFixed16",
+    "type" : [ "null", {
+      "type" : "fixed",
+      "name" : "fixed16",
+      "namespace" : "",
+      "size" : 16
+    } ],
+    "default" : null
+  }, {
+    "name" : "binUnbounded",
+    "type" : [ "null", "bytes" ],
+    "default" : null
+  } ]
+}


### PR DESCRIPTION
## Motivation

When `RelToAvroSchemaConverter` generates a view's Avro schema, **pass-through** columns reuse the base-table schema produced by `MergeCoralSchemaWithAvro` / `MergeHiveSchemaWithAvro`, while **computed and aggregate** expressions (e.g. `MAX(col)`, `COALESCE(col, …)`, `CASE … END`) have their Avro type derived from the Calcite `RelDataType` by `RelDataTypeToAvroType` (via `SchemaUtilities.appendField`).

That derivation was lossy for Iceberg-sourced types:

- `TIMESTAMP` was hardcoded to `timestamp-millis`, ignoring precision.
- `TIME` had no case at all — it threw `UnsupportedOperationException`.
- `BINARY` was always emitted as `bytes`.

Iceberg carries these precisely (`TIMESTAMP(6)`, `TIME`, fixed `BINARY(n)`), and Calcite's aggregate / `COALESCE` / `CASE` return-type inference preserves the operand type. So a view that **computes or aggregates over an Iceberg column** hit the gap (pass-through of the same column is already correct via the merge engine):

| Expression over an Iceberg base-table column | Before | After |
| --- | --- | --- |
| `MAX(time_col)` / `COALESCE(time_col, …)` | throws `UnsupportedOperationException` | `time-micros` |
| `MAX(ts6_col)` / `CASE … ts6_col … END` | `timestamp-millis` (wrong) | `timestamp-micros` |
| `MAX(fixed_col)` | `bytes` (lossy) | `fixed(n)` |

This also aligns the computed/aggregate path with the pass-through path, which `MergeCoralSchemaWithAvro` already emits as `time-micros` / `timestamp-micros` / `fixed`.

> On `TIME` specifically: Hive has no `TIME` type, so a Calcite `TIME` originates **only** from the Iceberg/CoralCatalog path. That is why the previous `default`-case `UnsupportedOperationException` was never reached on the Hive path but is reachable for Iceberg-backed views.

## Summary

`basicSqlTypeToAvroType` now derives the Avro logical type from the Calcite precision:

- `TIMESTAMP` precision > 3 (e.g. Iceberg's `TIMESTAMP(6)`) → `timestamp-micros`; unspecified precision and precision ≤ 3 → `timestamp-millis`.
- `TIME` → `time-micros` (previously unsupported).
- fixed-length `BINARY(n)` → Avro `fixed`; unbounded `BINARY` → `bytes`.

## Hive behavior is unchanged

Hive `TIMESTAMP`, `TIME`, and `BINARY` resolve to `PRECISION_NOT_SPECIFIED` (`HiveTypeSystem`), so they keep their exact current output (`timestamp-millis` / `bytes`). Only precision-specified types — which originate from the Iceberg/CoralCatalog path — change. The existing `testTimestampTypeField` (a Hive view) still emits `timestamp-millis`.

## Testing

- New `RelDataTypeToAvroTypeTests.testPrecisionSensitiveTypes` covering `TIMESTAMP(6)`, unspecified `TIMESTAMP`, `TIME`, fixed `BINARY(16)`, and unbounded `BINARY`, with golden `rel2avro-testPrecisionTypes-expected.avsc`.
- Full `coral-schema` suite green (143 tests).
