### PR TITLE
Fix translation of IN predicate inside JOIN clause

### DIFF
--- a/coral-hive/src/main/java/com/linkedin/coral/transformers/CoralRelToSqlNodeConverter.java
+++ b/coral-hive/src/main/java/com/linkedin/coral/transformers/CoralRelToSqlNodeConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2023 LinkedIn Corporation. All rights reserved.
+ * Copyright 2017-2026 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -50,6 +50,7 @@ import com.linkedin.coral.com.google.common.collect.ImmutableList;
 import com.linkedin.coral.com.google.common.collect.ImmutableMap;
 import com.linkedin.coral.common.functions.CoralSqlUnnestOperator;
 import com.linkedin.coral.common.functions.FunctionFieldReferenceOperator;
+import com.linkedin.coral.hive.hive2rel.functions.CoralINOperator;
 
 
 /**
@@ -132,6 +133,62 @@ public class CoralRelToSqlNodeConverter extends RelToSqlConverter {
         return false;
       }
     };
+  }
+
+  /**
+   * Converts a join condition from a {@link RexNode} to a {@link SqlNode}.
+   *
+   * Super's implementation renders join conditions from a hardcoded switch over
+   * {@link org.apache.calcite.sql.SqlKind}, covering only AND/OR, the comparison
+   * operators, LIKE, and IS [NOT] NULL; every other kind falls through to a
+   * `default` branch that throws an AssertionError.
+   *
+   * Coral represents `IN` with {@link CoralINOperator} rather than Calcite's
+   * `SqlStdOperatorTable.IN`, so that an `IN` list is preserved as-is instead of
+   * being rewritten into OR predicates or a join on a set of values. That operator
+   * declares {@link org.apache.calcite.sql.SqlKind#OTHER}, so an `IN` predicate
+   * inside a JOIN ... ON clause reaches the `default` branch and fails to translate.
+   * For example, the view:
+   *
+   * <pre>
+   * SELECT c.customer_id, ci.identification_number
+   FROM customer c
+   * INNER JOIN customer_identification ci
+   *   ON c.customer_id = ci.customer_id
+   *  AND ci.identification_type_code IN ('TIN', 'GIIN') * </pre>
+   *
+   * fails with `java.lang.AssertionError: IN($3, 'TIN', 'GIIN')`.
+   *
+   * This overriding implementation intercepts {@link CoralINOperator} calls and
+   * converts them under a join-scoped
+   * {@link org.apache.calcite.rel.rel2sql.SqlImplementor.Context}, which resolves
+   * field references against the concatenated row type of both join inputs (left
+   * fields occupy ordinals [0, leftFieldCount), right fields the remainder) and
+   * renders the operand list via {@link CoralINOperator#unparse}. All other
+   * conditions are delegated to super. Note that super's AND/OR branch recurses
+   * through this method, so an `IN` nested under an AND is intercepted as well,
+   * while sibling comparisons retain super's handling.
+   *
+   * The join context resolves the left/right ordinal offset internally, hence
+   * {@code leftFieldCount} is unused here. This mirrors what super itself does for
+   * the conditions its fast paths do not cover; Calcite removed the switch
+   * altogether in CALCITE-4620 (1.27.0) in favor of this single delegation, so
+   * this override can be dropped once that change is available in linkedin-calcite.
+   *
+   * @param node Join condition
+   * @param leftContext Left context
+   * @param rightContext Right context
+   * @param leftFieldCount Number of fields on left result
+   * @return SqlNode that represents the condition
+   */
+  @Override
+  public SqlNode convertConditionToSqlNode(RexNode node, Context leftContext, Context rightContext,
+      int leftFieldCount) {
+    if (node instanceof RexCall && ((RexCall) node).getOperator() instanceof CoralINOperator) {
+      Context joinContext = leftContext.implementor().joinContext(leftContext, rightContext);
+      return joinContext.toSql(null, node);
+    }
+    return super.convertConditionToSqlNode(node, leftContext, rightContext, leftFieldCount);
   }
 
   /**

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/HiveToRelConverterTest.java
@@ -31,6 +31,7 @@ import org.testng.annotations.Test;
 import com.linkedin.coral.common.ToRelConverterTestUtils;
 import com.linkedin.coral.common.functions.UnknownSqlFunctionException;
 import com.linkedin.coral.hive.hive2rel.functions.StaticHiveFunctionRegistry;
+import com.linkedin.coral.transformers.CoralRelToSqlNodeConverter;
 
 import static com.linkedin.coral.common.ToRelConverterTestUtils.*;
 import static org.apache.calcite.sql.type.OperandTypes.*;
@@ -666,6 +667,19 @@ public class HiveToRelConverterTest {
         + "  LogicalTableScan(table=[[hive, test, tableint]])\n";
 
     assertEquals(relToString(sql), expected);
+  }
+
+  @Test
+  public void testViewJoinWithInCondition() {
+    RelNode relNode = converter.convertView("test", "view_join_with_in_condition");
+    CoralRelToSqlNodeConverter coralConverter = new CoralRelToSqlNodeConverter();
+    SqlNode sqlNode = coralConverter.convert(relNode);
+    String generated = sqlNode.toSqlString(CoralRelToSqlNodeConverter.INSTANCE).getSql();
+    String expected = "SELECT party.party_id, party.party_name, party_identification.party_identification_number\n"
+        + "FROM test.party AS party\n" + "INNER JOIN test.party_identification AS party_identification"
+        + " ON party.party_id = party_identification.party_id"
+        + " AND party_identification.party_identification_type_code IN ('TIN', 'GIIN')";
+    assertEquals(generated, expected);
   }
 
   private String relToString(String sql) {

--- a/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/TestUtils.java
+++ b/coral-hive/src/test/java/com/linkedin/coral/hive/hive2rel/TestUtils.java
@@ -217,6 +217,14 @@ public class TestUtils {
           + "        LEFT JOIN ( SELECT trim(some_id) AS SOME_ID FROM duplicate_column_name_b) b ON a.some_id = b.some_id\n"
           + "        WHERE a.some_id != ''");
 
+      driver.run("CREATE TABLE IF NOT EXISTS test.party(party_id int, party_name string)");
+      driver.run(
+          "CREATE TABLE IF NOT EXISTS test.party_identification(party_id int, party_identification_type_code string, party_identification_number string)");
+      driver.run("CREATE VIEW IF NOT EXISTS test.view_join_with_in_condition AS "
+          + "SELECT p.party_id, p.party_name, pi.party_identification_number " + "FROM test.party p "
+          + "INNER JOIN test.party_identification pi " + "ON p.party_id = pi.party_id "
+          + "AND pi.party_identification_type_code IN ('TIN', 'GIIN')");
+
       testHive.databases = ImmutableList.of(
           new TestHive.DB("test", ImmutableList.of("tableOne", "tableTwo", "tableOneView")),
           new TestHive.DB("default",

--- a/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
+++ b/coral-trino/src/main/java/com/linkedin/coral/trino/rel2trino/RelToTrinoConverter.java
@@ -19,6 +19,7 @@ import org.apache.calcite.rel.logical.LogicalTableFunctionScan;
 import org.apache.calcite.rel.rel2sql.RelToSqlConverter;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexFieldAccess;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
@@ -33,6 +34,7 @@ import com.linkedin.coral.common.HiveMetastoreClient;
 import com.linkedin.coral.common.catalog.CoralCatalog;
 import com.linkedin.coral.common.functions.CoralSqlUnnestOperator;
 import com.linkedin.coral.common.functions.FunctionFieldReferenceOperator;
+import com.linkedin.coral.hive.hive2rel.functions.CoralINOperator;
 import com.linkedin.coral.transformers.CoralRelToSqlNodeConverter;
 
 import static com.google.common.base.Preconditions.*;
@@ -286,6 +288,62 @@ public class RelToTrinoConverter extends RelToSqlConverter {
       return val.getValue().equals(new BigDecimal(0));
     }
     return false;
+  }
+
+  /**
+   * Converts a join condition from a {@link RexNode} to a {@link SqlNode}.
+   *
+   * Super's implementation renders join conditions from a hardcoded switch over
+   * {@link org.apache.calcite.sql.SqlKind}, covering only AND/OR, the comparison
+   * operators, LIKE, and IS [NOT] NULL; every other kind falls through to a
+   * `default` branch that throws an AssertionError.
+   *
+   * Coral represents `IN` with {@link CoralINOperator} rather than Calcite's
+   * `SqlStdOperatorTable.IN`, so that an `IN` list is preserved as-is instead of
+   * being rewritten into OR predicates or a join on a set of values. That operator
+   * declares {@link org.apache.calcite.sql.SqlKind#OTHER}, so an `IN` predicate
+   * inside a JOIN ... ON clause reaches the `default` branch and fails to translate.
+   * For example, the view:
+   *
+   * <pre>
+   * SELECT c.customer_id, ci.identification_number
+   FROM customer c
+   * INNER JOIN customer_identification ci
+   *   ON c.customer_id = ci.customer_id
+   *  AND ci.identification_type_code IN ('TIN', 'GIIN') * </pre>
+   *
+   * fails with `java.lang.AssertionError: IN($3, 'TIN', 'GIIN')`.
+   *
+   * This overriding implementation intercepts {@link CoralINOperator} calls and
+   * converts them under a join-scoped
+   * {@link org.apache.calcite.rel.rel2sql.SqlImplementor.Context}, which resolves
+   * field references against the concatenated row type of both join inputs (left
+   * fields occupy ordinals [0, leftFieldCount), right fields the remainder) and
+   * renders the operand list via {@link CoralINOperator#unparse}. All other
+   * conditions are delegated to super. Note that super's AND/OR branch recurses
+   * through this method, so an `IN` nested under an AND is intercepted as well,
+   * while sibling comparisons retain super's handling.
+   *
+   * The join context resolves the left/right ordinal offset internally, hence
+   * {@code leftFieldCount} is unused here. This mirrors what super itself does for
+   * the conditions its fast paths do not cover; Calcite removed the switch
+   * altogether in CALCITE-4620 (1.27.0) in favor of this single delegation, so
+   * this override can be dropped once that change is available in linkedin-calcite.
+   *
+   * @param node Join condition
+   * @param leftContext Left context
+   * @param rightContext Right context
+   * @param leftFieldCount Number of fields on left result
+   * @return SqlNode that represents the condition
+   */
+  @Override
+  public SqlNode convertConditionToSqlNode(RexNode node, Context leftContext, Context rightContext,
+      int leftFieldCount) {
+    if (node instanceof RexCall && ((RexCall) node).getOperator() instanceof CoralINOperator) {
+      Context joinContext = leftContext.implementor().joinContext(leftContext, rightContext);
+      return joinContext.toSql(null, node);
+    }
+    return super.convertConditionToSqlNode(node, leftContext, rightContext, leftFieldCount);
   }
 
   /**

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/HiveToTrinoConverterTest.java
@@ -243,7 +243,11 @@ public class HiveToTrinoConverterTest {
         { "test", "view_union_no_casting", "SELECT \"table_with_mixed_columns\".\"a_tinyint\" AS \"a_tinyint\", \"table_with_mixed_columns\".\"a_smallint\" AS \"a_smallint\", \"table_with_mixed_columns\".\"a_integer\" AS \"a_integer\", \"table_with_mixed_columns\".\"a_bigint\" AS \"a_bigint\", \"table_with_mixed_columns\".\"a_float\" AS \"a_float\"\n"
             + "FROM \"test\".\"table_with_mixed_columns\" AS \"table_with_mixed_columns\"\n" + "UNION ALL\n"
             + "SELECT \"table_with_mixed_columns0\".\"a_tinyint\" AS \"a_tinyint\", \"table_with_mixed_columns0\".\"a_smallint\" AS \"a_smallint\", \"table_with_mixed_columns0\".\"a_integer\" AS \"a_integer\", \"table_with_mixed_columns0\".\"a_bigint\" AS \"a_bigint\", \"table_with_mixed_columns0\".\"a_float\" AS \"a_float\"\n"
-            + "FROM \"test\".\"table_with_mixed_columns\" AS \"table_with_mixed_columns0\"" } };
+            + "FROM \"test\".\"table_with_mixed_columns\" AS \"table_with_mixed_columns0\"" },
+
+        { "test", "view_join_with_in_condition", "SELECT \"party\".\"party_id\" AS \"party_id\", \"party\".\"party_name\" AS \"party_name\", \"party_identification\".\"party_identification_number\" AS \"party_identification_number\"\n"
+            + "FROM \"test\".\"party\" AS \"party\"\n"
+            + "INNER JOIN \"test\".\"party_identification\" AS \"party_identification\" ON \"party\".\"party_id\" = \"party_identification\".\"party_id\" AND \"party_identification\".\"party_identification_type_code\" IN ('TIN', 'GIIN')" } };
   }
 
   @Test

--- a/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
+++ b/coral-trino/src/test/java/com/linkedin/coral/trino/rel2trino/TestUtils.java
@@ -436,6 +436,15 @@ public class TestUtils {
     run(driver,
         "CREATE TABLE IF NOT EXISTS test.tableInt(tinyint_col tinyint, smallint_col smallint, int_col int, bigint_col bigint)");
 
+    run(driver, "CREATE TABLE IF NOT EXISTS test.party(party_id int, party_name string)");
+    run(driver,
+        "CREATE TABLE IF NOT EXISTS test.party_identification(party_id int, party_identification_type_code string, party_identification_number string)");
+    run(driver,
+        "CREATE VIEW IF NOT EXISTS test.view_join_with_in_condition AS "
+            + "SELECT p.party_id, p.party_name, pi.party_identification_number " + "FROM test.party p "
+            + "INNER JOIN test.party_identification pi " + "ON p.party_id = pi.party_id "
+            + "AND pi.party_identification_type_code IN ('TIN', 'GIIN')");
+
   }
 
   public static HiveConf loadResourceHiveConf() {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Here are some suggestions to help you:
  1. If you are new to this, kindly review our contributor guidelines at https://github.com/linkedin/coral/blob/master/CONTRIBUTING.md.
  2. Make sure you have added and executed the relevant tests for your PR.
  3. For unfinished PRs, include '[WIP]' in the title, e.g., '[WIP] Your PR title'.
  4. Keep the PR description up-to-date to reflect any changes.
  5. Craft a PR title that summarizes the proposal. If it pertains to a specific module, mention the module name, e.g., '[Coral-Hive] Your PR title'.
  6. If possible, provide a brief example to help reproduce the issue, which can expedite the review process.
  7. Make sure that the command './gradlew clean build' passes. Resolve any formatting errors by running './gradlew spotlessApply'.
-->

## Reproduction of the issue

```
CREATE TABLE party (
  party_id   INT,
  party_name STRING
)
STORED AS ORC;

CREATE TABLE party_identification (
  party_id                       INT,
  party_identification_type_code STRING,   -- e.g. 'TIN', 'GIIN', 'SSN'
  party_identification_number    STRING
)
STORED AS ORC;

CREATE VIEW view_repro_in_join AS
SELECT
  p.party_id,
  p.party_name,
  pi1.party_identification_number
FROM party p
INNER JOIN party_identification pi1
  ON  p.party_id = pi1.party_id
  AND pi1.party_identification_type_code IN ('TIN', 'GIIN');

```

Stacktrace when querying through Trino

```
Caused by: java.lang.AssertionError: IN($3, 'TIN', 'GIIN')
	at org.apache.calcite.rel.rel2sql.SqlImplementor.convertConditionToSqlNode(SqlImplementor.java:285)
	at org.apache.calcite.rel.rel2sql.SqlImplementor.convertConditionToSqlNode(SqlImplementor.java:222)
	at com.linkedin.coral.trino.rel2trino.RelToTrinoConverter.visit(RelToTrinoConverter.java:311)
```

<details>

<summary>Full stacktrace</summary>


```
io.trino.spi.TrinoException: Failed to translate Hive view 'hive_view_repro.view_repro_in_join': While invoking method 'public org.apache.calcite.rel.rel2sql.SqlImplementor$Result com.linkedin.coral.trino.rel2trino.RelToTrinoConverter.visit(org.apache.calcite.rel.core.Project)'
	at io.trino.plugin.hive.ViewReaderUtil$HiveViewReader.decodeViewData(ViewReaderUtil.java:269)
	at io.trino.plugin.hive.HiveMetadata.lambda$toConnectorViewDefinition$0(HiveMetadata.java:3022)
	at java.base/java.util.Optional.flatMap(Optional.java:289)
	at io.trino.plugin.hive.HiveMetadata.toConnectorViewDefinition(HiveMetadata.java:3006)
	at io.trino.plugin.hive.HiveMetadata.getView(HiveMetadata.java:3000)
	at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata.getView(ClassLoaderSafeConnectorMetadata.java:742)
	at io.trino.tracing.TracingConnectorMetadata.getView(TracingConnectorMetadata.java:875)
	at io.trino.metadata.MetadataManager.getViewInternal(MetadataManager.java:1700)
	at io.trino.metadata.MetadataManager.getView(MetadataManager.java:1638)
	at io.trino.tracing.TracingMetadata.getView(TracingMetadata.java:983)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitTable(StatementAnalyzer.java:2416)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitTable(StatementAnalyzer.java:540)
	at io.trino.sql.tree.Table.accept(Table.java:70)
	at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:559)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.analyzeFrom(StatementAnalyzer.java:5295)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:3281)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:540)
	at io.trino.sql.tree.QuerySpecification.accept(QuerySpecification.java:155)
	at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:559)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:567)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:1640)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:540)
	at io.trino.sql.tree.Query.accept(Query.java:130)
	at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.trino.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:559)
	at io.trino.sql.analyzer.StatementAnalyzer.analyze(StatementAnalyzer.java:519)
	at io.trino.sql.analyzer.StatementAnalyzer.analyze(StatementAnalyzer.java:508)
	at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:98)
	at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:87)
	at io.trino.execution.SqlQueryExecution.analyze(SqlQueryExecution.java:339)
	at io.trino.execution.SqlQueryExecution.<init>(SqlQueryExecution.java:247)
	at io.trino.execution.SqlQueryExecution$SqlQueryExecutionFactory.createQueryExecution(SqlQueryExecution.java:999)
	at io.trino.dispatcher.LocalDispatchQueryFactory.lambda$createDispatchQuery$0(LocalDispatchQueryFactory.java:165)
	at io.trino.$gen.Trino_480_e_1____20260602_153151_2.call(Unknown Source)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:128)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:80)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: java.lang.RuntimeException: While invoking method 'public org.apache.calcite.rel.rel2sql.SqlImplementor$Result com.linkedin.coral.trino.rel2trino.RelToTrinoConverter.visit(org.apache.calcite.rel.core.Project)'
	at org.apache.calcite.util.ReflectUtil$2.invoke(ReflectUtil.java:527)
	at org.apache.calcite.rel.rel2sql.RelToSqlConverter.dispatch(RelToSqlConverter.java:122)
	at org.apache.calcite.rel.rel2sql.RelToSqlConverter.visitChild(RelToSqlConverter.java:128)
	at com.linkedin.coral.trino.rel2trino.RelToTrinoConverter.convertToSqlNode(RelToTrinoConverter.java:103)
	at com.linkedin.coral.trino.rel2trino.RelToTrinoConverter.convert(RelToTrinoConverter.java:86)
	at io.trino.plugin.hive.ViewReaderUtil$HiveViewReader.decodeViewData(ViewReaderUtil.java:244)
	... 41 more
Caused by: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:119)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at org.apache.calcite.util.ReflectUtil$2.invoke(ReflectUtil.java:524)
	... 46 more
Caused by: java.lang.RuntimeException: While invoking method 'public org.apache.calcite.rel.rel2sql.SqlImplementor$Result com.linkedin.coral.trino.rel2trino.RelToTrinoConverter.visit(org.apache.calcite.rel.core.Join)'
	at org.apache.calcite.util.ReflectUtil$2.invoke(ReflectUtil.java:527)
	at org.apache.calcite.rel.rel2sql.RelToSqlConverter.dispatch(RelToSqlConverter.java:122)
	at org.apache.calcite.rel.rel2sql.RelToSqlConverter.visitChild(RelToSqlConverter.java:128)
	at com.linkedin.coral.trino.rel2trino.RelToTrinoConverter.visit(RelToTrinoConverter.java:130)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	... 48 more
Caused by: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:119)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at org.apache.calcite.util.ReflectUtil$2.invoke(ReflectUtil.java:524)
	... 52 more
Caused by: java.lang.AssertionError: IN($3, 'TIN', 'GIIN')
	at org.apache.calcite.rel.rel2sql.SqlImplementor.convertConditionToSqlNode(SqlImplementor.java:285)
	at org.apache.calcite.rel.rel2sql.SqlImplementor.convertConditionToSqlNode(SqlImplementor.java:222)
	at com.linkedin.coral.trino.rel2trino.RelToTrinoConverter.visit(RelToTrinoConverter.java:311)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	... 54 more
```
</details>




### What changes are proposed in this pull request, and why are they necessary?
<!--
Kindly explain the proposed changes in this section. The goal is to outline the modifications and how this PR addresses the issue. Also, clarify the reasons for these changes. For example,
  1. If a new API is proposed, explain the intended use case.
  2. If a bug is being fixed, describe why it is a bug.
  3. If design documentation is available, please include the link.
-->

Calcite's `SqlImplementor.convertConditionToSqlNode` only handles equality/comparison/null operators in join conditions. `CoralINOperator` uses `SqlKind.OTHER` (not `SqlKind.IN`), so it fell through to the default case and threw AssertionError.

Override `convertConditionToSqlNode` in `RelToTrinoConverter` to intercept `CoralINOperator` nodes and delegate to a join-scoped Context.toSql call, which correctly resolves column references from both sides of the join and renders the `IN` list via `CoralINOperator.unparse`.


### How was this patch tested?
<!--
Please describe all the tests conducted.
If new unit tests were included, mention that they were added in this section. Make sure to add test cases that thoroughly examine both negative and positive cases, if possible.
If the testing approach differed from regular unit tests (e.g., regression testing), please explain how it was conducted.
If no tests were added, please explain why they were not included and/or why it was difficult to add them.
-->

The patch has been tested with unit tests in `HiveToTrinoConverterTest`.
