### PR TITLE
[Coral-Schema] Reconstruct multi-branch unions from Iceberg union-structs

### DIFF
--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvro.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvro.java
@@ -20,6 +20,7 @@ import org.apache.avro.Schema;
 import com.linkedin.coral.common.types.ArrayType;
 import com.linkedin.coral.common.types.BinaryType;
 import com.linkedin.coral.common.types.CoralDataType;
+import com.linkedin.coral.common.types.CoralTypeKind;
 import com.linkedin.coral.common.types.DecimalType;
 import com.linkedin.coral.common.types.MapType;
 import com.linkedin.coral.common.types.StructField;
@@ -88,7 +89,12 @@ class MergeCoralSchemaWithAvro {
   private Schema mergeType(CoralDataType coralType, @Nullable Schema partner) {
     switch (coralType.getKind()) {
       case STRUCT:
-        return mergeStruct((StructType) coralType, partner);
+        StructType structType = (StructType) coralType;
+        Schema unionPartner = unionPartnerOrNull(structType, partner);
+        if (unionPartner != null) {
+          return mergeUnionStruct(structType, unionPartner);
+        }
+        return mergeStruct(structType, partner);
       case ARRAY:
         return mergeArray((ArrayType) coralType, partner);
       case MAP:
@@ -117,6 +123,81 @@ class MergeCoralSchemaWithAvro {
       result.setFields(fields);
     }
     return applyCoralNullability(result, structType.isNullable(), partner);
+  }
+
+  /**
+   * Decides whether {@code structType} is a Trino-style union-struct whose partner Avro is a genuine
+   * multi-branch union, and if so returns that partner union (null branch intact). Returns null to fall
+   * back to regular struct handling.
+   *
+   * <p>Iceberg's type system has no union type, so a Hive {@code uniontype<A,B,C>} that has been persisted
+   * into Iceberg surfaces as the struct {@code {tag:INT, field0:A, field1:B, field2:C}} — the same encoding
+   * {@link com.linkedin.coral.common.HiveToCoralTypeConverter#convertUnion} produces (Trino union
+   * representation, see <a href="https://github.com/trinodb/trino/pull/3483">trinodb/trino#3483</a>). To
+   * stay faithful to the legacy Hive Avro path ({@link MergeHiveSchemaWithAvro#union}), such a column must be
+   * emitted as an Avro union rather than a record.
+   *
+   * <p>The struct shape alone is ambiguous — a genuine record could be named {@code {tag, field0, ...}} — so
+   * two further conditions are required: the partner must be an Avro union, and its non-null branch count
+   * must equal the number of {@code fieldN} members. A genuine nullable struct yields {@code [null, record]}
+   * (one non-null branch), which fails the count check for any multi-branch union. The only residual
+   * ambiguity is a single-member {@code uniontype<record>}, which is vanishingly rare; it is treated as a
+   * struct (the pre-existing behavior).
+   */
+  @Nullable
+  private Schema unionPartnerOrNull(StructType structType, @Nullable Schema partner) {
+    if (partner == null || partner.getType() != Schema.Type.UNION || !isUnionStruct(structType)) {
+      return null;
+    }
+    int memberCount = structType.getFields().size() - 1; // exclude the leading "tag" field
+    int nonNullBranchCount = SchemaUtilities.discardNullFromUnionIfExist(partner).getTypes().size();
+    // Require at least two members so the count check is collision-free: a genuine nullable struct yields
+    // [null, record] (one non-null branch), which can never equal a member count of two or more. A
+    // single-member union-struct is left to the struct path (see Javadoc).
+    return memberCount >= 2 && memberCount == nonNullBranchCount ? partner : null;
+  }
+
+  /**
+   * Recognizes the union-struct shape: a leading {@code tag} field of type INT followed by
+   * {@code field0, field1, ..., fieldN-1} in order. See {@link #unionPartnerOrNull}.
+   */
+  private boolean isUnionStruct(StructType structType) {
+    List<StructField> fields = structType.getFields();
+    if (fields.size() < 2) {
+      return false;
+    }
+    StructField tag = fields.get(0);
+    if (!"tag".equals(tag.getName()) || tag.getType().getKind() != CoralTypeKind.INT) {
+      return false;
+    }
+    for (int i = 1; i < fields.size(); i++) {
+      if (!("field" + (i - 1)).equals(fields.get(i).getName())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Reconstructs an Avro union from a union-struct, merging each {@code fieldN} member against the
+   * corresponding partner union branch (by ordinal). Null placement follows {@link MergeHiveSchemaWithAvro#union}:
+   * the NULL branch is emitted first when the partner union carries one. Caller ({@link #unionPartnerOrNull})
+   * guarantees the member count matches the partner's non-null branch count.
+   */
+  private Schema mergeUnionStruct(StructType unionStruct, Schema partnerUnion) {
+    List<Schema> partnerBranches = SchemaUtilities.discardNullFromUnionIfExist(partnerUnion).getTypes();
+    List<StructField> members = unionStruct.getFields(); // [tag, field0, field1, ...]
+    List<Schema> unionTypes = new ArrayList<>();
+    if (SchemaUtilities.nullExistInUnion(partnerUnion)) {
+      unionTypes.add(Schema.create(Schema.Type.NULL));
+    }
+    for (int i = 1; i < members.size(); i++) {
+      Schema branch = mergeType(members.get(i).getType(), partnerBranches.get(i - 1));
+      // A union member is never itself nullable in Avro — the union's own NULL branch carries nullability,
+      // so strip any option wrapper the recursive merge may have added around the member.
+      unionTypes.add(SchemaUtilities.extractIfOption(branch));
+    }
+    return Schema.createUnion(unionTypes);
   }
 
   private Schema mergeArray(ArrayType arrayType, @Nullable Schema partner) {

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvro.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvro.java
@@ -457,20 +457,42 @@ class MergeCoralSchemaWithAvro {
   }
 
   /**
-   * Find a partner field by case-insensitive name match, returning the first match. Matches the
-   * behavior of {@link MergeHiveSchemaWithAvro}'s partner accessor. Iceberg's schema spec disallows
-   * sibling fields that differ only in case, so this is unambiguous for Iceberg-sourced Coral schemas.
+   * Resolves the partner field for a Coral field name, following the documented matching rules:
+   *
+   * <ol>
+   *   <li>an exact, case-sensitive match wins outright;</li>
+   *   <li>otherwise a <em>unique</em> case-insensitive match;</li>
+   *   <li>otherwise no match.</li>
+   * </ol>
+   *
+   * <p>Iceberg forbids sibling fields differing only in case, so the Coral side is always unambiguous —
+   * but the <em>partner</em> is Avro, which permits both {@code fA} and {@code fa} in one record. A
+   * first-match-wins scan could therefore attach the wrong field's doc, default, props or enum/fixed
+   * promotion even when an exact match exists. Preferring the exact match removes that; refusing to
+   * guess between two inexact candidates keeps a rare, genuinely ambiguous schema from silently
+   * inheriting arbitrary metadata.
+   *
+   * <p>The output field name is unaffected — it is always the Coral name (see {@link #mergeField}). Only
+   * the source of the partner's metadata is decided here.
    */
   @Nullable
   private Schema.Field findPartnerField(@Nullable Schema partnerRecord, String coralFieldName) {
     if (partnerRecord == null) {
       return null;
     }
+    Schema.Field exactMatch = partnerRecord.getField(coralFieldName);
+    if (exactMatch != null) {
+      return exactMatch;
+    }
+    Schema.Field caseInsensitiveMatch = null;
     for (Schema.Field field : partnerRecord.getFields()) {
       if (field.name().equalsIgnoreCase(coralFieldName)) {
-        return field;
+        if (caseInsensitiveMatch != null) {
+          return null; // ambiguous: two partner fields differ only in case and neither matches exactly
+        }
+        caseInsensitiveMatch = field;
       }
     }
-    return null;
+    return caseInsensitiveMatch;
   }
 }

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvro.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvro.java
@@ -34,7 +34,12 @@ import static com.linkedin.coral.schema.avro.AvroSerdeUtils.*;
  * Merges a Coral schema (from Iceberg) with a partner Avro schema, using Iceberg-first semantics:
  *
  * <ul>
- *   <li>CoralDataType is the source of truth for field existence, name, nullability, and type.</li>
+ *   <li>CoralDataType is the source of truth for field existence, name, and type.</li>
+ *   <li><b>Nullability is always relaxed:</b> where CoralDataType and the partner disagree, the output
+ *       is nullable. The merge never narrows. Iceberg's {@code required} flag is frequently inherited
+ *       from a Hive migration rather than from an enforced constraint, so treating it as authoritative
+ *       would drop a {@code null} branch the partner declared and produce a schema stricter than the
+ *       data. This supersedes the earlier Iceberg-first nullability rule.</li>
  *   <li>Partner Avro contributes whatever metadata it carries for a matched field — defaults, docs,
  *       field props, aliases, union envelope shape and null placement, enum/fixed/uuid materialization.
  *       Nothing is fabricated: attributes the partner does not carry are absent from the output. When
@@ -121,7 +126,7 @@ class MergeCoralSchemaWithAvro {
       result = Schema.createRecord("record" + recordNum, null, "namespace" + recordNum, false);
       result.setFields(fields);
     }
-    return applyCoralNullability(result, structType.isNullable(), partner);
+    return applyRelaxedNullability(result, structType.isNullable(), partner);
   }
 
   /**
@@ -210,24 +215,26 @@ class MergeCoralSchemaWithAvro {
 
   /**
    * Reconstructs an Avro union from a union-struct, merging each {@code fieldN} member against the
-   * corresponding partner union branch (by ordinal). Null placement follows {@link MergeHiveSchemaWithAvro#union}:
-   * the NULL branch is emitted first when the partner union carries one. Caller
-   * ({@link #isReconstructableUnionStruct}) guarantees the member count matches the partner's non-null branch
-   * count.
+   * corresponding partner union branch (by ordinal). Caller ({@link #isReconstructableUnionStruct})
+   * guarantees the member count matches the partner's non-null branch count.
    *
-   * <p><b>{@code unionStruct.isNullable()} is deliberately ignored.</b> For a union the partner Avro is the
-   * authority on the envelope — whether a NULL branch exists and where it sits — so nullability is taken
-   * solely from {@code partnerUnion}. This is the one place the Iceberg-first nullability rule applied by
-   * {@link #applyCoralNullability} does not hold, because Iceberg cannot express a union envelope: a nullable
-   * Hive {@code uniontype} rolls its null into the members, surfacing as {@code {tag, field0, ...}} with
-   * optional members rather than as an optional struct. Taking nullability from the struct would therefore
-   * both double-count it and lose the partner's null placement.
+   * <p>The envelope is nullable when <em>either</em> the union-struct or the partner union says so,
+   * matching the relaxed rule in {@link #applyRelaxedNullability}. {@code unionStruct.isNullable()} is
+   * real signal here: only Iceberg-backed tables reach this class ({@code SchemaUtilities} delegates a
+   * {@code HiveTable} to the Hive path), and {@code IcebergToCoralTypeConverter} passes Iceberg's
+   * {@code isOptional()} straight through, so the flag reflects the Iceberg column rather than a
+   * constant. The NULL branch is emitted first, matching {@link MergeHiveSchemaWithAvro#union}.
+   *
+   * <p>Member nullability is deliberately <em>not</em> relaxed into the envelope. Avro forbids a union
+   * directly containing a union, and in the union-struct encoding only one member is live at a time, so
+   * members are optional regardless of whether the union itself is nullable. Relaxing from them would
+   * make every union nullable; each member therefore keeps its option wrapper stripped.
    */
   private Schema mergeUnionStruct(StructType unionStruct, Schema partnerUnion) {
     List<Schema> partnerBranches = SchemaUtilities.discardNullFromUnionIfExist(partnerUnion).getTypes();
     List<StructField> members = unionStruct.getFields(); // [tag, field0, field1, ...]
     List<Schema> unionTypes = new ArrayList<>();
-    if (SchemaUtilities.nullExistInUnion(partnerUnion)) {
+    if (unionStruct.isNullable() || SchemaUtilities.nullExistInUnion(partnerUnion)) {
       unionTypes.add(Schema.create(Schema.Type.NULL));
     }
     for (int i = 1; i < members.size(); i++) {
@@ -250,7 +257,7 @@ class MergeCoralSchemaWithAvro {
 
     Schema elementSchema = mergeType(arrayType.getElementType(), partnerElement);
     Schema result = Schema.createArray(elementSchema);
-    return applyCoralNullability(result, arrayType.isNullable(), partner);
+    return applyRelaxedNullability(result, arrayType.isNullable(), partner);
   }
 
   private Schema mergeMap(MapType mapType, @Nullable Schema partner) {
@@ -264,13 +271,13 @@ class MergeCoralSchemaWithAvro {
 
     Schema valueSchema = mergeType(mapType.getValueType(), partnerValue);
     Schema result = Schema.createMap(valueSchema);
-    return applyCoralNullability(result, mapType.isNullable(), partner);
+    return applyRelaxedNullability(result, mapType.isNullable(), partner);
   }
 
   private Schema mergeLeaf(CoralDataType coralType, @Nullable Schema partner) {
     Schema coralPrimitive = coralPrimitiveToAvro(coralType);
     Schema result = partner == null ? coralPrimitive : checkCompatibilityAndPromote(coralPrimitive, partner);
-    return applyCoralNullability(result, coralType.isNullable(), partner);
+    return applyRelaxedNullability(result, coralType.isNullable(), partner);
   }
 
   /**
@@ -388,15 +395,18 @@ class MergeCoralSchemaWithAvro {
   }
 
   /**
-   * Apply Coral nullability: if the Coral type is nullable, wrap the result in a nullable union.
-   * Respects the partner's null placement order when available.
+   * Applies relaxed nullability: the result is nullable when <em>either</em> the Coral type or the
+   * partner says so, and is never narrowed. Null placement follows the partner when it has one.
+   *
+   * <p>Consulting the partner is the whole point. Iceberg's {@code required} flag is often inherited
+   * from a Hive migration rather than from an enforced constraint, so honouring it alone would drop a
+   * {@code null} branch the partner declared and publish a schema stricter than the data — breaking
+   * any consumer that has legitimate nulls.
    */
-  private Schema applyCoralNullability(Schema result, boolean coralNullable, @Nullable Schema partner) {
-    if (coralNullable && !isNullableType(result)) {
+  private Schema applyRelaxedNullability(Schema result, boolean coralNullable, @Nullable Schema partner) {
+    boolean partnerNullable = partner != null && isNullableType(partner);
+    if ((coralNullable || partnerNullable) && !isNullableType(result)) {
       return SchemaUtilities.makeNullable(result, SchemaUtilities.isNullSecond(partner));
-    }
-    if (!coralNullable && isNullableType(result)) {
-      return SchemaUtilities.extractIfOption(result);
     }
     return result;
   }

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvro.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvro.java
@@ -90,9 +90,8 @@ class MergeCoralSchemaWithAvro {
     switch (coralType.getKind()) {
       case STRUCT:
         StructType structType = (StructType) coralType;
-        Schema unionPartner = unionPartnerOrNull(structType, partner);
-        if (unionPartner != null) {
-          return mergeUnionStruct(structType, unionPartner);
+        if (isMultiBranchUnionStruct(structType, partner)) {
+          return mergeUnionStruct(structType, partner);
         }
         return mergeStruct(structType, partner);
       case ARRAY:
@@ -127,8 +126,7 @@ class MergeCoralSchemaWithAvro {
 
   /**
    * Decides whether {@code structType} is a Trino-style union-struct whose partner Avro is a genuine
-   * multi-branch union, and if so returns that partner union (null branch intact). Returns null to fall
-   * back to regular struct handling.
+   * multi-branch union, and must therefore be emitted as an Avro union rather than a record.
    *
    * <p>Iceberg's type system has no union type, so a Hive {@code uniontype<A,B,C>} that has been persisted
    * into Iceberg surfaces as the struct {@code {tag:INT, field0:A, field1:B, field2:C}} — the same encoding
@@ -144,22 +142,21 @@ class MergeCoralSchemaWithAvro {
    * ambiguity is a single-member {@code uniontype<record>}, which is vanishingly rare; it is treated as a
    * struct (the pre-existing behavior).
    */
-  @Nullable
-  private Schema unionPartnerOrNull(StructType structType, @Nullable Schema partner) {
+  private boolean isMultiBranchUnionStruct(StructType structType, @Nullable Schema partner) {
     if (partner == null || partner.getType() != Schema.Type.UNION || !isUnionStruct(structType)) {
-      return null;
+      return false;
     }
     int memberCount = structType.getFields().size() - 1; // exclude the leading "tag" field
     int nonNullBranchCount = SchemaUtilities.discardNullFromUnionIfExist(partner).getTypes().size();
     // Require at least two members so the count check is collision-free: a genuine nullable struct yields
     // [null, record] (one non-null branch), which can never equal a member count of two or more. A
     // single-member union-struct is left to the struct path (see Javadoc).
-    return memberCount >= 2 && memberCount == nonNullBranchCount ? partner : null;
+    return memberCount >= 2 && memberCount == nonNullBranchCount;
   }
 
   /**
    * Recognizes the union-struct shape: a leading {@code tag} field of type INT followed by
-   * {@code field0, field1, ..., fieldN-1} in order. See {@link #unionPartnerOrNull}.
+   * {@code field0, field1, ..., fieldN-1} in order. See {@link #isMultiBranchUnionStruct}.
    */
   private boolean isUnionStruct(StructType structType) {
     List<StructField> fields = structType.getFields();
@@ -181,8 +178,9 @@ class MergeCoralSchemaWithAvro {
   /**
    * Reconstructs an Avro union from a union-struct, merging each {@code fieldN} member against the
    * corresponding partner union branch (by ordinal). Null placement follows {@link MergeHiveSchemaWithAvro#union}:
-   * the NULL branch is emitted first when the partner union carries one. Caller ({@link #unionPartnerOrNull})
-   * guarantees the member count matches the partner's non-null branch count.
+   * the NULL branch is emitted first when the partner union carries one. Caller
+   * ({@link #isMultiBranchUnionStruct}) guarantees the member count matches the partner's non-null branch
+   * count.
    */
   private Schema mergeUnionStruct(StructType unionStruct, Schema partnerUnion) {
     List<Schema> partnerBranches = SchemaUtilities.discardNullFromUnionIfExist(partnerUnion).getTypes();

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvro.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvro.java
@@ -275,9 +275,41 @@ class MergeCoralSchemaWithAvro {
   }
 
   private Schema mergeLeaf(CoralDataType coralType, @Nullable Schema partner) {
+    // A Hive uniontype<X> whose Iceberg column was flattened to a plain field still arrives with a
+    // partner of ["X"]. Merge against the sole branch so promotions still apply, then restore the
+    // envelope below.
+    Schema soleBranch = nullFreeSingleBranchOrNull(partner);
+    Schema effectivePartner = soleBranch != null ? soleBranch : partner;
     Schema coralPrimitive = coralPrimitiveToAvro(coralType);
-    Schema result = partner == null ? coralPrimitive : checkCompatibilityAndPromote(coralPrimitive, partner);
-    return applyRelaxedNullability(result, coralType.isNullable(), partner);
+    Schema result =
+        effectivePartner == null ? coralPrimitive : checkCompatibilityAndPromote(coralPrimitive, effectivePartner);
+    Schema withNullability = applyRelaxedNullability(result, coralType.isNullable(), partner);
+    if (soleBranch != null && withNullability.getType() != Schema.Type.UNION) {
+      // Preserve the single-element union envelope the partner declared. Dropping it would lose the
+      // fact that the column is a uniontype, which coalesce_struct and the Hive path both rely on.
+      // When the field is nullable the envelope is already subsumed by ["null", X].
+      List<Schema> envelope = new ArrayList<>();
+      envelope.add(withNullability);
+      return Schema.createUnion(envelope);
+    }
+    return withNullability;
+  }
+
+  /**
+   * The sole branch of a partner that is a single-element union carrying no NULL ({@code ["int"]}), or
+   * null for anything else. This is the Avro shape of a Hive {@code uniontype<X>} whose Iceberg column
+   * has been flattened to a plain field, so the envelope must survive the merge.
+   *
+   * <p>{@code ["null","X"]} is deliberately excluded: it is simultaneously a plain nullable field and
+   * the only representation of a nullable single union, so it needs no special handling.
+   */
+  @Nullable
+  private Schema nullFreeSingleBranchOrNull(@Nullable Schema partner) {
+    if (partner == null || partner.getType() != Schema.Type.UNION || partner.getTypes().size() != 1) {
+      return null;
+    }
+    Schema branch = partner.getTypes().get(0);
+    return branch.getType() == Schema.Type.NULL ? null : branch;
   }
 
   /**

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvro.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvro.java
@@ -193,6 +193,9 @@ class MergeCoralSchemaWithAvro {
     if (memberCount >= 2) {
       return true;
     }
+    // Only reachable at arity 1, where the count above proves nothing: both uniontype<X> and a genuine
+    // nullable struct named {tag, field0} present exactly one non-null branch. The partner's sole branch
+    // is the tie-breaker — see describesStructItself.
     return !describesStructItself(nonNullBranches.get(0));
   }
 

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvro.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvro.java
@@ -6,6 +6,7 @@
 package com.linkedin.coral.schema.avro;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -92,13 +93,36 @@ class MergeCoralSchemaWithAvro {
   }
 
   private Schema mergeType(CoralDataType coralType, @Nullable Schema partner) {
+    // A union-struct whose partner still describes it as a union is reconstructed as a union. This
+    // takes precedence over the single-branch envelope handling below, which covers the opposite
+    // situation: Iceberg having flattened the uniontype away entirely.
+    if (coralType.getKind() == CoralTypeKind.STRUCT && isReconstructableUnionStruct((StructType) coralType, partner)) {
+      return mergeUnionStruct((StructType) coralType, partner);
+    }
+
+    Schema soleBranch = nullFreeSingleBranchOrNull(partner);
+    if (soleBranch == null) {
+      return mergeByKind(coralType, partner);
+    }
+
+    // Iceberg has no union type, so a Hive uniontype<X> may surface as a plain column of X while the
+    // partner still declares ["X"]. Merge against the sole branch so promotions and nested merging
+    // still apply, then restore the envelope. This is deliberately handled for every Coral kind, not
+    // just leaves: uniontype<array<...>>, uniontype<map<...>> and uniontype<struct<...>> flatten the
+    // same way, and dropping the envelope loses the fact that the column is a uniontype.
+    Schema merged = mergeByKind(coralType, soleBranch);
+    if (merged.getType() == Schema.Type.UNION) {
+      // Already nullable. ["null", X] is simultaneously the plain nullable form and the only Avro
+      // representation of a nullable single union, so the envelope is subsumed and nothing is added.
+      return merged;
+    }
+    return Schema.createUnion(Collections.singletonList(merged));
+  }
+
+  private Schema mergeByKind(CoralDataType coralType, @Nullable Schema partner) {
     switch (coralType.getKind()) {
       case STRUCT:
-        StructType structType = (StructType) coralType;
-        if (isReconstructableUnionStruct(structType, partner)) {
-          return mergeUnionStruct(structType, partner);
-        }
-        return mergeStruct(structType, partner);
+        return mergeStruct((StructType) coralType, partner);
       case ARRAY:
         return mergeArray((ArrayType) coralType, partner);
       case MAP:
@@ -275,24 +299,9 @@ class MergeCoralSchemaWithAvro {
   }
 
   private Schema mergeLeaf(CoralDataType coralType, @Nullable Schema partner) {
-    // A Hive uniontype<X> whose Iceberg column was flattened to a plain field still arrives with a
-    // partner of ["X"]. Merge against the sole branch so promotions still apply, then restore the
-    // envelope below.
-    Schema soleBranch = nullFreeSingleBranchOrNull(partner);
-    Schema effectivePartner = soleBranch != null ? soleBranch : partner;
     Schema coralPrimitive = coralPrimitiveToAvro(coralType);
-    Schema result =
-        effectivePartner == null ? coralPrimitive : checkCompatibilityAndPromote(coralPrimitive, effectivePartner);
-    Schema withNullability = applyRelaxedNullability(result, coralType.isNullable(), partner);
-    if (soleBranch != null && withNullability.getType() != Schema.Type.UNION) {
-      // Preserve the single-element union envelope the partner declared. Dropping it would lose the
-      // fact that the column is a uniontype, which coalesce_struct and the Hive path both rely on.
-      // When the field is nullable the envelope is already subsumed by ["null", X].
-      List<Schema> envelope = new ArrayList<>();
-      envelope.add(withNullability);
-      return Schema.createUnion(envelope);
-    }
-    return withNullability;
+    Schema result = partner == null ? coralPrimitive : checkCompatibilityAndPromote(coralPrimitive, partner);
+    return applyRelaxedNullability(result, coralType.isNullable(), partner);
   }
 
   /**

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvro.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvro.java
@@ -164,11 +164,13 @@ class MergeCoralSchemaWithAvro {
       return false;
     }
     StructField tag = fields.get(0);
-    if (!"tag".equals(tag.getName()) || tag.getType().getKind() != CoralTypeKind.INT) {
+    // Names are matched case-insensitively: the union-struct encoding may arrive through catalogs that
+    // normalize field casing, and a case-only mismatch must not silently downgrade a union to a record.
+    if (!"tag".equalsIgnoreCase(tag.getName()) || tag.getType().getKind() != CoralTypeKind.INT) {
       return false;
     }
     for (int i = 1; i < fields.size(); i++) {
-      if (!("field" + (i - 1)).equals(fields.get(i).getName())) {
+      if (!("field" + (i - 1)).equalsIgnoreCase(fields.get(i).getName())) {
         return false;
       }
     }
@@ -181,6 +183,14 @@ class MergeCoralSchemaWithAvro {
    * the NULL branch is emitted first when the partner union carries one. Caller
    * ({@link #isMultiBranchUnionStruct}) guarantees the member count matches the partner's non-null branch
    * count.
+   *
+   * <p><b>{@code unionStruct.isNullable()} is deliberately ignored.</b> For a union the partner Avro is the
+   * authority on the envelope — whether a NULL branch exists and where it sits — so nullability is taken
+   * solely from {@code partnerUnion}. This is the one place the Iceberg-first nullability rule applied by
+   * {@link #applyCoralNullability} does not hold, because Iceberg cannot express a union envelope: a nullable
+   * Hive {@code uniontype} rolls its null into the members, surfacing as {@code {tag, field0, ...}} with
+   * optional members rather than as an optional struct. Taking nullability from the struct would therefore
+   * both double-count it and lose the partner's null placement.
    */
   private Schema mergeUnionStruct(StructType unionStruct, Schema partnerUnion) {
     List<Schema> partnerBranches = SchemaUtilities.discardNullFromUnionIfExist(partnerUnion).getTypes();

--- a/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvro.java
+++ b/coral-schema/src/main/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvro.java
@@ -90,7 +90,7 @@ class MergeCoralSchemaWithAvro {
     switch (coralType.getKind()) {
       case STRUCT:
         StructType structType = (StructType) coralType;
-        if (isMultiBranchUnionStruct(structType, partner)) {
+        if (isReconstructableUnionStruct(structType, partner)) {
           return mergeUnionStruct(structType, partner);
         }
         return mergeStruct(structType, partner);
@@ -137,26 +137,57 @@ class MergeCoralSchemaWithAvro {
    *
    * <p>The struct shape alone is ambiguous — a genuine record could be named {@code {tag, field0, ...}} — so
    * two further conditions are required: the partner must be an Avro union, and its non-null branch count
-   * must equal the number of {@code fieldN} members. A genuine nullable struct yields {@code [null, record]}
-   * (one non-null branch), which fails the count check for any multi-branch union. The only residual
-   * ambiguity is a single-member {@code uniontype<record>}, which is vanishingly rare; it is treated as a
-   * struct (the pre-existing behavior).
+   * must equal the number of {@code fieldN} members.
+   *
+   * <p>For two or more members the count check alone is conclusive, because a genuine nullable struct yields
+   * {@code [null, record]} (one non-null branch) and can never match. A <em>single</em>-member union-struct
+   * is genuinely ambiguous on counts, since both {@code uniontype<X>} and a nullable struct named
+   * {@code {tag, field0}} present one non-null branch. The partner's sole branch breaks the tie: for a
+   * genuine struct it is the record describing that struct, and so carries its own {@code tag} field, whereas
+   * for {@code uniontype<X>} it is the member type {@code X}. Single unions must be reconstructed rather than
+   * left as structs — {@link com.linkedin.coral.common.HiveToCoralTypeConverter#convertUnion} emits the
+   * {@code {tag, field0}} encoding for every arity, so treating them as structs leaks that internal encoding
+   * into the output schema.
+   *
+   * <p>The only residual ambiguity is {@code uniontype<struct<tag:...>>}, whose member is itself a struct
+   * carrying a {@code tag} field; it is treated as a struct.
    */
-  private boolean isMultiBranchUnionStruct(StructType structType, @Nullable Schema partner) {
+  private boolean isReconstructableUnionStruct(StructType structType, @Nullable Schema partner) {
     if (partner == null || partner.getType() != Schema.Type.UNION || !isUnionStruct(structType)) {
       return false;
     }
     int memberCount = structType.getFields().size() - 1; // exclude the leading "tag" field
-    int nonNullBranchCount = SchemaUtilities.discardNullFromUnionIfExist(partner).getTypes().size();
-    // Require at least two members so the count check is collision-free: a genuine nullable struct yields
-    // [null, record] (one non-null branch), which can never equal a member count of two or more. A
-    // single-member union-struct is left to the struct path (see Javadoc).
-    return memberCount >= 2 && memberCount == nonNullBranchCount;
+    List<Schema> nonNullBranches = SchemaUtilities.discardNullFromUnionIfExist(partner).getTypes();
+    if (memberCount != nonNullBranches.size()) {
+      return false;
+    }
+    if (memberCount >= 2) {
+      return true;
+    }
+    return !describesStructItself(nonNullBranches.get(0));
+  }
+
+  /**
+   * Whether a partner union branch is the record describing the union-struct itself — i.e. the partner says
+   * "this really is a struct named {tag, field0}" — rather than the member type of a single
+   * {@code uniontype<X>}. See {@link #isReconstructableUnionStruct}.
+   */
+  private boolean describesStructItself(Schema branch) {
+    Schema extracted = SchemaUtilities.extractIfOption(branch);
+    if (extracted.getType() != Schema.Type.RECORD) {
+      return false;
+    }
+    for (Schema.Field field : extracted.getFields()) {
+      if ("tag".equalsIgnoreCase(field.name())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
    * Recognizes the union-struct shape: a leading {@code tag} field of type INT followed by
-   * {@code field0, field1, ..., fieldN-1} in order. See {@link #isMultiBranchUnionStruct}.
+   * {@code field0, field1, ..., fieldN-1} in order. See {@link #isReconstructableUnionStruct}.
    */
   private boolean isUnionStruct(StructType structType) {
     List<StructField> fields = structType.getFields();
@@ -181,7 +212,7 @@ class MergeCoralSchemaWithAvro {
    * Reconstructs an Avro union from a union-struct, merging each {@code fieldN} member against the
    * corresponding partner union branch (by ordinal). Null placement follows {@link MergeHiveSchemaWithAvro#union}:
    * the NULL branch is emitted first when the partner union carries one. Caller
-   * ({@link #isMultiBranchUnionStruct}) guarantees the member count matches the partner's non-null branch
+   * ({@link #isReconstructableUnionStruct}) guarantees the member count matches the partner's non-null branch
    * count.
    *
    * <p><b>{@code unionStruct.isNullable()} is deliberately ignored.</b> For a union the partner Avro is the

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvroTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvroTests.java
@@ -327,7 +327,58 @@ public class MergeCoralSchemaWithAvroTests {
     assertNotNull(outerSchema.getField("inner"));
   }
 
+  @Test
+  public void shouldReconstructMultiBranchUnionFromUnionStruct() {
+    // Hive uniontype<int,string,boolean> persisted into Iceberg is the struct {tag, field0, field1, field2}.
+    // The partner Avro keeps it as a union, so the engine must emit a union with the same branches/order.
+    StructType coral =
+        struct(field("u", unionStruct(intType(true), stringType(true), PrimitiveType.of(CoralTypeKind.BOOLEAN, true))));
+    Schema avro = avroStruct("r1", avroField("u",
+        avroUnion(Schema.Type.NULL, Schema.Type.INT, Schema.Type.STRING, Schema.Type.BOOLEAN), null, null, null));
+
+    Schema result = merge(coral, avro);
+    Schema u = result.getField("u").schema();
+    assertEquals(u.getType(), Schema.Type.UNION);
+    assertEquals(u.getTypes().get(0).getType(), Schema.Type.NULL);
+    assertEquals(u.getTypes().get(1).getType(), Schema.Type.INT);
+    assertEquals(u.getTypes().get(2).getType(), Schema.Type.STRING);
+    assertEquals(u.getTypes().get(3).getType(), Schema.Type.BOOLEAN);
+  }
+
+  @Test
+  public void shouldReconstructUnionWithoutNullBranch() {
+    // A non-nullable partner union (no null member) must not gain a null branch — null placement follows
+    // the partner, matching MergeHiveSchemaWithAvro.union.
+    StructType coral = struct(field("u", unionStruct(intType(true), stringType(true))));
+    Schema avro = avroStruct("r1", avroField("u", avroUnion(Schema.Type.INT, Schema.Type.STRING), null, null, null));
+
+    Schema result = merge(coral, avro);
+    Schema u = result.getField("u").schema();
+    assertEquals(u.getType(), Schema.Type.UNION);
+    assertEquals(u.getTypes().size(), 2);
+    assertEquals(u.getTypes().get(0).getType(), Schema.Type.INT);
+    assertEquals(u.getTypes().get(1).getType(), Schema.Type.STRING);
+  }
+
   /** Test Helpers */
+
+  /** Builds a Trino-style union-struct {tag:INT, field0, field1, ...} from the given union member types. */
+  private StructType unionStruct(com.linkedin.coral.common.types.CoralDataType... members) {
+    StructField[] fields = new StructField[members.length + 1];
+    fields[0] = field("tag", intType(true));
+    for (int i = 0; i < members.length; i++) {
+      fields[i + 1] = field("field" + i, members[i]);
+    }
+    return struct(fields);
+  }
+
+  private Schema avroUnion(Schema.Type... branchTypes) {
+    Schema[] branches = new Schema[branchTypes.length];
+    for (int i = 0; i < branchTypes.length; i++) {
+      branches[i] = Schema.create(branchTypes[i]);
+    }
+    return Schema.createUnion(Arrays.asList(branches));
+  }
 
   private Schema merge(StructType coral, Schema avro) {
     return MergeCoralSchemaWithAvro.merge(coral, avro, "TestRecord", "com.test");

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvroTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvroTests.java
@@ -640,6 +640,78 @@ public class MergeCoralSchemaWithAvroTests {
     assertEquals(result.getField("u").schema().getType(), Schema.Type.STRING);
   }
 
+  @Test
+  public void shouldPreferAnExactCaseMatchOverAnEarlierCaseInsensitiveOne() {
+    // Avro permits fa and fA as siblings. The exact match must win even though the inexact one is
+    // declared first, otherwise the wrong field's doc/default/props get copied.
+    StructType coral = struct(field("fA", intType(true)));
+    Schema avro = avroStruct("r1",
+        avroField("fa", SchemaUtilities.makeNullable(Schema.create(Schema.Type.INT), false), "lowercase-one", null,
+            null),
+        avroField("fA", SchemaUtilities.makeNullable(Schema.create(Schema.Type.INT), false), "exact-one", null, null));
+
+    Schema result = merge(coral, avro);
+    assertNotNull(result.getField("fA"));
+    assertEquals(result.getField("fA").doc(), "exact-one");
+  }
+
+  @Test
+  public void shouldNotGuessBetweenTwoInexactCaseMatches() {
+    // Neither partner field matches exactly and both match case-insensitively: refuse to pick one
+    // arbitrarily, so no partner metadata is inherited.
+    StructType coral = struct(field("fA", intType(true)));
+    Schema avro = avroStruct("r1",
+        avroField("fa", SchemaUtilities.makeNullable(Schema.create(Schema.Type.INT), false), "first", null, null),
+        avroField("FA", SchemaUtilities.makeNullable(Schema.create(Schema.Type.INT), false), "second", null, null));
+
+    Schema result = merge(coral, avro);
+    assertNotNull(result.getField("fA"));
+    assertNull(result.getField("fA").doc());
+  }
+
+  @Test
+  public void shouldStillMatchAUniqueCaseInsensitivePartner() {
+    // Rule 2 is unchanged: a single inexact candidate still matches and still carries its metadata.
+    StructType coral = struct(field("fA", intType(true)));
+    Schema avro = avroStruct("r1",
+        avroField("fa", SchemaUtilities.makeNullable(Schema.create(Schema.Type.INT), false), "ci-match", null, null));
+
+    Schema result = merge(coral, avro);
+    assertNotNull(result.getField("fA"));
+    assertEquals(result.getField("fA").doc(), "ci-match");
+  }
+
+  @Test
+  public void shouldLowercaseAnIcebergMergedSchemaWithoutLosingStructure() {
+    // Production reads spark.sql.force.lowercase.dali.schema (default false), and the parity harness
+    // runs with forceLowercase=false, so the lowercase visitor over an Iceberg-merged schema had no
+    // coverage. Nullability, union envelopes and nested shape must all survive the rename.
+    StructType coral =
+        struct(field("fA", intType(false)), field("uU", unionStruct(false, intType(true), stringType(true))),
+            field("nEst", struct(field("iNner", intType(false)))));
+    Schema avro = avroStruct("r1", optionalField("fA", Schema.Type.INT),
+        avroField("uU", avroUnion(Schema.Type.INT, Schema.Type.STRING), null, null, null),
+        requiredField("nEst", avroStruct("r2", optionalField("iNner", Schema.Type.INT))));
+
+    Schema merged = merge(coral, avro);
+    Schema lowercased = ToLowercaseSchemaVisitor.visit(merged);
+
+    // Names are lowercased ...
+    assertNotNull(lowercased.getField("fa"));
+    assertNotNull(lowercased.getField("uu"));
+    assertNotNull(lowercased.getField("nest"));
+    // ... the relaxed nullability survives ...
+    assertTrue(AvroSerdeUtils.isNullableType(lowercased.getField("fa").schema()));
+    // ... the reconstructed union envelope survives ...
+    Schema union = lowercased.getField("uu").schema();
+    assertEquals(union.getType(), Schema.Type.UNION);
+    assertEquals(union.getTypes().size(), 2);
+    // ... and nested fields are lowercased too, keeping their relaxed nullability.
+    Schema nested = SchemaUtilities.extractIfOption(lowercased.getField("nest").schema());
+    assertNotNull(nested.getField("inner"));
+    assertTrue(AvroSerdeUtils.isNullableType(nested.getField("inner").schema()));
+  }
+
   /** Test Helpers */
 
   /** Builds a Trino-style union-struct {tag:INT, field0, field1, ...} from the given union member types. */

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvroTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvroTests.java
@@ -647,10 +647,10 @@ public class MergeCoralSchemaWithAvroTests {
 
   @Test
   public void shouldPreserveSingleElementUnionEnvelopeAroundAnArray() {
-    // The production shape behind organization_mp.product_dbchanges_hourly $.value.productCategoryUrns:
-    // uniontype<array<string>> flattened by Iceberg to array<string> while the partner still declares
-    // [{"type":"array","items":"string"}]. Dispatch is on the Coral kind, so this reaches mergeArray
-    // rather than mergeLeaf — the envelope handling has to sit above that switch to cover it.
+    // A production shape: uniontype<array<string>> flattened by Iceberg to array<string> while the
+    // partner still declares [{"type":"array","items":"string"}]. Dispatch is on the Coral kind, so
+    // this reaches mergeArray rather than mergeLeaf — the envelope handling has to sit above that
+    // switch to cover it.
     StructType coral = struct(field("u", ArrayType.of(stringType(false), false)));
     Schema arrayBranch = Schema.createArray(Schema.create(Schema.Type.STRING));
     Schema avro = avroStruct("r1", avroField("u", avroUnionOf(arrayBranch), null, null, null));

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvroTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvroTests.java
@@ -476,9 +476,14 @@ public class MergeCoralSchemaWithAvroTests {
 
   @Test
   public void shouldReconstructNullableSingleUnion() {
-    // uniontype<string> persisted into Iceberg is {tag, field0} — HiveToCoralTypeConverter.convertUnion
-    // emits the union-struct encoding for EVERY arity, not just multi-branch. A nullable single union must
-    // come back as [null, string]; leaving it on the struct path would leak {tag, field0} into the output.
+    // Covers the case where the union-struct encoding SURVIVED into Iceberg: uniontype<string> stored as
+    // {tag, field0}. This is not an assertion that Iceberg always preserves it — a single uniontype is
+    // often flattened to a plain column instead, which is handled separately in mergeType and covered by
+    // shouldPreserveSingleElementUnionEnvelopeWhenIcebergFlattensIt. The preserved encoding is confirmed in
+    // production for multi-branch unions (the facetClauses array<union> tables); for arity 1 this test is
+    // defensive, since HiveToCoralTypeConverter.convertUnion emits {tag, field0} for EVERY arity and a
+    // writer may persist that shape. A nullable single union must come back as [null, string]; leaving it
+    // on the struct path would leak {tag, field0} into the output.
     StructType coral = struct(field("u", unionStruct(stringType(true))));
     Schema avro = avroStruct("r1", avroField("u", avroUnion(Schema.Type.NULL, Schema.Type.STRING), null, null, null));
 

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvroTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvroTests.java
@@ -49,15 +49,26 @@ public class MergeCoralSchemaWithAvroTests {
   }
 
   @Test
-  public void shouldUseNullabilityFromCoral() {
+  public void shouldRelaxNullabilityWhenEitherSourceSaysNullable() {
     StructType coral = struct(field("fA", intType(false)), field("fB", intType(true)));
     Schema avro = avroStruct("r1", optionalField("fA", Schema.Type.INT), requiredField("fB", Schema.Type.INT));
 
     Schema result = merge(coral, avro);
-    // Coral says fA is non-nullable
-    assertFalse(AvroSerdeUtils.isNullableType(result.getField("fA").schema()));
-    // Coral says fB is nullable
+    // Coral says fA is required but the partner declares [null,int]: nullability is always relaxed, so
+    // the partner's null branch survives rather than being dropped.
+    assertTrue(AvroSerdeUtils.isNullableType(result.getField("fA").schema()));
+    // Coral says fB is nullable while the partner says required: relaxed the other way round.
     assertTrue(AvroSerdeUtils.isNullableType(result.getField("fB").schema()));
+  }
+
+  @Test
+  public void shouldKeepFieldRequiredWhenNeitherSourceSaysNullable() {
+    StructType coral = struct(field("fA", intType(false)));
+    Schema avro = avroStruct("r1", requiredField("fA", Schema.Type.INT));
+
+    Schema result = merge(coral, avro);
+    // Relaxing never fabricates nullability: with both sources agreeing the field stays required.
+    assertFalse(AvroSerdeUtils.isNullableType(result.getField("fA").schema()));
   }
 
   @Test
@@ -347,9 +358,8 @@ public class MergeCoralSchemaWithAvroTests {
 
   @Test
   public void shouldReconstructUnionWithoutNullBranch() {
-    // A non-nullable partner union (no null member) must not gain a null branch — null placement follows
-    // the partner, matching MergeHiveSchemaWithAvro.union.
-    StructType coral = struct(field("u", unionStruct(intType(true), stringType(true))));
+    // Neither the union-struct nor the partner is nullable, so no null branch may be fabricated.
+    StructType coral = struct(field("u", unionStruct(false, intType(true), stringType(true))));
     Schema avro = avroStruct("r1", avroField("u", avroUnion(Schema.Type.INT, Schema.Type.STRING), null, null, null));
 
     Schema result = merge(coral, avro);
@@ -358,6 +368,36 @@ public class MergeCoralSchemaWithAvroTests {
     assertEquals(u.getTypes().size(), 2);
     assertEquals(u.getTypes().get(0).getType(), Schema.Type.INT);
     assertEquals(u.getTypes().get(1).getType(), Schema.Type.STRING);
+  }
+
+  @Test
+  public void shouldRelaxUnionEnvelopeWhenOnlyTheStructIsNullable() {
+    // Iceberg marks the union column optional while the partner union carries no null branch. The
+    // envelope is relaxed to nullable, matching the field-level rule.
+    StructType coral = struct(field("u", unionStruct(true, intType(true), stringType(true))));
+    Schema avro = avroStruct("r1", avroField("u", avroUnion(Schema.Type.INT, Schema.Type.STRING), null, null, null));
+
+    Schema result = merge(coral, avro);
+    Schema u = result.getField("u").schema();
+    assertEquals(u.getType(), Schema.Type.UNION);
+    assertEquals(u.getTypes().size(), 3);
+    assertEquals(u.getTypes().get(0).getType(), Schema.Type.NULL);
+    assertEquals(u.getTypes().get(1).getType(), Schema.Type.INT);
+    assertEquals(u.getTypes().get(2).getType(), Schema.Type.STRING);
+  }
+
+  @Test
+  public void shouldRelaxUnionEnvelopeWhenOnlyThePartnerIsNullable() {
+    // Mirror image: Iceberg says required, the partner declares a null branch — the null survives.
+    StructType coral = struct(field("u", unionStruct(false, intType(true), stringType(true))));
+    Schema avro = avroStruct("r1",
+        avroField("u", avroUnion(Schema.Type.NULL, Schema.Type.INT, Schema.Type.STRING), null, null, null));
+
+    Schema result = merge(coral, avro);
+    Schema u = result.getField("u").schema();
+    assertEquals(u.getType(), Schema.Type.UNION);
+    assertEquals(u.getTypes().size(), 3);
+    assertEquals(u.getTypes().get(0).getType(), Schema.Type.NULL);
   }
 
   @Test
@@ -452,8 +492,8 @@ public class MergeCoralSchemaWithAvroTests {
 
   @Test
   public void shouldReconstructNonNullableSingleUnion() {
-    // Same as above without a null branch: the partner owns null placement, so no null may be invented.
-    StructType coral = struct(field("u", unionStruct(stringType(true))));
+    // Same as above without a null branch anywhere: nothing may fabricate one.
+    StructType coral = struct(field("u", unionStruct(false, stringType(true))));
     Schema avro = avroStruct("r1", avroField("u", avroUnion(Schema.Type.STRING), null, null, null));
 
     Schema result = merge(coral, avro);
@@ -519,16 +559,52 @@ public class MergeCoralSchemaWithAvroTests {
     assertEquals(u.getTypes().get(2).getType(), Schema.Type.INT);
   }
 
+  @Test
+  public void shouldRelaxNullabilityForArrayElementAndMapValue() {
+    // The relax rule is applied at a single choke point, so nested positions inherit it. Coral marks the
+    // element and value required while the partner declares both nullable.
+    StructType coral = struct(field("arr", ArrayType.of(intType(false), false)),
+        field("m", MapType.of(stringType(false), intType(false), false)));
+    Schema nullableInt = SchemaUtilities.makeNullable(Schema.create(Schema.Type.INT), false);
+    Schema avro = avroStruct("r1", requiredField("arr", Schema.createArray(nullableInt)),
+        requiredField("m", Schema.createMap(nullableInt)));
+
+    Schema result = merge(coral, avro);
+    Schema arr = SchemaUtilities.extractIfOption(result.getField("arr").schema());
+    Schema map = SchemaUtilities.extractIfOption(result.getField("m").schema());
+    assertTrue(AvroSerdeUtils.isNullableType(arr.getElementType()));
+    assertTrue(AvroSerdeUtils.isNullableType(map.getValueType()));
+  }
+
+  @Test
+  public void shouldRelaxNullabilityForNestedStructField() {
+    StructType coral = struct(field("outer", struct(field("inner", intType(false)))));
+    Schema avro = avroStruct("r1", requiredField("outer", avroStruct("r2", optionalField("inner", Schema.Type.INT))));
+
+    Schema result = merge(coral, avro);
+    Schema outer = SchemaUtilities.extractIfOption(result.getField("outer").schema());
+    assertTrue(AvroSerdeUtils.isNullableType(outer.getField("inner").schema()));
+  }
+
   /** Test Helpers */
 
   /** Builds a Trino-style union-struct {tag:INT, field0, field1, ...} from the given union member types. */
   private StructType unionStruct(com.linkedin.coral.common.types.CoralDataType... members) {
+    return unionStruct(true, members);
+  }
+
+  /**
+   * Union-struct with explicit nullability. Iceberg's {@code optional}/{@code required} flag on the
+   * column reaches the merge engine as this flag, and the envelope is nullable when either it or the
+   * partner says so — so tests that assert an envelope without a NULL branch must pass {@code false}.
+   */
+  private StructType unionStruct(boolean nullable, com.linkedin.coral.common.types.CoralDataType... members) {
     StructField[] fields = new StructField[members.length + 1];
     fields[0] = field("tag", intType(true));
     for (int i = 0; i < members.length; i++) {
       fields[i + 1] = field("field" + i, members[i]);
     }
-    return struct(fields);
+    return StructType.of(Arrays.asList(fields), nullable);
   }
 
   private Schema avroUnion(Schema.Type... branchTypes) {

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvroTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvroTests.java
@@ -360,6 +360,80 @@ public class MergeCoralSchemaWithAvroTests {
     assertEquals(u.getTypes().get(1).getType(), Schema.Type.STRING);
   }
 
+  @Test
+  public void shouldMergeRecordMemberAgainstItsPartnerBranch() {
+    // uniontype<int, struct<x:int>>: the struct member must become a record branch whose fields are
+    // merged from the corresponding partner branch, and must NOT be double-wrapped in its own
+    // [null, record] option — the union's own NULL branch already carries nullability.
+    StructType coral = struct(field("u", unionStruct(intType(true), struct(field("x", intType(true))))));
+    Schema partnerRecordBranch = avroStruct("branchRec", optionalField("x", Schema.Type.INT));
+    Schema avro = avroStruct("r1",
+        avroField("u",
+            avroUnionOf(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT), partnerRecordBranch), null,
+            null, null));
+
+    Schema result = merge(coral, avro);
+    Schema u = result.getField("u").schema();
+    assertEquals(u.getType(), Schema.Type.UNION);
+    assertEquals(u.getTypes().size(), 3);
+    assertEquals(u.getTypes().get(0).getType(), Schema.Type.NULL);
+    assertEquals(u.getTypes().get(1).getType(), Schema.Type.INT);
+
+    Schema recordBranch = u.getTypes().get(2);
+    // Not wrapped in an option: the branch is the record itself, not [null, record].
+    assertEquals(recordBranch.getType(), Schema.Type.RECORD);
+    // The member's fields were merged against the partner branch rather than regenerated blindly.
+    assertEquals(recordBranch.getName(), "branchRec");
+    assertNotNull(recordBranch.getField("x"));
+  }
+
+  @Test
+  public void shouldKeepArrayMemberAsArrayBranch() {
+    // uniontype<int, array<string>>: the array member must stay an array branch rather than being
+    // collapsed or unwrapped into its element type.
+    StructType coral = struct(field("u", unionStruct(intType(true), ArrayType.of(stringType(true), true))));
+    Schema partnerArrayBranch =
+        Schema.createArray(SchemaUtilities.makeNullable(Schema.create(Schema.Type.STRING), false));
+    Schema avro = avroStruct("r1",
+        avroField("u", avroUnionOf(Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.INT), partnerArrayBranch),
+            null, null, null));
+
+    Schema result = merge(coral, avro);
+    Schema u = result.getField("u").schema();
+    assertEquals(u.getType(), Schema.Type.UNION);
+    assertEquals(u.getTypes().size(), 3);
+    assertEquals(u.getTypes().get(0).getType(), Schema.Type.NULL);
+    assertEquals(u.getTypes().get(1).getType(), Schema.Type.INT);
+
+    Schema arrayBranch = u.getTypes().get(2);
+    assertEquals(arrayBranch.getType(), Schema.Type.ARRAY);
+    assertEquals(SchemaUtilities.extractIfOption(arrayBranch.getElementType()).getType(), Schema.Type.STRING);
+  }
+
+  @Test
+  public void shouldPromoteStringMemberToPartnerEnumBranch() {
+    // uniontype<string, int> whose partner branch is an enum: branches go through the normal promotion
+    // path (checkCompatibilityAndPromote), so the STRING member must surface as the partner's ENUM
+    // rather than a bare string.
+    StructType coral = struct(field("u", unionStruct(stringType(true), intType(true))));
+    Schema partnerEnumBranch = Schema.createEnum("Color", null, "com.test", Arrays.asList("RED", "GREEN"));
+    Schema avro = avroStruct("r1",
+        avroField("u", avroUnionOf(Schema.create(Schema.Type.NULL), partnerEnumBranch, Schema.create(Schema.Type.INT)),
+            null, null, null));
+
+    Schema result = merge(coral, avro);
+    Schema u = result.getField("u").schema();
+    assertEquals(u.getType(), Schema.Type.UNION);
+    assertEquals(u.getTypes().size(), 3);
+    assertEquals(u.getTypes().get(0).getType(), Schema.Type.NULL);
+
+    Schema enumBranch = u.getTypes().get(1);
+    assertEquals(enumBranch.getType(), Schema.Type.ENUM);
+    assertEquals(enumBranch.getName(), "Color");
+    assertEquals(enumBranch.getEnumSymbols(), Arrays.asList("RED", "GREEN"));
+    assertEquals(u.getTypes().get(2).getType(), Schema.Type.INT);
+  }
+
   /** Test Helpers */
 
   /** Builds a Trino-style union-struct {tag:INT, field0, field1, ...} from the given union member types. */
@@ -377,6 +451,11 @@ public class MergeCoralSchemaWithAvroTests {
     for (int i = 0; i < branchTypes.length; i++) {
       branches[i] = Schema.create(branchTypes[i]);
     }
+    return Schema.createUnion(Arrays.asList(branches));
+  }
+
+  /** Union builder for branches that are not plain primitives (records, arrays, enums). */
+  private Schema avroUnionOf(Schema... branches) {
     return Schema.createUnion(Arrays.asList(branches));
   }
 

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvroTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvroTests.java
@@ -641,6 +641,90 @@ public class MergeCoralSchemaWithAvroTests {
   }
 
   @Test
+  public void shouldPreserveSingleElementUnionEnvelopeAroundAnArray() {
+    // The production shape behind organization_mp.product_dbchanges_hourly $.value.productCategoryUrns:
+    // uniontype<array<string>> flattened by Iceberg to array<string> while the partner still declares
+    // [{"type":"array","items":"string"}]. Dispatch is on the Coral kind, so this reaches mergeArray
+    // rather than mergeLeaf — the envelope handling has to sit above that switch to cover it.
+    StructType coral = struct(field("u", ArrayType.of(stringType(false), false)));
+    Schema arrayBranch = Schema.createArray(Schema.create(Schema.Type.STRING));
+    Schema avro = avroStruct("r1", avroField("u", avroUnionOf(arrayBranch), null, null, null));
+
+    Schema result = merge(coral, avro);
+    Schema u = result.getField("u").schema();
+    assertEquals(u.getType(), Schema.Type.UNION);
+    assertEquals(u.getTypes().size(), 1);
+    assertEquals(u.getTypes().get(0).getType(), Schema.Type.ARRAY);
+    assertEquals(u.getTypes().get(0).getElementType().getType(), Schema.Type.STRING);
+  }
+
+  @Test
+  public void shouldPreserveSingleElementUnionEnvelopeAroundAMap() {
+    StructType coral = struct(field("u", MapType.of(stringType(false), stringType(false), false)));
+    Schema mapBranch = Schema.createMap(Schema.create(Schema.Type.STRING));
+    Schema avro = avroStruct("r1", avroField("u", avroUnionOf(mapBranch), null, null, null));
+
+    Schema result = merge(coral, avro);
+    Schema u = result.getField("u").schema();
+    assertEquals(u.getType(), Schema.Type.UNION);
+    assertEquals(u.getTypes().size(), 1);
+    assertEquals(u.getTypes().get(0).getType(), Schema.Type.MAP);
+    assertEquals(u.getTypes().get(0).getValueType().getType(), Schema.Type.STRING);
+  }
+
+  @Test
+  public void shouldPreserveSingleElementUnionEnvelopeAroundAStructAndStillMergeIt() {
+    // The partner record must still be merged through the envelope, otherwise its name, docs and
+    // props are lost exactly as they were before the envelope was recognised at all.
+    StructType coral = struct(field("u", StructType.of(Arrays.asList(field("x", intType(false))), false)));
+    Schema recordBranch = avroStruct("Inner", "inner-doc", "com.test",
+        avroField("x", SchemaUtilities.makeNullable(Schema.create(Schema.Type.INT), false), "x-doc", null, null));
+    Schema avro = avroStruct("r1", avroField("u", avroUnionOf(recordBranch), null, null, null));
+
+    Schema result = merge(coral, avro);
+    Schema u = result.getField("u").schema();
+    assertEquals(u.getType(), Schema.Type.UNION);
+    assertEquals(u.getTypes().size(), 1);
+    Schema inner = u.getTypes().get(0);
+    assertEquals(inner.getType(), Schema.Type.RECORD);
+    assertEquals(inner.getName(), "Inner");
+    assertEquals(inner.getField("x").doc(), "x-doc");
+    // Relaxed nullability still applies inside the envelope: the partner says x is nullable.
+    assertEquals(inner.getField("x").schema().getType(), Schema.Type.UNION);
+  }
+
+  @Test
+  public void shouldSubsumeAFlattenedArrayEnvelopeIntoTheNullableForm() {
+    // Same as the array case but Iceberg marks the column optional, so ["null", array] already
+    // carries the union and no extra envelope is added.
+    StructType coral = struct(field("u", ArrayType.of(stringType(true), true)));
+    Schema arrayBranch = Schema.createArray(Schema.create(Schema.Type.STRING));
+    Schema avro = avroStruct("r1", avroField("u", avroUnionOf(arrayBranch), null, null, null));
+
+    Schema result = merge(coral, avro);
+    Schema u = result.getField("u").schema();
+    assertEquals(u.getType(), Schema.Type.UNION);
+    assertEquals(u.getTypes().size(), 2);
+    assertEquals(u.getTypes().get(0).getType(), Schema.Type.NULL);
+    assertEquals(u.getTypes().get(1).getType(), Schema.Type.ARRAY);
+  }
+
+  @Test
+  public void shouldStillReconstructAMultiBranchUnionStructWhenPartnerIsAUnion() {
+    // Guard on precedence: a genuine union-struct must keep going through mergeUnionStruct and must
+    // not be diverted by the single-branch envelope path.
+    StructType coral = struct(field("u", unionStruct(false, intType(true), stringType(true))));
+    Schema avro = avroStruct("r1", avroField("u", avroUnion(Schema.Type.INT, Schema.Type.STRING), null, null, null));
+
+    Schema result = merge(coral, avro);
+    Schema u = result.getField("u").schema();
+    assertEquals(u.getType(), Schema.Type.UNION);
+    assertEquals(u.getTypes().size(), 2);
+    assertEquals(u.getTypes().get(0).getType(), Schema.Type.INT);
+    assertEquals(u.getTypes().get(1).getType(), Schema.Type.STRING);
+  }
+
+  @Test
   public void shouldPreferAnExactCaseMatchOverAnEarlierCaseInsensitiveOne() {
     // Avro permits fa and fA as siblings. The exact match must win even though the inexact one is
     // declared first, otherwise the wrong field's doc/default/props get copied.

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvroTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvroTests.java
@@ -434,6 +434,91 @@ public class MergeCoralSchemaWithAvroTests {
     assertEquals(u.getTypes().get(2).getType(), Schema.Type.INT);
   }
 
+  @Test
+  public void shouldReconstructNullableSingleUnion() {
+    // uniontype<string> persisted into Iceberg is {tag, field0} — HiveToCoralTypeConverter.convertUnion
+    // emits the union-struct encoding for EVERY arity, not just multi-branch. A nullable single union must
+    // come back as [null, string]; leaving it on the struct path would leak {tag, field0} into the output.
+    StructType coral = struct(field("u", unionStruct(stringType(true))));
+    Schema avro = avroStruct("r1", avroField("u", avroUnion(Schema.Type.NULL, Schema.Type.STRING), null, null, null));
+
+    Schema result = merge(coral, avro);
+    Schema u = result.getField("u").schema();
+    assertEquals(u.getType(), Schema.Type.UNION);
+    assertEquals(u.getTypes().size(), 2);
+    assertEquals(u.getTypes().get(0).getType(), Schema.Type.NULL);
+    assertEquals(u.getTypes().get(1).getType(), Schema.Type.STRING);
+  }
+
+  @Test
+  public void shouldReconstructNonNullableSingleUnion() {
+    // Same as above without a null branch: the partner owns null placement, so no null may be invented.
+    StructType coral = struct(field("u", unionStruct(stringType(true))));
+    Schema avro = avroStruct("r1", avroField("u", avroUnion(Schema.Type.STRING), null, null, null));
+
+    Schema result = merge(coral, avro);
+    Schema u = result.getField("u").schema();
+    assertEquals(u.getType(), Schema.Type.UNION);
+    assertEquals(u.getTypes().size(), 1);
+    assertEquals(u.getTypes().get(0).getType(), Schema.Type.STRING);
+  }
+
+  @Test
+  public void shouldTreatGenuineNullableStructNamedLikeUnionStructAsStruct() {
+    // A real struct that happens to be named {tag, field0} is shape-indistinguishable from a single
+    // uniontype. The partner disambiguates: its sole branch is the record describing the struct, so it
+    // carries its own "tag" field. This must stay a record, not become a union.
+    StructType coral = struct(field("u", struct(field("tag", intType(true)), field("field0", stringType(true)))));
+    Schema partnerRecord =
+        avroStruct("genuineStruct", optionalField("tag", Schema.Type.INT), optionalField("field0", Schema.Type.STRING));
+    Schema avro =
+        avroStruct("r1", avroField("u", avroUnionOf(Schema.create(Schema.Type.NULL), partnerRecord), null, null, null));
+
+    Schema result = merge(coral, avro);
+    Schema u = result.getField("u").schema();
+    assertEquals(u.getType(), Schema.Type.UNION);
+    Schema inner = SchemaUtilities.extractIfOption(u);
+    assertEquals(inner.getType(), Schema.Type.RECORD);
+    assertEquals(inner.getName(), "genuineStruct");
+    assertNotNull(inner.getField("tag"));
+    assertNotNull(inner.getField("field0"));
+  }
+
+  @Test
+  public void shouldReconstructSingleUnionWhoseMemberIsARecord() {
+    // uniontype<struct<x:int>>: the partner's sole branch is a record WITHOUT a "tag" field, so it is the
+    // member type rather than a description of the union-struct — reconstruct as a union.
+    StructType coral = struct(field("u", unionStruct(struct(field("x", intType(true))))));
+    Schema memberRecord = avroStruct("memberRec", optionalField("x", Schema.Type.INT));
+    Schema avro =
+        avroStruct("r1", avroField("u", avroUnionOf(Schema.create(Schema.Type.NULL), memberRecord), null, null, null));
+
+    Schema result = merge(coral, avro);
+    Schema u = result.getField("u").schema();
+    assertEquals(u.getType(), Schema.Type.UNION);
+    assertEquals(u.getTypes().size(), 2);
+    assertEquals(u.getTypes().get(0).getType(), Schema.Type.NULL);
+    assertEquals(u.getTypes().get(1).getType(), Schema.Type.RECORD);
+    assertEquals(u.getTypes().get(1).getName(), "memberRec");
+    assertNotNull(u.getTypes().get(1).getField("x"));
+  }
+
+  @Test
+  public void shouldDetectUnionStructMarkerNamesCaseInsensitively() {
+    // A catalog that normalizes field casing must not silently downgrade a union to a record.
+    StructType coral = struct(field("u",
+        struct(field("TAG", intType(true)), field("Field0", stringType(true)), field("FIELD1", intType(true)))));
+    Schema avro = avroStruct("r1",
+        avroField("u", avroUnion(Schema.Type.NULL, Schema.Type.STRING, Schema.Type.INT), null, null, null));
+
+    Schema result = merge(coral, avro);
+    Schema u = result.getField("u").schema();
+    assertEquals(u.getType(), Schema.Type.UNION);
+    assertEquals(u.getTypes().get(0).getType(), Schema.Type.NULL);
+    assertEquals(u.getTypes().get(1).getType(), Schema.Type.STRING);
+    assertEquals(u.getTypes().get(2).getType(), Schema.Type.INT);
+  }
+
   /** Test Helpers */
 
   /** Builds a Trino-style union-struct {tag:INT, field0, field1, ...} from the given union member types. */

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvroTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/MergeCoralSchemaWithAvroTests.java
@@ -586,6 +586,60 @@ public class MergeCoralSchemaWithAvroTests {
     assertTrue(AvroSerdeUtils.isNullableType(outer.getField("inner").schema()));
   }
 
+  @Test
+  public void shouldPreserveSingleElementUnionEnvelopeWhenIcebergFlattensIt() {
+    // Iceberg has no union type, so uniontype<string> may surface as a plain field while the partner
+    // still declares ["string"]. The old path reconstructs uniontype<string> from the partner via
+    // AvroAwareHiveSchemaUtil and emits ["string"], so dropping the envelope here would regress.
+    StructType coral = struct(field("u", stringType(false)));
+    Schema avro = avroStruct("r1", avroField("u", avroUnion(Schema.Type.STRING), null, null, null));
+
+    Schema result = merge(coral, avro);
+    Schema u = result.getField("u").schema();
+    assertEquals(u.getType(), Schema.Type.UNION);
+    assertEquals(u.getTypes().size(), 1);
+    assertEquals(u.getTypes().get(0).getType(), Schema.Type.STRING);
+  }
+
+  @Test
+  public void shouldSubsumeFlattenedSingleUnionEnvelopeIntoTheNullableForm() {
+    // Same input but Iceberg marks the column optional. ["null","string"] is the only Avro
+    // representation of a nullable single union, so no extra envelope is added.
+    StructType coral = struct(field("u", stringType(true)));
+    Schema avro = avroStruct("r1", avroField("u", avroUnion(Schema.Type.STRING), null, null, null));
+
+    Schema result = merge(coral, avro);
+    Schema u = result.getField("u").schema();
+    assertEquals(u.getType(), Schema.Type.UNION);
+    assertEquals(u.getTypes().size(), 2);
+    assertEquals(u.getTypes().get(0).getType(), Schema.Type.NULL);
+    assertEquals(u.getTypes().get(1).getType(), Schema.Type.STRING);
+  }
+
+  @Test
+  public void shouldPromoteThroughAFlattenedSingleUnionEnvelope() {
+    // The branch is still merged, so an enum partner branch promotes the Coral string as usual.
+    StructType coral = struct(field("u", stringType(false)));
+    Schema enumBranch = Schema.createEnum("Color", null, "com.test", Arrays.asList("RED", "GREEN"));
+    Schema avro = avroStruct("r1", avroField("u", avroUnionOf(enumBranch), null, null, null));
+
+    Schema result = merge(coral, avro);
+    Schema u = result.getField("u").schema();
+    assertEquals(u.getType(), Schema.Type.UNION);
+    assertEquals(u.getTypes().size(), 1);
+    assertEquals(u.getTypes().get(0).getType(), Schema.Type.ENUM);
+    assertEquals(u.getTypes().get(0).getName(), "Color");
+  }
+
+  @Test
+  public void shouldNotFabricateAnEnvelopeForAPlainPartner() {
+    StructType coral = struct(field("u", stringType(false)));
+    Schema avro = avroStruct("r1", requiredField("u", Schema.Type.STRING));
+
+    Schema result = merge(coral, avro);
+    assertEquals(result.getField("u").schema().getType(), Schema.Type.STRING);
+  }
+
   /** Test Helpers */
 
   /** Builds a Trino-style union-struct {tag:INT, field0, field1, ...} from the given union member types. */

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
@@ -20,6 +20,7 @@ import org.testng.annotations.Test;
 
 import com.linkedin.coral.common.catalog.CoralTable;
 import com.linkedin.coral.common.catalog.TableType;
+import com.linkedin.coral.common.types.ArrayType;
 import com.linkedin.coral.common.types.CoralDataType;
 import com.linkedin.coral.common.types.CoralTypeKind;
 import com.linkedin.coral.common.types.PrimitiveType;
@@ -175,6 +176,98 @@ public class SchemaUtilitiesTests {
     Assert.assertEquals(result.getNamespace(), "flat");
   }
 
+  @Test
+  public void testGetAvroSchemaForCoralTableMultiBranchUnion() {
+    // A Hive uniontype<int,string,boolean> persisted into Iceberg surfaces as the struct
+    // {tag, field0, field1, field2}. The partner Avro keeps it as a real union, so the merge engine must
+    // reconstruct that union (matching the legacy Hive path) rather than synthesize a record.
+    StructType unionStruct = struct(field("tag", intType(true)), field("field0", intType(true)),
+        field("field1", stringType(true)), field("field2", boolType(true)));
+    StructType coralSchema = struct(field("u", unionStruct));
+    String partner = "{\"type\":\"record\",\"name\":\"R\",\"namespace\":\"x\",\"fields\":["
+        + "{\"name\":\"u\",\"type\":[\"null\",\"int\",\"string\",\"boolean\"],\"default\":null}]}";
+    Map<String, String> properties = new HashMap<>();
+    properties.put("avro.schema.literal", partner);
+
+    Schema result = SchemaUtilities.getAvroSchemaForTable(new TestCoralTable("db.tbl", coralSchema, properties), false);
+
+    Schema u = result.getField("u").schema();
+    Assert.assertEquals(u.getType(), Schema.Type.UNION);
+    List<Schema.Type> branchTypes = new ArrayList<>();
+    for (Schema branch : u.getTypes()) {
+      branchTypes.add(branch.getType());
+    }
+    Assert.assertEquals(branchTypes,
+        Arrays.asList(Schema.Type.NULL, Schema.Type.INT, Schema.Type.STRING, Schema.Type.BOOLEAN));
+  }
+
+  @Test
+  public void testGetAvroSchemaForCoralTableUnionInArray() {
+    // facetClauses-style column: an array whose element is a union. The element union-struct must be
+    // reconstructed into an Avro union, not collapsed.
+    StructType unionStruct =
+        struct(field("tag", intType(true)), field("field0", intType(true)), field("field1", stringType(true)));
+    StructType coralSchema = struct(field("facets", ArrayType.of(unionStruct, true)));
+    String partner = "{\"type\":\"record\",\"name\":\"R\",\"namespace\":\"x\",\"fields\":["
+        + "{\"name\":\"facets\",\"type\":[\"null\",{\"type\":\"array\",\"items\":[\"null\",\"int\",\"string\"]}],"
+        + "\"default\":null}]}";
+    Map<String, String> properties = new HashMap<>();
+    properties.put("avro.schema.literal", partner);
+
+    Schema result = SchemaUtilities.getAvroSchemaForTable(new TestCoralTable("db.tbl", coralSchema, properties), false);
+
+    Schema facets = AvroSerdeUtils.isNullableType(result.getField("facets").schema())
+        ? AvroSerdeUtils.getOtherTypeFromNullableType(result.getField("facets").schema())
+        : result.getField("facets").schema();
+    Assert.assertEquals(facets.getType(), Schema.Type.ARRAY);
+    Schema element = facets.getElementType();
+    Assert.assertEquals(element.getType(), Schema.Type.UNION);
+    Assert.assertEquals(element.getTypes().get(0).getType(), Schema.Type.NULL);
+    Assert.assertEquals(element.getTypes().size(), 3); // [null, int, string]
+  }
+
+  @Test
+  public void testGetAvroSchemaForCoralTableUnionWithDefaultDoesNotThrow() {
+    // Regression for legacy tables that failed outright because a union-typed field default could not be
+    // applied to the synthesized record. With the union correctly reconstructed, the partner default holds.
+    StructType unionStruct =
+        struct(field("tag", intType(true)), field("field0", intType(true)), field("field1", stringType(true)));
+    StructType coralSchema = struct(field("u", unionStruct));
+    String partner = "{\"type\":\"record\",\"name\":\"R\",\"namespace\":\"x\",\"fields\":["
+        + "{\"name\":\"u\",\"type\":[\"null\",\"int\",\"string\"],\"default\":null}]}";
+    Map<String, String> properties = new HashMap<>();
+    properties.put("avro.schema.literal", partner);
+
+    Schema result = SchemaUtilities.getAvroSchemaForTable(new TestCoralTable("db.tbl", coralSchema, properties), false);
+
+    Assert.assertEquals(result.getField("u").schema().getType(), Schema.Type.UNION);
+    Assert.assertTrue(AvroCompatibilityHelper.fieldHasDefault(result.getField("u")));
+  }
+
+  @Test
+  public void testUnionStructShapeWithRecordPartnerStaysStruct() {
+    // A genuine nullable struct that happens to reuse the union-struct field names. Its partner is
+    // [null, record] — one non-null branch — so the member-count guard keeps it a record, not a union.
+    StructType genuineStruct =
+        struct(field("tag", intType(true)), field("field0", intType(true)), field("field1", stringType(true)));
+    StructType coralSchema = struct(field("s", genuineStruct));
+    String partner = "{\"type\":\"record\",\"name\":\"R\",\"namespace\":\"x\",\"fields\":["
+        + "{\"name\":\"s\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"S\",\"fields\":["
+        + "{\"name\":\"tag\",\"type\":[\"null\",\"int\"],\"default\":null},"
+        + "{\"name\":\"field0\",\"type\":[\"null\",\"int\"],\"default\":null},"
+        + "{\"name\":\"field1\",\"type\":[\"null\",\"string\"],\"default\":null}]}],\"default\":null}]}";
+    Map<String, String> properties = new HashMap<>();
+    properties.put("avro.schema.literal", partner);
+
+    Schema result = SchemaUtilities.getAvroSchemaForTable(new TestCoralTable("db.tbl", coralSchema, properties), false);
+
+    Schema s = AvroSerdeUtils.isNullableType(result.getField("s").schema())
+        ? AvroSerdeUtils.getOtherTypeFromNullableType(result.getField("s").schema()) : result.getField("s").schema();
+    Assert.assertEquals(s.getType(), Schema.Type.RECORD);
+    Assert.assertNotNull(s.getField("tag"));
+    Assert.assertNotNull(s.getField("field0"));
+  }
+
   /**
    * Minimal {@link CoralTable} test fixture. Used to exercise the non-Hive path of
    * {@link SchemaUtilities#getAvroSchemaForTable(CoralTable, boolean)} without requiring a real
@@ -227,6 +320,10 @@ public class SchemaUtilitiesTests {
 
   private static PrimitiveType stringType(boolean nullable) {
     return PrimitiveType.of(CoralTypeKind.STRING, nullable);
+  }
+
+  private static PrimitiveType boolType(boolean nullable) {
+    return PrimitiveType.of(CoralTypeKind.BOOLEAN, nullable);
   }
 
   @Test

--- a/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
+++ b/coral-schema/src/test/java/com/linkedin/coral/schema/avro/SchemaUtilitiesTests.java
@@ -120,10 +120,10 @@ public class SchemaUtilitiesTests {
   }
 
   @Test
-  public void testGetAvroSchemaForCoralTableIcebergCoralNullabilityWins() {
-    // Coral declares id as non-nullable; partner Avro declares id as nullable ([null,int]).
-    // Iceberg-first semantics require the Coral nullability to win, which proves the merge
-    // engine ran rather than the partner schema being passed through unchanged.
+  public void testGetAvroSchemaForCoralTableIcebergRelaxesNullability() {
+    // Coral declares id as required; partner Avro declares id as nullable ([null,int]). Nullability is
+    // always relaxed, so the partner's null branch survives. This also proves the merge engine ran
+    // rather than the partner schema being passed through unchanged, since the record is rebuilt.
     StructType coralSchema = struct(field("id", intType(false)));
     String nullablePartner = "{\"type\":\"record\",\"name\":\"R\",\"namespace\":\"x\","
         + "\"fields\":[{\"name\":\"id\",\"type\":[\"null\",\"int\"],\"default\":null}]}";
@@ -134,8 +134,8 @@ public class SchemaUtilitiesTests {
     Schema result = SchemaUtilities.getAvroSchemaForTable(coralTable, false);
 
     Assert.assertNotNull(result.getField("id"));
-    Assert.assertFalse(AvroSerdeUtils.isNullableType(result.getField("id").schema()),
-        "Coral nullability (non-nullable) must win over partner Avro nullability");
+    Assert.assertTrue(AvroSerdeUtils.isNullableType(result.getField("id").schema()),
+        "nullability must be relaxed: the partner's null branch must not be dropped");
   }
 
   @Test


### PR DESCRIPTION
## What
Adds a multi-branch union reconstruction path to `MergeCoralSchemaWithAvro` (the Iceberg-first Avro merge engine introduced in #600/#604).

## Why
Iceberg has no union type. A Hive `uniontype<A,B,C>` that has been persisted into an Iceberg table surfaces as the struct `{tag:INT, field0:A, field1:B, field2:C}` — the Trino union representation ([trinodb/trino#3483](https://github.com/trinodb/trino/pull/3483)), the same encoding `HiveToCoralTypeConverter.convertUnion` produces — while the partner Avro still describes the column as a real union `[null,A,B,C]`.

Before this change, the engine could not match the union partner, so it synthesized a record: multi-branch unions collapsed, and union-typed field defaults failed outright. This diverged from the legacy Hive Avro path (`MergeHiveSchemaWithAvro.union`).

## How
- **`unionPartnerOrNull`** detects the case, requiring all of: (1) the Coral struct is union-shaped (`tag:INT` then `field0..fieldN-1` in order), (2) the partner is an Avro union, and (3) the partner's non-null branch count equals the member count. A `memberCount >= 2` guard makes detection collision-free — a genuine nullable struct yields `[null, record]` (one non-null branch), which can never equal a member count of two or more. Single-member union-structs fall back to the struct path.
- **`mergeUnionStruct`** merges each `fieldN` member against the partner union branch by ordinal, strips per-member null wrappers (the union's own NULL branch carries nullability), and emits the NULL branch first when the partner union has one — matching `MergeHiveSchemaWithAvro.union`. Emitting a real union also lets the partner's field default apply exactly as on the Hive path.

## Testing
Six new tests (full `coral-schema` suite green, spotless clean): multi-branch reconstruction, the no-null-branch case, arrays of unions, the union-default regression, and a negative case proving a genuine record partner is not mistaken for a union.
