### PR TITLE
Chain the underlying cause into type derivation failures, and stop swallowing schema-load errors silently

### DIFF
--- a/coral-common/src/main/java/com/linkedin/coral/common/HiveCalciteTableAdapter.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/HiveCalciteTableAdapter.java
@@ -286,8 +286,10 @@ public class HiveCalciteTableAdapter implements ScannableTable {
         return MetaStoreUtils.getFieldsFromDeserializer(hiveTable.getTableName(), getDeserializer());
       } catch (Exception e) {
         // if there is an exception like failing to get the deserializer or failing to get columns using deserializer,
-        // we use sd.getCols() to avoid throwing exception
-        LOG.warn("Failed to get columns using deserializer: {}", e.getMessage());
+        // we use sd.getCols() to avoid throwing exception. These columns may be incomplete, so log the table and the
+        // full exception -- otherwise the problem resurfaces later as an opaque type derivation failure.
+        LOG.warn("Failed to get columns using deserializer for table {}.{}; falling back to storage descriptor "
+            + "columns, which may be incomplete.", hiveTable.getDbName(), hiveTable.getTableName(), e);
         return sd.getCols();
       }
     }

--- a/coral-common/src/main/java/com/linkedin/coral/common/catalog/IcebergHiveTableConverter.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/catalog/IcebergHiveTableConverter.java
@@ -14,6 +14,8 @@ import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.iceberg.hive.HiveSchemaUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -48,6 +50,8 @@ import org.apache.iceberg.hive.HiveSchemaUtil;
  * @see <a href="https://github.com/linkedin/coral/issues/575">Issue #575: Refactor ParseTreeBuilder to Use CoralTable</a>
  */
 public class IcebergHiveTableConverter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(IcebergHiveTableConverter.class);
 
   private IcebergHiveTableConverter() {
     // Utility class - prevent instantiation
@@ -99,8 +103,11 @@ public class IcebergHiveTableConverter {
     try {
       storageDescriptor.setCols(HiveSchemaUtil.convert(icebergTable.schema()));
     } catch (Exception e) {
-      // If schema conversion fails, set empty columns list
-      // This shouldn't break function resolution as it only needs properties
+      // Empty columns keep property-only callers working but break anything needing the schema: type
+      // derivation then fails later with an error that no longer names this table. Note schema() can
+      // perform lazy I/O and authorization, so this may also catch access denials.
+      LOG.warn("Failed to convert Iceberg schema to Hive columns for table {}; falling back to an empty "
+          + "column list, which will likely break downstream type derivation.", fullName, e);
       storageDescriptor.setCols(new ArrayList<>());
     }
 

--- a/coral-common/src/main/java/com/linkedin/coral/common/utils/TypeDerivationUtil.java
+++ b/coral-common/src/main/java/com/linkedin/coral/common/utils/TypeDerivationUtil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023-2024 LinkedIn Corporation. All rights reserved.
+ * Copyright 2023-2026 LinkedIn Corporation. All rights reserved.
  * Licensed under the BSD-2 Clause license.
  * See LICENSE in the project root for license information.
  */
@@ -64,6 +64,10 @@ public class TypeDerivationUtil {
       return cachedDataType;
     }
 
+    // Retained so the terminal RuntimeException can report why derivation failed. Candidate SELECTs are
+    // tried in turn and individual failures are expected, so they are not logged.
+    Throwable lastFailure = null;
+
     for (SqlSelect topSqlSelectNode : topSelectNodes) {
       final SqlSelect dummySqlSelect = new SqlSelect(topSqlSelectNode.getParserPosition(), null,
           SqlNodeList.of(sqlNode), topSqlSelectNode.getFrom(), topSqlSelectNode.getWhere(), topSqlSelectNode.getGroup(),
@@ -73,7 +77,8 @@ public class TypeDerivationUtil {
       try {
         sqlValidator.validate(dummySqlSelect);
         return sqlValidator.getValidatedNodeType(dummySqlSelect).getFieldList().get(0).getType();
-      } catch (Throwable ignored) {
+      } catch (Throwable t) {
+        lastFailure = t;
       }
     }
 
@@ -86,11 +91,14 @@ public class TypeDerivationUtil {
           SqlNodeList.of(sqlNode), topSelectNodes.get(0), null, null, null, null, null, null, null);
       sqlValidator.validate(dummySqlSelect);
       return sqlValidator.getValidatedNodeType(sqlNode);
-    } catch (Throwable ignored) {
+    } catch (Throwable t) {
+      lastFailure = t;
     }
 
+    // Chain the cause: without it this message masks the real failure (e.g. an authorization denial
+    // while loading a base table's schema).
     throw new RuntimeException(String.format("Failed to derive the RelDataType for SqlNode: %s with topSqlNode: %s",
-        sqlNode, topSelectNodes.get(0)));
+        sqlNode, topSelectNodes.get(0)), lastFailure);
   }
 
   public RelDataType leastRestrictive(List<RelDataType> types) {

--- a/coral-common/src/test/java/com/linkedin/coral/common/utils/TypeDerivationUtilTest.java
+++ b/coral-common/src/test/java/com/linkedin/coral/common/utils/TypeDerivationUtilTest.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright 2026 LinkedIn Corporation. All rights reserved.
+ * Licensed under the BSD-2 Clause license.
+ * See LICENSE in the project root for license information.
+ */
+package com.linkedin.coral.common.utils;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.BasicSqlType;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class TypeDerivationUtilTest {
+
+  private static final String TOP_SQL = "SELECT a FROM foo";
+
+  /**
+   * When type derivation genuinely fails, the RuntimeException must carry the underlying failure as its
+   * cause. Without it, unrelated root causes (for example an authorization denial raised while loading a
+   * base table's schema) are silently discarded and resurface only as an opaque type derivation error.
+   */
+  @Test
+  public void testFailedDerivationPropagatesCause() throws Exception {
+    RuntimeException sentinel = new RuntimeException("access denied while loading base table schema");
+    TypeDerivationUtil typeDerivationUtil =
+        new TypeDerivationUtil(failingValidator(sentinel), SqlParser.create(TOP_SQL).parseQuery());
+
+    try {
+      typeDerivationUtil.getRelDataType(new SqlIdentifier("a", SqlParserPos.ZERO));
+      fail("Expected type derivation to fail");
+    } catch (RuntimeException e) {
+      assertTrue(e.getMessage().startsWith("Failed to derive the RelDataType for SqlNode:"),
+          "Unexpected message: " + e.getMessage());
+      assertNotNull(e.getCause(), "RuntimeException must chain the underlying derivation failure");
+      assertSame(e.getCause(), sentinel);
+    }
+  }
+
+  /**
+   * Capturing the failures must not perturb the success path: a type already known to the validator is
+   * still returned directly, without any exception.
+   */
+  @Test
+  public void testCachedTypeIsReturnedWithoutFailure() throws Exception {
+    RelDataType expectedType = new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.INTEGER);
+    TypeDerivationUtil typeDerivationUtil =
+        new TypeDerivationUtil(cachingValidator(expectedType), SqlParser.create(TOP_SQL).parseQuery());
+
+    assertSame(typeDerivationUtil.getRelDataType(new SqlIdentifier("a", SqlParserPos.ZERO)), expectedType);
+  }
+
+  /**
+   * A SqlValidator whose validate() always fails, so every derivation attempt is exhausted.
+   */
+  private static SqlValidator failingValidator(final RuntimeException sentinel) {
+    return newValidatorProxy(new InvocationHandler() {
+      @Override
+      public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        if ("validate".equals(method.getName())) {
+          throw sentinel;
+        }
+        return defaultValue(proxy, method, args);
+      }
+    });
+  }
+
+  /**
+   * A SqlValidator that already knows the type of the requested node.
+   */
+  private static SqlValidator cachingValidator(final RelDataType cachedType) {
+    return newValidatorProxy(new InvocationHandler() {
+      @Override
+      public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        if ("getValidatedNodeTypeIfKnown".equals(method.getName())) {
+          return cachedType;
+        }
+        return defaultValue(proxy, method, args);
+      }
+    });
+  }
+
+  private static SqlValidator newValidatorProxy(InvocationHandler handler) {
+    return (SqlValidator) Proxy.newProxyInstance(TypeDerivationUtilTest.class.getClassLoader(),
+        new Class<?>[] { SqlValidator.class }, handler);
+  }
+
+  /**
+   * Returns a benign value for any method the tests do not care about, so unrelated SqlValidator calls
+   * neither fail nor unbox a null primitive.
+   */
+  private static Object defaultValue(Object proxy, Method method, Object[] args) {
+    String name = method.getName();
+    if ("toString".equals(name)) {
+      return "TestSqlValidator";
+    }
+    if ("hashCode".equals(name)) {
+      return System.identityHashCode(proxy);
+    }
+    if ("equals".equals(name)) {
+      return proxy == args[0];
+    }
+
+    Class<?> returnType = method.getReturnType();
+    if (!returnType.isPrimitive()) {
+      return null;
+    }
+    if (returnType == boolean.class) {
+      return false;
+    }
+    if (returnType == char.class) {
+      return (char) 0;
+    }
+    if (returnType == byte.class) {
+      return (byte) 0;
+    }
+    if (returnType == short.class) {
+      return (short) 0;
+    }
+    if (returnType == int.class) {
+      return 0;
+    }
+    if (returnType == long.class) {
+      return 0L;
+    }
+    if (returnType == float.class) {
+      return 0.0f;
+    }
+    if (returnType == double.class) {
+      return 0.0d;
+    }
+    return null;
+  }
+}

--- a/coral-common/src/test/java/com/linkedin/coral/common/utils/TypeDerivationUtilTest.java
+++ b/coral-common/src/test/java/com/linkedin/coral/common/utils/TypeDerivationUtilTest.java
@@ -5,10 +5,6 @@
  */
 package com.linkedin.coral.common.utils;
 
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
-
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.sql.SqlIdentifier;
@@ -17,6 +13,7 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.BasicSqlType;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.validate.SqlValidator;
+import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -65,81 +62,18 @@ public class TypeDerivationUtilTest {
    * A SqlValidator whose validate() always fails, so every derivation attempt is exhausted.
    */
   private static SqlValidator failingValidator(final RuntimeException sentinel) {
-    return newValidatorProxy(new InvocationHandler() {
-      @Override
-      public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-        if ("validate".equals(method.getName())) {
-          throw sentinel;
-        }
-        return defaultValue(proxy, method, args);
-      }
-    });
+    SqlValidator validator = Mockito.mock(SqlValidator.class);
+    Mockito.when(validator.getValidatedNodeTypeIfKnown(Mockito.any())).thenReturn(null);
+    Mockito.doThrow(sentinel).when(validator).validate(Mockito.any());
+    return validator;
   }
 
   /**
    * A SqlValidator that already knows the type of the requested node.
    */
   private static SqlValidator cachingValidator(final RelDataType cachedType) {
-    return newValidatorProxy(new InvocationHandler() {
-      @Override
-      public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-        if ("getValidatedNodeTypeIfKnown".equals(method.getName())) {
-          return cachedType;
-        }
-        return defaultValue(proxy, method, args);
-      }
-    });
-  }
-
-  private static SqlValidator newValidatorProxy(InvocationHandler handler) {
-    return (SqlValidator) Proxy.newProxyInstance(TypeDerivationUtilTest.class.getClassLoader(),
-        new Class<?>[] { SqlValidator.class }, handler);
-  }
-
-  /**
-   * Returns a benign value for any method the tests do not care about, so unrelated SqlValidator calls
-   * neither fail nor unbox a null primitive.
-   */
-  private static Object defaultValue(Object proxy, Method method, Object[] args) {
-    String name = method.getName();
-    if ("toString".equals(name)) {
-      return "TestSqlValidator";
-    }
-    if ("hashCode".equals(name)) {
-      return System.identityHashCode(proxy);
-    }
-    if ("equals".equals(name)) {
-      return proxy == args[0];
-    }
-
-    Class<?> returnType = method.getReturnType();
-    if (!returnType.isPrimitive()) {
-      return null;
-    }
-    if (returnType == boolean.class) {
-      return false;
-    }
-    if (returnType == char.class) {
-      return (char) 0;
-    }
-    if (returnType == byte.class) {
-      return (byte) 0;
-    }
-    if (returnType == short.class) {
-      return (short) 0;
-    }
-    if (returnType == int.class) {
-      return 0;
-    }
-    if (returnType == long.class) {
-      return 0L;
-    }
-    if (returnType == float.class) {
-      return 0.0f;
-    }
-    if (returnType == double.class) {
-      return 0.0d;
-    }
-    return null;
+    SqlValidator validator = Mockito.mock(SqlValidator.class);
+    Mockito.when(validator.getValidatedNodeTypeIfKnown(Mockito.any())).thenReturn(cachedType);
+    return validator;
   }
 }

--- a/coral-common/src/test/java/com/linkedin/coral/common/utils/TypeDerivationUtilTest.java
+++ b/coral-common/src/test/java/com/linkedin/coral/common/utils/TypeDerivationUtilTest.java
@@ -5,6 +5,10 @@
  */
 package com.linkedin.coral.common.utils;
 
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.sql.SqlIdentifier;
@@ -13,7 +17,6 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.BasicSqlType;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.validate.SqlValidator;
-import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -62,18 +65,81 @@ public class TypeDerivationUtilTest {
    * A SqlValidator whose validate() always fails, so every derivation attempt is exhausted.
    */
   private static SqlValidator failingValidator(final RuntimeException sentinel) {
-    SqlValidator validator = Mockito.mock(SqlValidator.class);
-    Mockito.when(validator.getValidatedNodeTypeIfKnown(Mockito.any())).thenReturn(null);
-    Mockito.doThrow(sentinel).when(validator).validate(Mockito.any());
-    return validator;
+    return newValidatorProxy(new InvocationHandler() {
+      @Override
+      public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        if ("validate".equals(method.getName())) {
+          throw sentinel;
+        }
+        return defaultValue(proxy, method, args);
+      }
+    });
   }
 
   /**
    * A SqlValidator that already knows the type of the requested node.
    */
   private static SqlValidator cachingValidator(final RelDataType cachedType) {
-    SqlValidator validator = Mockito.mock(SqlValidator.class);
-    Mockito.when(validator.getValidatedNodeTypeIfKnown(Mockito.any())).thenReturn(cachedType);
-    return validator;
+    return newValidatorProxy(new InvocationHandler() {
+      @Override
+      public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        if ("getValidatedNodeTypeIfKnown".equals(method.getName())) {
+          return cachedType;
+        }
+        return defaultValue(proxy, method, args);
+      }
+    });
+  }
+
+  private static SqlValidator newValidatorProxy(InvocationHandler handler) {
+    return (SqlValidator) Proxy.newProxyInstance(TypeDerivationUtilTest.class.getClassLoader(),
+        new Class<?>[] { SqlValidator.class }, handler);
+  }
+
+  /**
+   * Returns a benign value for any method the tests do not care about, so unrelated SqlValidator calls
+   * neither fail nor unbox a null primitive.
+   */
+  private static Object defaultValue(Object proxy, Method method, Object[] args) {
+    String name = method.getName();
+    if ("toString".equals(name)) {
+      return "TestSqlValidator";
+    }
+    if ("hashCode".equals(name)) {
+      return System.identityHashCode(proxy);
+    }
+    if ("equals".equals(name)) {
+      return proxy == args[0];
+    }
+
+    Class<?> returnType = method.getReturnType();
+    if (!returnType.isPrimitive()) {
+      return null;
+    }
+    if (returnType == boolean.class) {
+      return false;
+    }
+    if (returnType == char.class) {
+      return (char) 0;
+    }
+    if (returnType == byte.class) {
+      return (byte) 0;
+    }
+    if (returnType == short.class) {
+      return (short) 0;
+    }
+    if (returnType == int.class) {
+      return 0;
+    }
+    if (returnType == long.class) {
+      return 0L;
+    }
+    if (returnType == float.class) {
+      return 0.0f;
+    }
+    if (returnType == double.class) {
+      return 0.0d;
+    }
+    return null;
   }
 }


### PR DESCRIPTION
## Summary

Three diagnostics-only changes. **No behaviour change** — every fallback and control-flow path is preserved. The goal is that when Coral fails, the reason survives.

## Motivation

`TypeDerivationUtil.getRelDataType()` tries each candidate top-level `SELECT` in turn, catches every `Throwable` along the way, discards them all, and finishes with:

```
java.lang.RuntimeException: Failed to derive the RelDataType for SqlNode: <expr> with topSqlNode: <sql>
```

**with no cause attached.** Whatever actually went wrong is gone by the time anyone sees it.

Issue **#574** is a good public illustration of the consequence: an unrelated root cause — a CTE reaching `ShiftArrayIndexTransformer` — surfaces as this exact string. The message is effectively a catch-all, and today it is the *only* information a user or operator gets.

We hit the same wall in an internal production incident. A view referenced a base table the querying user was not authorized to read; because the view runs with invoker semantics, loading that base table was denied. The failure surfaced as the type-derivation error above, and the authorization error was absent from the output entirely. What made the incident expensive to diagnose was not that it failed, but that the reason had been discarded.

### Confirmed by a controlled before/after

When a view references a base table the caller is not authorized to read, the authorization failure raised by the metastore/catalog client propagates into `TypeDerivationUtil`, which discards it and throws a `RuntimeException` carrying only a message. The underlying reason is then absent from both the resulting error and the logs, leaving no way to distinguish an authorization failure from any other type-derivation failure.

This was confirmed by a controlled comparison — two runs identical in query, view, invoking user and host, differing only in which Coral build was on the classpath:

| | before | after |
|---|---|---|
| `RuntimeException: Failed to derive the RelDataType ...` | identical | identical |
| authorization error text anywhere in the output | **absent** | present, attached as the cause |

Both arms fail through the same frames:

```
java.lang.RuntimeException: Failed to derive the RelDataType for SqlNode: <expr>
    at TypeDerivationUtil.getRelDataType(...)
    at SqlCallTransformer.deriveRelDatatype(SqlCallTransformer.java:68)
    at ShiftArrayIndexTransformer.condition(ShiftArrayIndexTransformer.java:37)
    ...
    at ToRelConverter.convertView(ToRelConverter.java:165)
```

The "before" arm is the important half. The authorization denial demonstrably *did* occur there — it resurfaced later from a separate fallback path — yet its message appears nowhere in that arm's output. The denial *happening* is not sufficient to make the reason visible; only cause-chaining makes it recoverable.

This is directly visible in the current source: the terminal `throw new RuntimeException(...)` takes only a message, so no build prior to this change can attach a cause at this site.

The benefit is not specific to authorization. A view with an unresolvable column now yields a three-deep chain — `RuntimeException` → `CalciteContextException` → `SqlValidatorException: Column '...' not found in any table` — where previously it also produced only the bare message.

### What is established

- **Established by experiment:** an authorization failure raised by the metastore/catalog client reaches `TypeDerivationUtil.getRelDataType()`, is discarded there, and is recovered by this change. The masking does not depend on how the view was resolved: `processViewWithCoralCatalog` and `processViewWithMsc` both converge on `toSqlNode(...)`, and type derivation runs downstream of it — as #574 shows, it is reachable through `convertSql` with no catalog branch involved at all.
- **Established from source:** `getRelDataType()` catches every `Throwable` and throws a `RuntimeException` with no cause.
- **Established independently:** **#574** — identical user-facing string, unrelated root cause.

## Changes

### 1. `TypeDerivationUtil` — chain the cause (the substantive fix)

`getRelDataType()` tries each candidate top-level `SELECT` in turn; failures are **normal control flow**, so they are correctly not logged. But the last failure was discarded entirely, so the terminal `RuntimeException` carried no cause.

Now a `lastFailure` local captures the most recent `Throwable` and is passed as the cause of the terminal exception. Nothing is logged inside the loop — that would be noisy on every happy path.

This matters concretely because **Trino already chains**: `ViewReaderUtil.decodeViewData` wraps translation failures with `new TrinoException(HIVE_VIEW_TRANSLATION_ERROR, ..., e)`. Today that chain dead-ends at Coral's causeless exception. With this change, the real failure reaches Trino's logged stack trace.

Note this improves the **logged stack trace**, not the user-facing message string (Trino surfaces `e.getMessage()`).

### 2. `HiveCalciteTableAdapter.getColumns()` — log what was lost (hygiene)

The `catch` falls back to `sd.getCols()` and logged only `e.getMessage()`: no stack trace, no table identity. It now logs the qualified table name and the full exception, consistent with the table-identity logging already used in this class (lines ~201-202). The throwable is passed as the trailing argument only, since SLF4J already renders its message alongside the stack trace. **The fallback is unchanged.**

Scope note: this path emitted **no warning in either arm** of the experiment above, so it was demonstrably *not* involved in the observed failure. This is opportunistic hygiene rather than part of the fix — worth doing because a message-only log with no table identity is not diagnosable if it ever does fire, but it is not load-bearing here.

### 3. `IcebergHiveTableConverter` — the same anti-pattern at an adjacent site

This is change 1's defect in a stronger form. On master the caught exception is never used at all — no log, no rethrow, no cause:

```java
} catch (Exception e) {
  // If schema conversion fails, set empty columns list
  // This shouldn't break function resolution as it only needs properties
  storageDescriptor.setCols(new ArrayList<>());
}
```

The class has no logger at all, so the failure leaves no trace whatsoever. The comment is also wrong: an empty column list **does** break anything that needs the schema — downstream type derivation then fails with an error that no longer names this table.

This matters because `icebergTable.schema()` is not a pure in-memory call — it can perform lazy catalog/storage I/O and authorization. So this `catch` is capable of silently turning an access denial into "zero columns".

A logger is added, the exception is logged at WARN with the table name, and the comment is corrected. **The fallback is unchanged.**

Scope note: this site did **not** fire in the before/after comparison — change 1 is the evidenced fix. This is a defensive correction of the same anti-pattern at an adjacent, authorization-capable site.

## Testing Done

### Automated

New `TypeDerivationUtilTest` in `coral-common`:

- `testFailedDerivationPropagatesCause` — asserts the `RuntimeException` message is unchanged **and** that `getCause()` is non-null and is the originating failure. Verified as a genuine regression test: it **fails** with the production change reverted and passes with it applied.
- `testCachedTypeIsReturnedWithoutFailure` — regression guard proving the success path is untouched.

The test drives `TypeDerivationUtil` through a `java.lang.reflect.Proxy`-based `SqlValidator` stub, so it needs no metastore and adds no dependency (TestNG only; this repo has no mocking library and this PR does not add one).

Commands run:

- `./gradlew :coral-common:test --tests '*TypeDerivationUtilTest*'` — 2 tests, 0 failures.
- `./gradlew clean build` — green across every module, `spotlessCheck` included.

### Manual

The before/after comparison described under Motivation was run in a Spark shell against a live metastore, on a view whose base table the invoking user was not authorized to read. Coral reaches that environment through a downstream distribution that shades and repackages it, so the two arms were **separate shell invocations** — identical in view, query, invoking user and cluster — differing only in which build of that distribution was on the driver classpath:

- **stock build** — `RuntimeException: Failed to derive the RelDataType ...`, with no trace of the authorization failure anywhere in the output.
- **this change** — the same `RuntimeException`, with the authorization error attached as its cause.

## Question for maintainers (deliberately not implemented)

Should an **authorization** failure be propagated as a distinct or typed exception, rather than being flattened into a generic type-derivation failure — so that engines such as Trino can surface `ACCESS_DENIED` instead of an opaque type error?

That is the outcome users actually want: "you are not authorized to read table X" rather than "failed to derive the RelDataType". But it is a genuine behaviour change with real regression risk — today's silent degradation may be load-bearing for callers that only need table properties rather than a full schema, so failing loudly could break paths that currently work.

Happy to implement in a follow-up if there's appetite, but it needs a maintainer decision on the compatibility question first. This PR stays purely diagnostic.

## Notes

- Relates to **#574** — same user-facing string, unrelated root cause. Change 1 addresses the general defect that issue exposes, not just the authorization case.
- **#575** proposes deleting `IcebergHiveTableConverter` entirely. Change 3 becomes moot if that lands; it has been open since 2026-01-08, so the class looks likely to outlive expectations in the meantime. Changes 1 and 2 are unaffected by #575 either way.
- `HiveCalciteTableAdapter` (change 2) obtains its table via the deprecated `getHiveTable()` that **#606** targets. This PR does not change that call — only what is logged when the subsequent column lookup fails.
