### PR TITLE
Bump Avro to 1.11.4 and avroutil1 helper to 0.4.38

### DIFF
--- a/coral-schema/build.gradle
+++ b/coral-schema/build.gradle
@@ -16,6 +16,6 @@ dependencies {
 
 configurations.all {
   resolutionStrategy {
-    force 'org.apache.avro:avro:1.10.2'
+    force 'org.apache.avro:avro:1.11.4'
   }
 }

--- a/coral-spark/build.gradle
+++ b/coral-spark/build.gradle
@@ -18,9 +18,9 @@ dependencies {
   testImplementation deps.'kryo'
 }
 
-// Needs to enforce using Avro 1.10 because Coral-Spark depends on Coral-Schema which uses Avro 1.10
+// Needs to enforce using Avro 1.11.4 because Coral-Spark depends on Coral-Schema which uses Avro 1.11.4
 configurations.all {
   resolutionStrategy {
-    force 'org.apache.avro:avro:1.10.2'
+    force 'org.apache.avro:avro:1.11.4'
   }
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,7 +1,7 @@
 def versions = [
   'antlr': '3.4',
   'automaton': '1.11-8',
-  'avro-utl': '0.2.117',
+  'avro-utl': '0.4.38',
   'graph-vis': '0.18.1',
   'gson': '2.9.0',
   'hadoop': '2.7.0',


### PR DESCRIPTION
Move the forced Avro pin in coral-schema and coral-spark from 1.10.2 to 1.11.4 to pick up the security fix, and bump the avroutil1 compatibility helper from 0.2.117 to 0.4.38. The forced pin now resolves the previously vulnerable transitive Avro (1.7.x/1.8.2/1.11.1) up to 1.11.4 across coral-schema and coral-spark.

### What changes are proposed in this pull request, and why are they necessary?
Bump Avro from 1.10.2 to 1.11.4 to pick up the security fix, and bump the avroutil1 compatibility helper from 0.2.117 to 0.4.38.

•  coral-schema/build.gradle : forced Avro pin  1.10.2  →  1.11.4 
•  coral-spark/build.gradle : forced Avro pin  1.10.2  →  1.11.4  (and updated the accompanying comment)
•  gradle/dependencies.gradle :  avro-utl  helper  0.2.117  →  0.4.38 

### How was this patch tested?
• `./gradlew clean build`  passes; existing  coral-schema  and  coral-spark  unit test suites pass against Avro 1.11.4.
• Regression tested Avro schema generation across 884 datasets, producing 867 Avro schemas, and confirmed no regressions between the current release and this change — the generated schemas were identical across versions.
