### PR TITLE
Register member-id-utils Hive UDFs in StaticHiveFunctionRegistry 

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/hive/hive2rel/functions/StaticHiveFunctionRegistry.java
@@ -434,6 +434,14 @@ public class StaticHiveFunctionRegistry implements FunctionRegistry {
     createAddUserDefinedFunction("org.apache.hadoop.hive.ql.udf.generic.GenericProject", ARG0,
         family(SqlTypeFamily.ANY, SqlTypeFamily.STRING));
     createAddUserDefinedFunction("com.linkedin.dali.view.udf.entityhandles.GetIdFromUrn", BIGINT, STRING);
+
+    // Start of member-id-utils Hive UDFs
+    createAddUserDefinedFunction("com.linkedin.memberidutils.hive.GetIdFromMemberUrnUdf", BIGINT_NULLABLE, STRING);
+    createAddUserDefinedFunction("com.linkedin.memberidutils.hive.GetSaltedIdUdf", BIGINT, NILADIC);
+    createAddUserDefinedFunction("com.linkedin.memberidutils.hive.IsMemberFromUrnUdf", ReturnTypes.BOOLEAN, STRING);
+    createAddUserDefinedFunction("com.linkedin.memberidutils.hive.IsMemberUdf", ReturnTypes.BOOLEAN, NUMERIC);
+    createAddUserDefinedFunction("com.linkedin.memberidutils.hive.IsSaltedIdUdf", ReturnTypes.BOOLEAN, NUMERIC);
+    // End of member-id-utils Hive UDFs
     createAddUserDefinedFunction("com.linkedin.dali.view.udf.entityhandles.GetPermissionsString",
         FunctionReturnTypes.STRING, family(SqlTypeFamily.ARRAY));
     createAddUserDefinedFunction("com.linkedin.dali.view.udf.entityhandles.EpochTimeInSeconds", BIGINT, STRING);


### PR DESCRIPTION
Fix RuntimeException when using member-id-utils Hive UDFs.

### What changes are proposed in this pull request, and why are they necessary?

Coral failed to translate views using c`om.linkedin.memberidutils.hive.*` UDFs because these UDFs are not registered. Coral fallback logic attempted to use reflection to load the UDFs but it failed because the UDFs extend `org.apache.hadoop.hive.ql.exec.UDF` as opposed to the expected `org.apache.hadoop.hive.ql.udf.generic.GenericUDF`.

Registering the five UDFs by their implementing class name provides the return type and operand type inference statically, so Coral no longer needs to load the class reflectively during view translation.

Followed example PR: https://github.com/linkedin/coral/pull/576

### How was this patch tested?
```
./gradlew -Dorg.gradle.java.home=/Library/Java/JavaVirtualMachines/jdk17.0.5-msft.jdk/Contents/Home clean build
./gradlew -Dorg.gradle.java.home=/Library/Java/JavaVirtualMachines/jdk17.0.5-msft.jdk/Contents/Home spotlessApply
```
