### PR TITLE
 [Coral-Spark] Upgrade standard-udfs-dali-udfs to 2.0.124 for Spark Scala 2.12 

### DIFF
--- a/coral-spark/src/main/java/com/linkedin/coral/spark/transformers/TransportUDFTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/transformers/TransportUDFTransformer.java
@@ -46,7 +46,7 @@ public class TransportUDFTransformer extends SqlCallTransformer {
   public static final String DALI_UDFS_IVY_URL_SPARK_2_11 =
       "ivy://com.linkedin.standard-udfs-dali-udfs:standard-udfs-dali-udfs:2.0.3?classifier=spark_2.11";
   public static final String DALI_UDFS_IVY_URL_SPARK_2_12 =
-      "ivy://com.linkedin.standard-udfs-dali-udfs:standard-udfs-dali-udfs:2.0.3?classifier=spark_2.12";
+      "ivy://com.linkedin.standard-udfs-dali-udfs:standard-udfs-dali-udfs:2.0.124?classifier=spark_2.12";
 
   public enum ScalaVersion {
     SCALA_2_11,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:
  1. If you are new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you have added and executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
  7. Make sure that the command './gradlew clean build' passes. Resolve any formatting errors by running './gradlew spotlessApply'.
-->

### What changes are proposed in this pull request, and why are they necessary?
<!--
Kindly explain the proposed changes in this section. The goal is to outline the modifications and how this PR addresses the issue. Also, clarify the reasons for these changes. For example,
  1. If a new API is proposed, explain the intended use case.
  2. If a bug is being fixed, describe why it is a bug.
  3. If design documentation is available, please include the link.
-->
This PR bumps the Transport UDF artifact version for Spark Scala 2.12 from  2.0.3  to  2.0.124 .

The version is encoded in the  DALI_UDFS_IVY_URL_SPARK_2_12  constant in  TransportUDFTransformer , which builds the Ivy URL Coral emits so Spark can resolve and load the Dali standard UDF implementations at query time:

```
// coral-spark/src/main/java/com/linkedin/coral/spark/transformers/TransportUDFTransformer.java
public static final String DALI_UDFS_IVY_URL_SPARK_2_12 =
    "ivy://com.linkedin.standard-udfs-dali-udfs:standard-udfs-dali-udfs:2.0.124?classifier=spark_2.12";
```

Coral translates selective UDF references into a Transport UDF Ivy dependency ( `ivy://com.linkedin.standard-udfs-dali-udfs:standard-udfs-dali-udfs:<version>?classifier=spark_2.12` ). Pinning to  2.0.124  moves Scala 2.12 Spark consumers onto the current published  standard-udfs-dali-udfs  release, picking up the UDF fixes/additions shipped since  2.0.3 .


### How was this patch tested?
<!--
Please describe all the tests conducted.
If new unit tests were included, mention that they were added in this section. Make sure to add test cases that thoroughly examine both negative and positive cases, if possible.
If the testing approach differed from regular unit tests (e.g., regression testing), please explain how it was conducted.
If no tests were added, please explain why they were not included and/or why it was difficult to add them.
-->
mint build 
the `standard-udfs-dali-udfs` version has been tested independently