### PR TITLE
[Coral-Spark] Upgrade standard-udfs-dali-udfs to 2.0.140 for Spark Scala 2.12

### DIFF
--- a/coral-spark/src/main/java/com/linkedin/coral/spark/transformers/TransportUDFTransformer.java
+++ b/coral-spark/src/main/java/com/linkedin/coral/spark/transformers/TransportUDFTransformer.java
@@ -46,7 +46,7 @@ public class TransportUDFTransformer extends SqlCallTransformer {
   public static final String DALI_UDFS_IVY_URL_SPARK_2_11 =
       "ivy://com.linkedin.standard-udfs-dali-udfs:standard-udfs-dali-udfs:2.0.3?classifier=spark_2.11";
   public static final String DALI_UDFS_IVY_URL_SPARK_2_12 =
-      "ivy://com.linkedin.standard-udfs-dali-udfs:standard-udfs-dali-udfs:2.0.124?classifier=spark_2.12";
+      "ivy://com.linkedin.standard-udfs-dali-udfs:standard-udfs-dali-udfs:2.0.140?classifier=spark_2.12";
 
   public enum ScalaVersion {
     SCALA_2_11,


### PR DESCRIPTION
### What changes are proposed in this pull request, and why are they necessary?

On the Spark path, `TransportUDFTransformer` resolves Dali UDFs by loading the Transport UDF from a version hardcoded in `DALI_UDFS_IVY_URL_SPARK_2_12`, rather than from the version declared by the view being queried. That constant is currently pinned to `standard-udfs-dali-udfs` 2.0.124.

2.0.124 predates the expanded member id range support in `standard-udfs-dali-udfs`, so `is_guest_member` treats every negative member id as a guest:

```java
// 2.0.124
return id == null || id <= 0;

// 2.0.140
return id == null || !MemberIdUtil.isMember(id);
```

The effect is that `is_guest_member` returns `true` on Spark for ids that fall outside the legacy positive range but are still valid members. The same view returns the correct value on Trino, because `coral-trino` has no transportable-UDF rewrite and therefore honors the UDF version the view itself declares. This bump restores parity between the two engines.

Only the Scala 2.12 constant is changed, matching the precedent set by #613.

One thing worth flagging separately: `DALI_UDFS_IVY_URL_SPARK_2_11` is still pinned at 2.0.3, and `getScalaVersionOfSpark()` falls back to `SCALA_2_11` whenever the Spark version cannot be determined. So the stale 2.11 pin is reachable even on a 2.12 cluster if version detection fails. I have left it alone here to keep this change minimal, but it likely deserves its own fix.

### How was this patch tested?

- `./gradlew :coral-spark:compileJava` — passes
- `./gradlew :coral-spark:test` — passes
- `./gradlew :coral-spark:spotlessCheck` — passes

I also verified against the published artifacts that `standard-udfs-dali-udfs:2.0.140?classifier=spark_2.12` is available and that its `IsGuestMemberId` delegates to `MemberIdUtil.isMember`, by decompiling the relocated `com/linkedin/ds/udf/filter/IsGuestMemberId` class in both 2.0.124 and 2.0.140 and diffing the bytecode.

No new unit tests were added: this is a constant version bump, and the existing `TransportUDFTransformer` tests reference the constants symbolically rather than asserting a literal version string, so they continue to cover the transformation logic unchanged.
